### PR TITLE
Add default implementation parser

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -181,7 +181,9 @@ export default {
     },
     // This registers a node to use in the bpmn modeler
     registerNode(nodeType, customParser) {
-      const defaultParser = () => nodeType.id;
+      const defaultParser = nodeType.implementation
+        ? definition => definition.get('implementation') === nodeType.implementation && nodeType.id
+        : () => nodeType.id;
 
       this.nodeRegistry[nodeType.id] = nodeType;
 
@@ -304,9 +306,10 @@ export default {
         return;
       }
 
-      const type = this.parsers[definition.$type].reduce((type, parser) => {
-        return parser(definition) || type;
-      }, null);
+      const type = this.parsers[definition.$type]
+        .reduce((type, parser) => {
+          return parser(definition, this.moddle) || type;
+        }, null);
 
       const unnamedElements = ['bpmn:TextAnnotation'];
       const requireName = unnamedElements.indexOf(definition.$type) === -1;

--- a/src/setup/extensions/testCustomConnector.js
+++ b/src/setup/extensions/testCustomConnector.js
@@ -1,15 +1,19 @@
 import {
   task,
 } from '@/components/nodes';
+import testIcon from '@/assets/connect-artifacts.svg';
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
   /* Add a custom node example */
 
-  const implementation = 'processmaker-social-twitter-send';
-  const nodeId = 'processmaker-connectors-social-twitter-send';
+  const implementation = 'test-message';
+  const nodeId = 'connectors-test-message';
 
   const component = {
     extends: task.component,
+    mounted() {
+      this.shape.attr('image/xlink:href', testIcon);
+    },
   };
 
   const nodeType = {
@@ -19,13 +23,13 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
     control: true,
     category: 'Social',
     icon: require('@/assets/toolpanel/task.svg'),
-    label: 'Send Tweet',
+    label: 'Test',
     implementation,
     definition(moddle) {
       return moddle.create('bpmn:ServiceTask', {
-        name: 'Send Tweet',
+        name: 'Test Connector',
         implementation,
-        config: JSON.stringify({ tweet: '' }),
+        config: JSON.stringify({ testMessage: '' }),
       });
     },
     diagram(moddle) {
@@ -73,12 +77,12 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
     },
     inspectorConfig: [
       {
-        name: 'Send Tweet',
+        name: 'Test Connector',
         items: [
           {
             component: 'FormText',
             config: {
-              label: 'Send Tweet',
+              label: 'Test Connector',
               fontSize: '2em',
             },
           },
@@ -93,9 +97,9 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
           {
             component: 'FormTextArea',
             config: {
-              label: 'Tweet Body',
-              helper: 'The Body Of The Tweet to Send',
-              name: 'tweet',
+              label: 'Test Message',
+              helper: 'The Body of The Message to Send',
+              name: 'testMessage',
             },
           },
         ],

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -3,6 +3,8 @@ import './globals';
 // Import Extensions for Testing Modeler
 import './defaultNodes';
 import './extensions/testTaskInspectorExtension';
+import './extensions/twitterConnector';
+import './extensions/testCustomConnector';
 
 const blank = `
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Fixes #175.

**How to test:**
 * In the modeler, click Upload XML and select a BPMN file which contains multiple `bpmn:serviceTask` elements with different implementations.
 * The modeler should render a different component for different implementations.


**Important changes:**

The `registerNode` function now expects the node config to have an `implementation` property to correctly parse it. For example:

Before:
```js
window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
  const nodeType = {
    /* ... */
    definition(moddle) { /* ... */ },
    /* ... */
  };

  registerNode(nodeType);
});
```

After:
```js
window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
  const nodeType = {
    /* ... */
    implementation: 'processmaker-social-twitter-send',
    definition(moddle) { /* ... */ },
    /* ... */
  };

  registerNode(nodeType);
});
```