### PR TITLE
Fix gateway rename. Resolves #100

### DIFF
--- a/src/components/nodes/exclusiveGateway/exclusiveGateway.vue
+++ b/src/components/nodes/exclusiveGateway/exclusiveGateway.vue
@@ -77,8 +77,7 @@ export default {
   },
   watch: {
     'node.definition.name'(name) {
-      const { width } = this.shapeView.getBBox();
-      this.shape.attr('label/text', joint.util.breakText(name, { width }));
+      this.shape.attr('.label/text', name);
     },
   },
   mounted() {


### PR DESCRIPTION
Remove break because gateway width is too small to frame the text