### PR TITLE
Support to register extended BPMN nodes and properties. #57

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "vue-upload-component": "^2.8.14"
   },
   "devDependencies": {
+    "@processmaker/processmaker-bpmn-moddle": "^0.1.2",
     "@vue/cli-plugin-babel": "^3.0.5",
     "@vue/cli-plugin-eslint": "^3.0.5",
     "@vue/cli-plugin-unit-jest": "^3.0.5",

--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -8,7 +8,7 @@
       </div>
     </div>
     <div class="modeler-container">
-      <modeler ref="modeler"   @parsed.once="addStartEvent"/>
+      <modeler ref="modeler"   @parsed.once="addStartEvent" @initialize="modelerInitialize" @ready="modelerReady"/>
     </div>
     <statusbar>
       {{statusText}}
@@ -30,6 +30,9 @@ import FileUpload from 'vue-upload-component';
 import FilerSaver from 'file-saver';
 import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
+//Extenssion example
+import bpmnExtension from '@processmaker/processmaker-bpmn-moddle/resources/processmaker.json';
 
 // Our initial node types to register with our modeler
 import {
@@ -76,26 +79,62 @@ export default {
     };
   },
   mounted() {
-    let blank = `
-    <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
-  <bpmn:process id="Process_1" isExecutable="true">
-  </bpmn:process>
-  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-    </bpmndi:BPMNPlane>
-  </bpmndi:BPMNDiagram>
-</bpmn:definitions>
-
-    `;
-
-    this.$refs.modeler.loadXML(blank);
-    for (let nodeType of nodeTypes) {
-      this.$refs.modeler.registerNodeType(nodeType);
-    }
+    //Before ready: To load BPMN extensions and Node types
+    this.$emit('beforeReady');
+    //The modeler app is ready to be used with extensions and custom nodes
+    this.$emit('ready');
 
   },
   methods: {
+    testAddBpmnExtension (modeler) {
+      //Add a bpmn extension
+      modeler.registerBpmnExtension('pm', bpmnExtension);
+      //Add custom properties to inspector
+      task.inspectorConfig[0].items.push({
+          component: "FormInput",
+          config: {
+              type: "number",
+              label: "Due In",
+              placeholder: "72 hours",
+              helper: "Time when the task will due (hours)",
+              name: "dueIn"
+          }
+      });
+    },
+    testLoadBPMN (modeler) {
+      let blank = `<?xml version="1.0" encoding="UTF-8"?>
+        <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+          <bpmn:process id="Process_1" isExecutable="true">
+          </bpmn:process>
+          <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+            <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+            </bpmndi:BPMNPlane>
+          </bpmndi:BPMNDiagram>
+        </bpmn:definitions>
+      `;
+      this.$refs.modeler.loadXML(blank);
+      for (let nodeType of nodeTypes) {
+        this.$refs.modeler.registerNodeType(nodeType);
+      }
+    },
+    /**
+     * The modeler is initializing.
+     */
+    modelerInitialize(moddle) {
+      // Here the application could register BPMN extensions
+      this.$emit('modeler-init', this.$refs.modeler);
+      // Example of extension
+      this.testAddBpmnExtension(this.$refs.modeler);
+    },
+    /**
+     * The modeler is ready to be used
+     */
+    modelerReady() {
+      // Here the modeler is ready to be used
+      this.$emit('modeler-ready', this.$refs.modeler);
+      // Load a BPMN of example
+      this.testLoadBPMN(this.$refs.modeler);
+    },
     download() {
       this.$refs.modeler.toXML(function(err, xml) {
         if (err) {

--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -107,8 +107,8 @@ export default {
       });
     },
     addStartEvent() {
-      const definition = startEvent.definition();
-      const diagram = startEvent.diagram();
+      const definition = startEvent.definition(this.$refs.modeler.moddle);
+      const diagram = startEvent.diagram(this.$refs.modeler.moddle);
 
       diagram.bounds.x = 150;
       diagram.bounds.y = 150;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -401,10 +401,11 @@ export default {
       }
     },
   },
-  created() {
-    this.moddle = new BpmnModdle(this.extensions);
-  },
   mounted() {
+    // Initialize the BpmnModdle and its extensions
+    this.$emit('initialize');
+    this.moddle = new BpmnModdle(this.extensions);
+
     // Handle window resize
     this.handleResize();
     window.addEventListener('resize', this.handleResize);
@@ -497,6 +498,9 @@ export default {
         cellView.model.component.handleClick();
       }
     });
+
+    // Register custom nodes
+    this.$emit('ready');
   },
 };
 </script>

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -160,6 +160,21 @@ export default {
   },
   methods: {
     /**
+     * Register an inspector component to configure extended attributes and elements 
+     * for specific bpmn extensions and execution environments. If the inspector
+     * component is already registered, it is replaced by the new one.
+     */
+    registerInspectorExtension(node, config) {
+      const registeredIndex = node.inspectorConfig[0].items.findIndex((item) => {
+        return config.id && config.id === item.id;
+      });
+      if (registeredIndex === -1) {
+        node.inspectorConfig[0].items.push(config);
+      } else {
+        node.inspectorConfig[0].items[registeredIndex]= config;
+      }
+    },
+    /**
      * Register a BPMN Moddle extension in order to support extensions to the bpmn xml format.
      * This is used to support new attributes and elements that would be needed for specific
      * bpmn execution environments.
@@ -401,10 +416,12 @@ export default {
       }
     },
   },
-  mounted() {
+  created () {
     // Initialize the BpmnModdle and its extensions
-    this.$emit('initialize');
+    this.$emit('initialize', this);
     this.moddle = new BpmnModdle(this.extensions);
+  },
+  mounted() {
 
     // Handle window resize
     this.handleResize();
@@ -499,7 +516,6 @@ export default {
       }
     });
 
-    // Register custom nodes
     this.$emit('ready');
   },
 };

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -260,10 +260,10 @@ export default {
       const type = transferData.type;
 
       // Add to our processNode
-      const definition = this.nodeRegistry[type].definition();
+      const definition = this.nodeRegistry[type].definition(this.moddle);
 
       // Now, let's modify planeElement
-      const diagram = this.nodeRegistry[type].diagram();
+      const diagram = this.nodeRegistry[type].diagram(this.moddle);
 
       // Handle transform
       diagram.bounds.x = event.offsetX - this.paper.options.origin.x;

--- a/src/components/nodes/association/association.vue
+++ b/src/components/nodes/association/association.vue
@@ -8,9 +8,6 @@ import joint from 'jointjs';
 import crownConfig from '@/mixins/crownConfig';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle;
 
 export default {
   props: ['graph', 'node', 'id'],

--- a/src/components/nodes/association/association.vue
+++ b/src/components/nodes/association/association.vue
@@ -64,7 +64,7 @@ export default {
       const connections = this.shape.findView(this.paper).getConnection();
       const points = connections.segments.map(segment => segment.end);
 
-      this.node.diagram.waypoint = points.map(point => moddle.create('dc:Point', point));
+      this.node.diagram.waypoint = points.map(point => this.$parent.moddle.create('dc:Point', point));
       this.updateCrownPosition();
     },
     updateLinkTarget({ clientX, clientY }) {

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -24,6 +24,14 @@ export default {
       }),
     });
   },
+  /**
+   * Validate whether to accept an outgoing flow to the node
+   * 
+   * @param node
+   */
+  validateOutgoing: function () {
+    return false;
+  },
   inspectorHandler: function(value, definition, component) {
     // Go through each property and rebind it to our data
     for (var key in value) {

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,6 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
 
 import component from './endEvent.vue';
 
@@ -12,12 +9,12 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/end-event.svg'),
   label: 'End Event',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:EndEvent', {
       name: 'End Event',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 36,

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './exclusiveGateway.vue';
 
 export const gatewayDirectionOptions = { Diverging: 'Diverging', Converging: 'Converging' };
@@ -14,13 +10,13 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/exclusive-gateway.svg'),
   label: 'Exclusive Gateway',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:ExclusiveGateway', {
       name: 'New Exclusive Gateway',
       gatewayDirection: 'Diverging',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 42,

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './inclusiveGateway.vue';
 
 export default {
@@ -12,13 +8,13 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/inclusive-gateway.svg'),
   label: 'Inclusive Gateway',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:InclusiveGateway', {
       name: 'New Inclusive Gateway',
       gatewayDirection: 'Diverging',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 42,

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './parallelGateway.vue';
 
 export default {
@@ -12,13 +8,13 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/parallel-gateway.svg'),
   label: 'Parallel Gateway',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:ParallelGateway', {
       name: 'New Parallel Gateway',
       gatewayDirection: 'Diverging',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 42,

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -1,7 +1,4 @@
-import BpmnModdle from 'bpmn-moddle';
 import component from './pool';
-
-const moddle = new BpmnModdle();
 
 export const id = 'processmaker-modeler-pool';
 export const labelWidth = 30;
@@ -15,12 +12,12 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/pool.svg'),
   label: 'Pool',
-  definition: function () {
+  definition: function (moddle) {
     return moddle.create('bpmn:Participant', {
       name: 'New Pool',
     });
   },
-  diagram: function () {
+  diagram: function (moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 250,

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -11,11 +11,8 @@ import { id as poolId, labelWidth, poolPadding } from './index';
 import { id as laneId } from '../poolLane';
 import laneAboveIcon from '@/assets/lane-above.svg';
 import laneBelowIcon from '@/assets/lane-below.svg';
-import BpmnModdle from 'bpmn-moddle';
 import { invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
 import pull from 'lodash/pull';
-
-const moddle = new BpmnModdle();
 
 joint.shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
   markup: [
@@ -95,11 +92,11 @@ export default {
        * Get the current laneSet element or create a new one. */
 
       if (!this.laneSet) {
-        const laneSet = moddle.create('bpmn:LaneSet');
+        const laneSet = this.$parent.moddle.create('bpmn:LaneSet');
         this.laneSet = laneSet;
         this.containingProcess.get('laneSets').push(laneSet);
 
-        const definition = Lane.definition();
+        const definition = Lane.definition(this.$parent.moddle);
 
         /* If there are currently elements in the pool, add them to the first lane */
         this.shape.getEmbeddedCells().filter(element => {
@@ -113,12 +110,12 @@ export default {
 
       this.pushNewLane();
     },
-    pushNewLane(definition = Lane.definition()) {
+    pushNewLane(definition = Lane.definition(this.$parent.moddle)) {
       this.$emit('set-pool-target', this.shape);
       this.$emit('add-node', {
         type: Lane.id,
         definition,
-        diagram: Lane.diagram(),
+        diagram: Lane.diagram(this.$parent.moddle),
       });
     },
     addToPool(element) {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -1,7 +1,4 @@
-import BpmnModdle from 'bpmn-moddle';
 import component from './poolLane';
-
-const moddle = new BpmnModdle();
 
 export const id = 'processmaker-modeler-lane';
 
@@ -12,8 +9,8 @@ export default {
   control: false,
   category: 'BPMN',
   label: 'New Lane',
-  definition: () => moddle.create('bpmn:Lane', { name: '' }),
-  diagram: () => moddle.create('bpmndi:BPMNShape', {
+  definition: (moddle) => moddle.create('bpmn:Lane', { name: '' }),
+  diagram: (moddle) => moddle.create('bpmndi:BPMNShape', {
     bounds: moddle.create('dc:Bounds', {
       height: 150,
       width: 600,

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -22,18 +22,20 @@ export default {
       sourceShape: null,
       target: null,
       anchorPadding: 25,
-      validConnections: {
-        'processmaker-modeler-task': ['processmaker-modeler-task', 'processmaker-modeler-end-event', 'processmaker-modeler-exclusive-gateway', 'processmaker-modeler-inclusive-gateway', 'processmaker-modeler-parallel-gateway'],
-        'processmaker-modeler-start-event': ['processmaker-modeler-task', 'processmaker-modeler-end-event'],
-        'processmaker-modeler-exclusive-gateway': ['processmaker-modeler-task', 'processmaker-modeler-end-event'],
-        'processmaker-modeler-inclusive-gateway': ['processmaker-modeler-task', 'processmaker-modeler-end-event'],
-        'processmaker-modeler-parallel-gateway': ['processmaker-modeler-task', 'processmaker-modeler-end-event'],
-      },
     };
   },
   computed: {
+    sourceNode() {
+      return this.sourceShape && this.sourceShape.component.node;
+    },
+    targetNode() {
+      return this.target && this.target.component.node;
+    },
     sourceType() {
-      return this.sourceShape && this.sourceShape.component.node.type;
+      return this.sourceNode && this.$parent.nodeRegistry[this.sourceNode.type];
+    },
+    targetType() {
+      return this.targetNode && this.$parent.nodeRegistry[this.targetNode.type];
     },
     elementPadding() {
       return this.shape && this.shape.source().id === this.shape.target().id ? 20 : 1;
@@ -109,7 +111,11 @@ export default {
         return false;
       }
 
-      if (!this.validConnections[this.sourceType].includes(targetType)) {
+      const invalidIncoming = this.targetType.validateIncoming instanceof Function
+        && !this.targetType.validateIncoming(this.sourceNode);
+      const invalidOutgoing = this.sourceType.validateOutgoing instanceof Function
+        && !this.sourceType.validateOutgoing(this.targetNode);
+      if (invalidIncoming || invalidOutgoing) {
         return false;
       }
 

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -9,11 +9,8 @@ import crownConfig from '@/mixins/crownConfig';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
 import pull from 'lodash/pull';
-import BpmnModdle from 'bpmn-moddle';
 import { gatewayDirectionOptions } from '../exclusiveGateway/index';
 import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
-
-const moddle = new BpmnModdle;
 
 export default {
   props: ['graph', 'node', 'id'],
@@ -93,7 +90,7 @@ export default {
       const connections = this.shape.findView(this.paper).getConnection();
       const points = connections.segments.map(segment => segment.end);
 
-      this.node.diagram.waypoint = points.map(point => moddle.create('dc:Point', point));
+      this.node.diagram.waypoint = points.map(point => this.$parent.moddle.create('dc:Point', point));
       this.updateCrownPosition();
     },
     isValidConnection() {

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './startEvent.vue';
 
 export default {
@@ -12,12 +8,12 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/start-event.svg'),
   label: 'Start Event',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:StartEvent', {
       name: 'Start Event',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 36,

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -23,6 +23,14 @@ export default {
       }),
     });
   },
+  /**
+   * Validate whether to accept an incoming flow from the node
+   * 
+   * @param node
+   */
+  validateIncoming: function () {
+    return false;
+  },
   inspectorHandler: function(value, definition, component) {
     // Go through each property and rebind it to our data
     for (var key in value) {

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './task.vue';
 
 export const taskHeight = 80;
@@ -14,12 +10,12 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/task.svg'),
   label: 'Task',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:Task', {
       name: 'New Task',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: taskHeight,

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -1,7 +1,3 @@
-import BpmnModdle from 'bpmn-moddle';
-
-let moddle = new BpmnModdle();
-
 import component from './textAnnotation.vue';
 
 export default {
@@ -12,12 +8,12 @@ export default {
   category: 'BPMN',
   icon: require('../../../assets/toolpanel/text-annotation.svg'),
   label: 'Text Annotation',
-  definition: function() {
+  definition: function(moddle) {
     return moddle.create('bpmn:TextAnnotation', {
       text: 'New Text Annotation',
     });
   },
-  diagram: function() {
+  diagram: function(moddle) {
     return moddle.create('bpmndi:BPMNShape', {
       bounds: moddle.create('dc:Bounds', {
         height: 30,


### PR DESCRIPTION
This PR includes:

- Modeler use only one reference to the instance of BpmnModdle
- Add method Modeler.registerInspectorExtension
- Add validation rules for incoming and outgoing flows.
- Add tests to Register custom properties and nodes.
