### PR TITLE
Undo/redo XML refactor

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -62,15 +62,12 @@ import store from '@/store';
 import InspectorPanel from '@/components/inspectors/InspectorPanel';
 import undoRedoStore from '@/undoRedoStore';
 
-window.undoRedoStore = undoRedoStore;
-
 // Our renderer for our inspector
 import { Drop } from 'vue-drag-drop';
 
 import { id as poolId } from './nodes/pool';
 import { id as laneId } from './nodes/poolLane';
 import { id as sequenceFlowId } from './nodes/sequenceFlow';
-import { setTimeout } from 'timers';
 
 const version = '1.0';
 
@@ -129,7 +126,6 @@ export default {
   },
   methods: {
     pushToUndoStack() {
-      console.log('pushToUndoStack');
       this.toXML((err,xml) => {
         undoRedoStore.dispatch('pushState', xml);
       });
@@ -348,8 +344,8 @@ export default {
       });
     },
     hasSourceAndTarget(definition) {
-      const hasSource = this.parsers[definition.sourceRef.$type];
-      const hasTarget = this.parsers[definition.targetRef.$type];
+      const hasSource = definition.sourceRef && this.parsers[definition.sourceRef.$type];
+      const hasTarget = definition.targetRef && this.parsers[definition.targetRef.$type];
 
       return hasSource && hasTarget;
     },
@@ -441,7 +437,7 @@ export default {
         pool: this.poolTarget,
       });
 
-      if (type !== sequenceFlowId) {
+      if (![sequenceFlowId, laneId].includes(type)) {
         setTimeout(() => this.pushToUndoStack());
       }
 
@@ -545,8 +541,6 @@ export default {
     this.moddle = new BpmnModdle(this.extensions);
   },
   mounted() {
-    // this.saveInterval = setInterval(this.logXml, 1000);
-
     // Handle window resize
     this.handleResize();
     window.addEventListener('resize', this.handleResize);

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -101,7 +101,8 @@ export default {
   },
   methods: {
     setNodeProp: debounce(function(node, key, value) {
-      store.dispatch('updateNodeProp', { node, key, value });
+      store.commit('updateNodeProp', { node, key, value });
+      this.$emit('save-state');
     }, saveDebounce),
     defaultInspectorHandler(value, node, setNodeProp) {
       /* Go through each property and rebind it to our data */

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -135,7 +135,9 @@ export default {
       }
 
       this.pushNewLane();
-      setTimeout(() => store.commit('commitBatchAction'));
+      this.$nextTick(() => {
+        this.$emit('save-state');
+      });
     },
     createLaneSet() {
       const laneSet = this.moddle.create('bpmn:LaneSet');
@@ -148,7 +150,6 @@ export default {
       const diagram = Lane.diagram(this.moddle);
       diagram.bounds.width = this.shape.getBBox().width;
 
-      store.commit('startBatchAction');
       this.$emit('add-node', {
         type: Lane.id,
         definition,
@@ -224,7 +225,7 @@ export default {
         elementBounds.set('width', element.get('size').width);
         elementBounds.set('height', element.get('size').height);
 
-        store.dispatch('updateNodeBounds', {
+        store.commit('updateNodeBounds', {
           node: this.node,
           bounds: this.shape.getBBox(),
         });
@@ -279,19 +280,19 @@ export default {
           this.resizeLanes();
 
           this.sortedLanes().forEach(laneShape => {
-            store.dispatch('updateNodeBounds', {
+            store.commit('updateNodeBounds', {
               node: laneShape.component.node,
               bounds: laneShape.getBBox(),
             });
           });
         }
 
-        store.dispatch('updateNodeBounds', {
+        store.commit('updateNodeBounds', {
           node: this.node,
           bounds: this.shape.getBBox(),
         });
 
-        store.commit('commitBatchAction');
+        this.$emit('save-state');
       }
     },
     fillLanes(resizingLane, direction, remove) {
@@ -428,7 +429,7 @@ export default {
           : currentRefs.length > 0;
 
         if (hasChanged) {
-          store.dispatch('updateNodeProp', {
+          store.commit('updateNodeProp', {
             node: laneShape.component.node,
             key: 'flowNodeRef',
             value: newRefs || [],
@@ -539,10 +540,8 @@ export default {
         }
 
         if (previousValidPosition) {
-          store.commit('startBatchAction');
-
           draggingElement.position(previousValidPosition.x, previousValidPosition.y, { deep: true });
-          store.dispatch('updateNodeBounds', {
+          store.commit('updateNodeBounds', {
             node: draggingElement.component.node,
             bounds: previousValidPosition,
           });

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -207,14 +207,7 @@ export default {
           direction: this.addLaneAbove ? 'top-right' : 'bottom-right',
         });
 
-        /* Resizing causes rounding errors.
-         * E.g. Setting 180.0000000000001 instead of 180.
-         * Re-position pool based on rounded values.
-         */
-        this.shape.position(
-          Math.round(this.shape.getBBox().x),
-          Math.round(this.shape.getBBox().y)
-        );
+        this.fixResizeRounding();
 
         this.updateCrownPosition();
         this.updateAnchorPointPosition();
@@ -284,6 +277,8 @@ export default {
         this.shape.resize(Math.max(newWidth, width), Math.max(newHeight, height), {
           direction: `${directionHeight}-${directionWidth}`,
         });
+
+        this.fixResizeRounding();
 
         this.updateCrownPosition();
         this.updateAnchorPointPosition();

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -206,7 +206,16 @@ export default {
         this.shape.resize(width, isFirstLane ? height : height + laneHeight, {
           direction: this.addLaneAbove ? 'top-right' : 'bottom-right',
         });
-        this.shape.position(poolX, poolY);
+
+        /* Resizing causes rounding errors.
+         * E.g. Setting 180.0000000000001 instead of 180.
+         * Re-position pool based on rounded values.
+         */
+        this.shape.position(
+          Math.round(this.shape.getBBox().x),
+          Math.round(this.shape.getBBox().y)
+        );
+
         this.updateCrownPosition();
         this.updateAnchorPointPosition();
 

--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -9,7 +9,6 @@ import crownConfig from '@/mixins/crownConfig';
 import resizeConfig from '@/mixins/resizeConfig';
 import { labelWidth } from '../pool/poolSizes';
 import pull from 'lodash/pull';
-import store from '@/store';
 
 export default {
   props: ['graph', 'node', 'nodes', 'id', 'collaboration'],
@@ -27,7 +26,6 @@ export default {
   },
   methods: {
     removeShape() {
-      store.commit('startBatchAction');
       this.$emit('remove-node', this.node);
 
       const poolComponent = this.node.pool.component;

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -13,7 +13,6 @@ import data from './index';
 import { gatewayDirectionOptions } from '../exclusiveGateway/index';
 import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
 import { id as laneId } from '../poolLane';
-import store from '@/store';
 
 export default {
   props: ['graph', 'node', 'id', 'moddle', 'nodeRegistry'],
@@ -170,7 +169,7 @@ export default {
       this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {
         this.completeLink();
         this.updateDefinitionLinks();
-        store.commit('commitTemp');
+        this.$emit('save-state');
       });
 
       this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
@@ -182,7 +181,7 @@ export default {
     },
     removeLink() {
       this.resetPaper();
-      store.commit('purgeTemp');
+      this.$emit('remove-node', this.node);
     },
     resetPaper() {
       this.$emit('set-cursor', null);

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -207,16 +207,9 @@ export default {
         return;
       }
 
-      const { x, y } = this.node.diagram.bounds;
-      const bbox = this.shape.getBBox();
-
-      if (x === bbox.x && y === bbox.y) {
-        return;
-      }
-
       store.commit('updateNodeBounds', {
         node: this.node,
-        bounds: bbox,
+        bounds: this.shape.getBBox(),
       });
 
       this.$emit('save-state');

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -55,6 +55,14 @@ export default {
   },
   methods: {
     removeShape() {
+      this.graph.getConnectedLinks(this.shape).forEach(shape => this.$emit('remove-node', shape.component.node));
+      this.shape.getEmbeddedCells().forEach(cell => {
+        if (cell.component) {
+          this.shape.unembed(cell);
+          this.$emit('remove-node', cell.component.node);
+        }
+      });
+
       this.$emit('remove-node', this.node);
     },
     removeCrown() {
@@ -258,15 +266,6 @@ export default {
       }
     });
   },
-  beforeDestroy() {
-    this.graph.getConnectedLinks(this.shape).forEach(shape => this.$emit('remove-node', shape.component.node));
-    this.shape.getEmbeddedCells().forEach(cell => {
-      if (cell.component) {
-        this.shape.unembed(cell);
-        this.$emit('remove-node', cell.component.node);
-      }
-    });
-  },
   destroyed() {
     this.shape.stopListening();
     this.shape.remove();
@@ -278,6 +277,5 @@ export default {
     pull(process.get('flowElements'), this.node.definition);
     pull(this.planeElements, this.node.diagram);
     pull(process.get('artifacts'), this.node.definition);
-    console.log('destroyed');
   },
 };

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -55,10 +55,6 @@ export default {
   },
   methods: {
     removeShape() {
-      if (this.isPool || this.isLane) {
-        store.commit('startBatchAction');
-      }
-
       this.$emit('remove-node', this.node);
     },
     removeCrown() {
@@ -80,13 +76,15 @@ export default {
         targetRef: { x, y },
       });
 
-      if (sequenceLink.sourceRef.$type === 'bpmn:ExclusiveGateway' || sequenceLink.sourceRef.$type === 'bpmn:InclusiveGateway') {
+      if (
+        sequenceLink.sourceRef.$type === 'bpmn:ExclusiveGateway' ||
+        sequenceLink.sourceRef.$type === 'bpmn:InclusiveGateway')
+      {
         sequenceLink.conditionExpression = this.moddle.create('bpmn:FormalExpression', {
           body: '',
         });
       }
 
-      store.commit('useTemp');
       this.$emit('add-node', {
         type: 'processmaker-modeler-sequence-flow',
         definition: sequenceLink,
@@ -178,7 +176,12 @@ export default {
       });
     },
     configurePoolLane() {
-      if (['processmaker-modeler-pool', 'processmaker-modeler-sequence-flow', 'processmaker-modeler-association'].includes(this.node.type)) {
+      if ([
+        'processmaker-modeler-pool',
+        'processmaker-modeler-sequence-flow',
+        'processmaker-modeler-association',
+      ].includes(this.node.type))
+      {
         return;
       }
 
@@ -216,10 +219,12 @@ export default {
         return;
       }
 
-      store.dispatch('updateNodeBounds', {
+      store.commit('updateNodeBounds', {
         node: this.node,
         bounds: bbox,
       });
+
+      this.$emit('save-state');
     },
   },
   mounted() {
@@ -273,9 +278,6 @@ export default {
     pull(process.get('flowElements'), this.node.definition);
     pull(this.planeElements, this.node.diagram);
     pull(process.get('artifacts'), this.node.definition);
-
-    if (this.isPool || this.isLane) {
-      store.commit('commitBatchAction');
-    }
+    console.log('destroyed');
   },
 };

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -23,24 +23,6 @@ export default {
         this.removeCrown();
       }
     },
-    'node.diagram.bounds': {
-      handler({ x, y, width, height }) {
-        const { x: shapeX, y: shapeY } = this.shape.position();
-        const { width: shapeWidth, height: shapeHeight } = this.shape.get('size');
-        const sizeChanged = width !== shapeWidth || height !== shapeHeight;
-        const positionChanged = x !== shapeX || y !== shapeY;
-
-        if (!sizeChanged && !positionChanged) {
-          return;
-        }
-
-        sizeChanged && this.shape.resize(width, height);
-        positionChanged && this.shape.position(x, y, { deep: !sizeChanged });
-
-        this.updateCrownPosition();
-      },
-      deep: true,
-    },
   },
   computed: {
     shapeView() {
@@ -166,6 +148,11 @@ export default {
           shapeView.unhighlight();
           shapeView.highlight();
         }
+      });
+
+      this.shape.on('change:position', (element, newPosition) => {
+        this.node.diagram.bounds.x = newPosition.x;
+        this.node.diagram.bounds.y = newPosition.y;
       });
     },
     updateCrownPosition() {

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -147,26 +147,25 @@ export default {
       const bbox = this.shape.getBBox();
       if (width !== bbox.width || height !== bbox.height) {
         if (this.poolComponent.laneSet) {
-          store.commit('startBatchAction');
           setTimeout(() => {
-            store.commit('commitBatchAction');
+            this.$emit('save-state');
           });
 
           this.poolComponent.updateLaneChildren();
 
-          store.dispatch('updateNodeBounds', {
+          store.commit('updateNodeBounds', {
             node: this.poolComponent.node,
             bounds: this.poolComponent.shape.getBBox(),
           });
 
           this.poolComponent.sortedLanes().forEach(laneShape => {
-            store.dispatch('updateNodeBounds', {
+            store.commit('updateNodeBounds', {
               node: laneShape.component.node,
               bounds: laneShape.getBBox(),
             });
           });
         } else {
-          store.dispatch('updateNodeBounds', {
+          store.commit('updateNodeBounds', {
             node: this.node,
             bounds: this.shape.getBBox(),
           });

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -17,5 +17,3 @@ const blank = `
 window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML }) => {
   loadXML(blank);
 });
-
-

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import pull from 'lodash/pull';
 
 Vue.use(Vuex);
 
@@ -9,48 +8,17 @@ export const saveDebounce = 300;
 export default new Vuex.Store({
   state: {
     graph: null,
-    useTemp: false,
     highlightedNode: null,
-    undoList: [],
-    redoList: [],
-    tempAction: null,
     nodes: [],
-    batch: false,
-    batchActions: [],
   },
   getters: {
     nodes: state => state.nodes,
-    canUndo: state => state.undoList.length > 0,
-    canRedo: state => state.redoList.length > 0,
     highlightedNode: state => state.highlightedNode,
     nodeShape: state => node => {
       return state.graph.getCells().find(cell => cell.component && cell.component.node === node);
     },
   },
   mutations: {
-    undo(state) {
-      if (state.undoList.length > 0) {
-        state.highlightedNode = null;
-        const undoRedo = state.undoList.pop();
-
-        Array.isArray(undoRedo)
-          ? undoRedo.forEach(({ undo }) => undo())
-          : undoRedo.undo();
-
-        state.redoList.unshift(undoRedo);
-      }
-    },
-    redo(state) {
-      if (state.redoList.length > 0) {
-        const undoRedo = state.redoList.shift();
-
-        Array.isArray(undoRedo)
-          ? undoRedo.forEach(({ redo }) => redo())
-          : undoRedo.redo();
-
-        state.undoList.push(undoRedo);
-      }
-    },
     updateNodeBounds(state, { node, bounds }) {
       Object.entries(bounds).forEach(([key, val]) => {
         if (key === '$type') {
@@ -66,121 +34,21 @@ export default new Vuex.Store({
     clearNodes(state) {
       state.nodes = [];
     },
-    clearHistory(state) {
-      state.undoList = [];
-      state.redoList = [];
-    },
-    clearRedoList(state) {
-      state.redoList = [];
-    },
     highlightNode(state, node) {
       state.highlightedNode = node;
     },
     addNode(state, node) {
       state.nodes.push(node);
     },
-    unembedNodes(state, nodeShape) {
-      nodeShape.getEmbeddedCells().forEach(cell => {
-        if (cell.component) {
-          cell.component.node.pool = null;
-          nodeShape.unembed(cell);
-        }
-      });
-    },
     removeNode(state, node) {
-      pull(state.nodes, node);
-    },
-    useTemp(state) {
-      state.useTemp = true;
-    },
-    commitTemp(state) {
-      state.useTemp = false;
-      state.redoList = [];
-      state.undoList.push(state.tempAction);
-      state.tempAction = null;
-    },
-    purgeTemp(state) {
-      state.useTemp = false;
-      state.tempAction.undo();
-      state.tempAction = null;
-    },
-    startBatchAction(state) {
-      state.batch = true;
-    },
-    commitBatchAction(state) {
-      if (!state.batch) {
-        return;
+      const index = state.nodes.indexOf(node);
+
+      if (index !== -1) {
+        state.nodes.splice(index, 1);
       }
-
-      state.batch = false;
-
-      if (state.batchActions.length > 0) {
-        state.undoList.push(state.batchActions);
-      }
-
-      state.batchActions = [];
     },
     setGraph(state, graph) {
       state.graph = graph;
-    },
-  },
-  actions: {
-    addNode({ commit, state, getters }, node) {
-      const undo = () => {
-        commit('unembedNodes', getters.nodeShape(node));
-        commit('removeNode', node);
-      };
-      const redo = () => commit('addNode', node);
-
-      redo();
-
-      if (state.useTemp) {
-        state.tempAction = { undo, redo };
-      } else {
-        commit('clearRedoList');
-        state.batch
-          ? state.batchActions.push({ undo, redo })
-          : state.undoList.push({ undo, redo });
-      }
-    },
-    removeNode({ commit, state }, node) {
-      const undo = () => commit('addNode', node);
-      const redo = () => commit('removeNode', node);
-      redo();
-
-      state.batch
-        ? state.batchActions.push({ undo, redo })
-        : state.undoList.push({ undo, redo });
-
-      commit('clearRedoList');
-    },
-    updateNodeBounds({ commit, state }, { node, bounds }) {
-      /* Nodes may aquire properties that are not 'watched' by undo/redo. So, it's important to
-       * spread the old bounds over the previous bounds to ensure this data is not lost during
-       * undo. */
-      const previousBounds = { ...bounds, ...node.diagram.bounds };
-
-      const undo = () => commit('updateNodeBounds', { node, bounds: previousBounds });
-      const redo = () => commit('updateNodeBounds', { node, bounds });
-      redo();
-
-      state.batch
-        ? state.batchActions.push({ undo, redo })
-        : state.undoList.push({ undo, redo });
-
-      commit('clearRedoList');
-    },
-    updateNodeProp({ commit, state }, { node, key, value }) {
-      const previousValue = node.definition.get(key);
-      const undo = () => commit('updateNodeProp', { node, key, value: previousValue });
-      const redo = () => commit('updateNodeProp', { node, key, value });
-      redo();
-
-      state.batch
-        ? state.batchActions.push({ undo, redo })
-        : state.undoList.push({ undo, redo });
-
-      commit('clearRedoList');
     },
   },
 });

--- a/src/undoRedoStore.js
+++ b/src/undoRedoStore.js
@@ -1,0 +1,55 @@
+import Vue from 'vue';
+import Vuex from 'vuex';
+
+Vue.use(Vuex);
+
+export default new Vuex.Store( {
+  state: {
+    stack: [],
+    position: null,
+  },
+  getters: {
+    canUndo(state) {
+      return state.position > 0;
+    },
+    canRedo(state) {
+      return state.position < state.stack.length - 1;
+    },
+    currentState(state) {
+      return state.stack[state.position];
+    },
+  },
+  mutations: {
+    setPosition(state, position) {
+      state.position = position;
+    },
+    setState(state, newState) {
+      state.stack = state.stack.slice(0, state.position + 1);
+      state.stack.push(newState);
+    },
+  },
+  actions: {
+    pushState({ state, getters, commit }, newState) {
+      if (newState === getters.currentState) {
+        return;
+      }
+
+      commit('setState', newState);
+      commit('setPosition', state.stack.length - 1);
+    },
+    async undo({ state, getters, commit }) {
+      if (!getters.canUndo) {
+        return;
+      }
+
+      commit('setPosition', state.position - 1);
+    },
+    async redo({ state, getters, commit }) {
+      if (!getters.canRedo) {
+        return;
+      }
+
+      commit('setPosition', state.position + 1);
+    },
+  },
+});


### PR DESCRIPTION
Fixes #157, Fixes #159, fixes #160, fixes #161, fixes #162, fixes #163, fixes #158.

**How to test:**

Ensure undo/redo works as expected from the issues listed above.

**Important changes:**

Undo/redo has been changed from using actions (functions), to saving a snapshot of the XML (a string) after an action is performed, and restoring from this snapshot (loading/parsing the XML string) when traversing through the undo/redo stack.