### PR TITLE
Fix bug when resizing pool with lanes

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -281,6 +281,13 @@ export default {
         if (this.laneSet) {
           /* Expand any lanes within the pool */
           this.resizeLanes();
+
+          this.sortedLanes().forEach(laneShape => {
+            store.dispatch('updateNodeBounds', {
+              node: laneShape.component.node,
+              bounds: laneShape.getBBox(),
+            });
+          });
         }
 
         store.dispatch('updateNodeBounds', {
@@ -340,11 +347,6 @@ export default {
 
         laneShape.resize(width, newHeight);
         laneShape.position(0, newY, { parentRelative: true });
-
-        store.dispatch('updateNodeBounds', {
-          node: laneShape.component.node,
-          bounds: laneShape.getBBox(),
-        });
       });
     },
     captureChildren() {

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -146,19 +146,21 @@ export default {
       const { width, height } = this.node.diagram.bounds;
       const bbox = this.shape.getBBox();
       if (width !== bbox.width || height !== bbox.height) {
-        if (this.node.type === laneId) {
+        if (this.poolComponent.laneSet) {
           store.commit('startBatchAction');
-          setTimeout(() => store.commit('commitBatchAction'));
+          setTimeout(() => {
+            store.commit('commitBatchAction');
+          });
 
           store.dispatch('updateNodeBounds', {
             node: this.poolComponent.node,
             bounds: this.poolComponent.shape.getBBox(),
           });
 
-          this.poolComponent.sortedLanes().forEach(lane => {
+          this.poolComponent.sortedLanes().forEach(laneShape => {
             store.dispatch('updateNodeBounds', {
-              node: lane.component.node,
-              bounds: lane.component.shape.getBBox(),
+              node: laneShape.component.node,
+              bounds: laneShape.getBBox(),
             });
           });
         } else {


### PR DESCRIPTION
Undo would incorrectly resize lanes after resizing a pool with lanes, or resizing a lane. This PR fixes that bug.