### PR TITLE
Fix bug with resizing direction for undo/redo

### DIFF
--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -236,7 +236,7 @@ export default {
         return;
       }
 
-      store.dispatch('updateNodeBounds', { node: this.node, bounds: { ...newSize, direction: opt.direction} });
+      store.dispatch('updateNodeBounds', { node: this.node, bounds: { ...newSize, direction: opt.direction } });
     },
     startBatch() {
       store.commit('startBatchAction');

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -112,6 +112,22 @@ export default {
         this.updateAnchorPointPosition();
       });
 
+      /* Resize triggers a position change, which will cause issues with undo/redo.
+       * Disabled the position change listener when resizing. */
+      if (this.updateNodePosition) {
+        const points = [pointBottomRight, pointBottomLeft, pointTopRight, pointTopLeft];
+        const enablePositionUpdate = () => {
+          this.shape.on('change:position', this.updateNodePosition);
+        };
+        const disablePositionUpdate = cellView => {
+          if (points.includes(cellView.model)) {
+            this.shape.off('change:position', this.updateNodePosition);
+            this.paper.once('element:pointerup', enablePositionUpdate);
+          }
+        };
+
+        this.paper.on('element:pointerdown', disablePositionUpdate);
+      }
     },
     getYLimit() {
       const lowestShapeY = this.poolComponent.shape.getEmbeddedCells().filter(element => {

--- a/src/store.js
+++ b/src/store.js
@@ -155,7 +155,11 @@ export default new Vuex.Store({
       commit('clearRedoList');
     },
     updateNodeBounds({ commit, state }, { node, bounds }) {
-      const previousBounds = { ...node.diagram.bounds };
+      /* Nodes may aquire properties that are not 'watched' by undo/redo. So, it's important to
+       * spread the old bounds over the previous bounds to ensure this data is not lost during
+       * undo. */
+      const previousBounds = { ...bounds, ...node.diagram.bounds, direction: bounds.direction };
+
       const undo = () => commit('updateNodeBounds', { node, bounds: previousBounds });
       const redo = () => commit('updateNodeBounds', { node, bounds });
       redo();


### PR DESCRIPTION
Fixes #111.

To test: Resize a pool in any direction, then undo and redo the action. During undo and redo, the pool should resize in the direction you originally resized it.