### PR TITLE
Recalculate element drop position relative to the paper origin

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -359,8 +359,9 @@ export default {
       const diagram = this.nodeRegistry[type].diagram(this.moddle);
 
       // Handle transform
-      diagram.bounds.x = event.offsetX - this.paper.options.origin.x;
-      diagram.bounds.y = event.offsetY - this.paper.options.origin.y;
+      const paperOrigin = this.paper.localToPagePoint(0, 0);
+      diagram.bounds.x = event.clientX - paperOrigin.x;
+      diagram.bounds.y = event.clientY - paperOrigin.y;
 
       // Our BPMN models are updated, now add to our nodes
       // @todo come up with random id


### PR DESCRIPTION
Root cause: when dropping an element inside a pool in Firefox, the calculated offset is relative to the pool and the drop is relative to the paper origin. Interestingly, Firefox handles the drop event more closely to spec for the offset attributes.

Fix:
Set the origin of the page, and use it to calculate the position of the drop. 

Fixes #168 