### PR TITLE
Organize the Task component to be extensible. Resolves #91

### DIFF
--- a/src/components/nodes/scriptTask/scriptTask.vue
+++ b/src/components/nodes/scriptTask/scriptTask.vue
@@ -4,104 +4,18 @@
 </template>
 
 <script>
-import joint from 'jointjs';
-import connectIcon from '@/assets/connect-elements.svg';
-import crownConfig from '@/mixins/crownConfig';
-import TaskShape from '@/components/nodes/task/shape';
-import { taskHeight } from './index';
-
-const labelPadding = 15;
+import TaskComponent from '@/components/nodes/task/task';
 
 export default {
-  props: ['graph', 'node', 'id'],
-  mixins: [crownConfig],
-  data() {
-    return {
-      shape: null,
-      definition: null,
-      crownConfig: [
-        {
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
-    };
-  },
+  extends: TaskComponent,
   methods: {
-    getShape() {
-      return this.shape;
-    },
-    updateShape() {
-      let bounds = this.node.diagram.bounds;
-      this.shape.position(bounds.x, bounds.y);
-      this.shape.resize(bounds.width, bounds.height);
-      this.shape.attr({
-        body: {},
-        label: {
-          text: joint.util.breakText(this.node.definition.get('name'), {
-            width: bounds.width,
-          }),
-          fill: 'black',
-        },
-      });
-
-      const name = this.node.definition.get('name');
-      let labelText = joint.util.breakText(name, { width: bounds.width });
-
-      /* Update shape height if label text overflows */
-
-      this.shape.attr('label/text', labelText);
-
-      const shapeView = this.shape.findView(this.paper);
-      const labelHeight = shapeView.selectors.label.getBBox().height;
-      const { height } = this.shape.size();
-
-      if (labelHeight + labelPadding !== height) {
-        bounds.height = Math.max(labelHeight + 15, taskHeight);
-        this.shape.resize(bounds.width, bounds.height);
-      }
-
-      // Alert anyone that we have moved
+    getMarker() {
+      return { 'xlink:href': require('@/assets/script.svg') };
     },
     handleClick() {
       this.$parent.loadInspector('processmaker-modeler-script-task', this.node.definition, this);
     },
   },
-  mounted() {
-    this.shape = new TaskShape();
-
-    let bounds = this.node.diagram.bounds;
-    this.shape.position(bounds.x, bounds.y);
-    this.shape.resize(bounds.width, bounds.height);
-    this.shape.attr({
-      body: {
-        rx: 8,
-        ry: 8,
-      },
-      label: {
-        text: joint.util.breakText(this.node.definition.get('name'), { width: bounds.width }),
-        fill: 'black',
-      },
-      image: { 'xlink:href': require('@/assets/script.svg') },
-    });
-
-    this.shape.on('change:position', (element, position) => {
-      this.node.diagram.bounds.x = position.x;
-      this.node.diagram.bounds.y = position.y;
-      // This is done so any flows pointing to this task are updated
-      this.$emit(
-        'move',
-        {
-          x: bounds.x,
-          y: bounds.y,
-        },
-        element
-      );
-    });
-
-    this.shape.addTo(this.graph);
-    this.shape.component = this;
-    this.$parent.nodes[this.id].component = this;
-  },
 };
+
 </script>

--- a/src/components/nodes/task/shape.js
+++ b/src/components/nodes/task/shape.js
@@ -18,7 +18,7 @@ export default joint.shapes.standard.Rectangle.extend({
     type: 'processmaker.components.nodes.task.Shape',
     size: { width: 100, height: 60 },
     attrs: {
-      'image': { 'ref-x': 2, 'ref-y': 2, ref: 'rect', width: 16, height: 16 },
+      'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16 },
     },
 
   }, joint.shapes.standard.Rectangle.prototype.defaults),

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -7,6 +7,7 @@
 import joint from 'jointjs';
 import connectIcon from '@/assets/connect-elements.svg';
 import crownConfig from '@/mixins/crownConfig';
+import TaskShape from '@/components/nodes/task/shape';
 import { taskHeight } from './index';
 
 const labelPadding = 15;
@@ -27,6 +28,9 @@ export default {
     };
   },
   methods: {
+    getMarker() {
+      return undefined;
+    },
     getShape() {
       return this.shape;
     },
@@ -67,7 +71,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new joint.shapes.standard.Rectangle();
+    this.shape = new TaskShape();
 
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
@@ -81,6 +85,7 @@ export default {
         text: joint.util.breakText(this.node.definition.get('name'), { width: bounds.width }),
         fill: 'black',
       },
+      image: this.getMarker(),
     });
 
     this.shape.on('change:position', (element, position) => {


### PR DESCRIPTION
A script task component looks like:

```
import TaskComponent from '@/components/nodes/task/task';

export default {
  extends: TaskComponent,
  methods: {
    getMarker() {
      return { 'xlink:href': require('@/assets/script.svg') };
    },
    handleClick() {
      this.$parent.loadInspector('processmaker-modeler-script-task', this.node.definition, this);
    },
  },
};
```
