### PR TITLE
Change the order of loading elements. Resolves #104

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -240,8 +240,14 @@ export default {
         }
 
         /* Add all other elements */
-        process.get('flowElements').forEach(this.setNode);
-        process.get('artifacts').forEach(this.setNode);
+        // First load the flow elements
+        process.get('flowElements').filter(node => node.$type !== 'bpmn:SequenceFlow').forEach(this.setNode);
+        // Then the sequence flows
+        process.get('flowElements').filter(node => node.$type === 'bpmn:SequenceFlow').forEach(this.setNode);
+        // Then the artifacts
+        process.get('artifacts').filter(node => node.$type !== 'bpmn:Association').forEach(this.setNode);
+        // Then the associations
+        process.get('artifacts').filter(node => node.$type === 'bpmn:Association').forEach(this.setNode);
       });
     },
     setNode(definition) {


### PR DESCRIPTION
With this change, when a process is loaded from a BPMN file, the order in which the vue components that render the elements are loaded is:

1. Flow elements (tasks, gateways, ...)
2. Sequence flows
3. Artifacts (text annotation)
4. Associations
