### PR TITLE
Clean up definitions after deleting pool with lanes

### DIFF
--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -89,11 +89,11 @@ export default {
      * If this was the 2nd last lane, remove all lanes and revert the pool back to normal. */
 
     const poolComponent = this.node.pool.component;
-    const sortedLanes = poolComponent.sortedLanes();
+    const lanes = poolComponent.laneSet.get('lanes');
 
-    pull(poolComponent.laneSet.get('lanes'), this.node.definition);
+    pull(lanes, this.node.definition);
 
-    if (sortedLanes.length === 1) {
+    if (lanes.length === 0) {
       /* Last lane being removed; remove laneSet */
       poolComponent.containingProcess.set('laneSets', []);
       poolComponent.laneSet = null;


### PR DESCRIPTION
Fixes #178.

When a pool with lanes was deleted, the BPMN definitions weren't properly updated to reflect the new state, causing bugs; this PR fixes that. 

To test:
* Add a pool, add lanes to the pool, then delete the pool.
* Add another pool and ensure you can repeat the above without errors.