### PR TITLE
Fix errors when saving some elements. #74

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -396,7 +396,7 @@ export default {
     },
     loadInspector(type, data, component) {
       this.inspectorNode = data;
-      if(type === 'processmaker-modeler-sequence-flow' && data.sourceRef.$type === 'bpmn:ExclusiveGateway') {
+      if(type === 'processmaker-modeler-sequence-flow' && (data.sourceRef.$type === 'bpmn:ExclusiveGateway' || data.sourceRef.$type === 'bpmn:InclusiveGateway')) {
         this.inspectorConfig = this.sequenceExpressionInspectorConfig;
       } else {
         this.inspectorConfig = this.nodeRegistry[type].inspectorConfig;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -239,6 +239,7 @@ export default {
 
         /* Add all other elements */
         process.get('flowElements').forEach(this.setNode);
+        process.get('artifacts').forEach(this.setNode);
       });
     },
     setNode(definition) {

--- a/src/components/inspectors/sequenceExpression.js
+++ b/src/components/inspectors/sequenceExpression.js
@@ -30,7 +30,7 @@ export default [
         config: {
           label: 'Expression',
           helper: 'The Name of Expression',
-          name: 'body',
+          name: 'conditionExpression.body',
         },
       },
     ],

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -49,7 +49,7 @@ export default {
         targetRef: { x, y },
       });
 
-      if (sequenceLink.sourceRef.$type === 'bpmn:ExclusiveGateway') {
+      if (sequenceLink.sourceRef.$type === 'bpmn:ExclusiveGateway' || sequenceLink.sourceRef.$type === 'bpmn:InclusiveGateway') {
         sequenceLink.conditionExpression = moddle.create('bpmn:FormalExpression', {
           body: '',
         });


### PR DESCRIPTION
- Fix issue in flow expression that can not be read from a loaded process.
- Fix the storage of expression in conditional fl;ows.
- Load text annotations when the process is loaded.
- Remove the connection from the text annotation because it is not working properly

