### PR TITLE
Fix build-bundle to point index.js inside nodes and add Modeler export.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "build-bundle": "vue-cli-service build --target lib --name modeler ./src/components/index.js",
+    "build-bundle": "vue-cli-service build --target lib --name modeler ./src/components/nodes/index.js",
     "lint": "vue-cli-service lint",
     "test:unit": "vue-cli-service test:unit"
   },

--- a/src/components/nodes/index.js
+++ b/src/components/nodes/index.js
@@ -11,3 +11,4 @@ export { default as serviceTask } from './serviceTask';
 export { default as textAnnotation } from './textAnnotation';
 export { default as pool } from './pool';
 export { default as poolLane } from './poolLane';
+export { default as Modeler } from '../Modeler';


### PR DESCRIPTION
Point the build-bundle to the index.js inside nodes that is cleaner.

Fixes: #170 
