### PR TITLE
Fix Sequence Flow Rendering issues when positioning connected nodes.

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -24,7 +24,6 @@ export default {
       definition: null,
       sourceShape: null,
       target: null,
-      anchorPadding: 40,
     };
   },
   computed: {
@@ -128,11 +127,7 @@ export default {
       this.updateCrownPosition();
     },
     updateRouter() {
-      this.shape.router('manhattan', {
-        padding: this.anchorPadding,
-        maximumLoops: 1,
-        maxAllowedDirectionChange: 1,
-      });
+      this.shape.router('orthogonal');
     },
     updateLinkTarget({ clientX, clientY }) {
       const localMousePosition = this.paper.clientToLocalPoint({ x: clientX, y: clientY });
@@ -218,12 +213,7 @@ export default {
   mounted() {
     this.shape = new joint.shapes.standard.Link({
       router: {
-        name: 'manhattan',
-        args: {
-          padding: this.anchorPadding,
-          maximumLoops: 1,
-          maxAllowedDirectionChange: 1,
-        },
+        name: 'orthogonal',
       },
     });
 


### PR DESCRIPTION
Fixes #172 

Removed padding on the anchor points prevents the routers to break which in some cases would cause the overlapping in the flows. Switch from the **manhattan** router option to the **orthogonal** since the options were not needed from it.