### PR TITLE
Allow undo/redo of text annotation

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -69,6 +69,7 @@ import { Drop } from 'vue-drag-drop';
 import { id as poolId } from './nodes/pool';
 import { id as laneId } from './nodes/poolLane';
 import { id as sequenceFlowId } from './nodes/sequenceFlow';
+import { id as associationId } from './nodes/association';
 
 const version = '1.0';
 
@@ -444,7 +445,7 @@ export default {
         pool: this.poolTarget,
       });
 
-      if (![sequenceFlowId, laneId].includes(type)) {
+      if (![sequenceFlowId, laneId, associationId].includes(type)) {
         setTimeout(() => this.pushToUndoStack());
       }
 

--- a/src/components/nodes/association/association.vue
+++ b/src/components/nodes/association/association.vue
@@ -6,74 +6,18 @@
 <script>
 import joint from 'jointjs';
 import crownConfig from '@/mixins/crownConfig';
+import linkConfig from '@/mixins/linkConfig';
 import get from 'lodash/get';
-import debounce from 'lodash/debounce';
-import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
 
 export default {
   props: ['graph', 'node', 'id', 'moddle', 'nodeRegistry'],
-  mixins: [crownConfig],
+  mixins: [crownConfig, linkConfig],
   data() {
     return {
       shape: null,
-      definition: null,
-      sourceShape: null,
-      target: null,
-      anchorPadding: 25,
     };
   },
   computed: {
-    sourceNode() {
-      return get(this.sourceShape, 'component.node');
-    },
-    targetNode() {
-      return get(this.target, 'component.node');
-    },
-    sourceConfig() {
-      return this.sourceNode && this.nodeRegistry[this.sourceNode.type];
-    },
-    targetConfig() {
-      return this.targetNode && this.nodeRegistry[this.targetNode.type];
-    },
-    elementPadding() {
-      return this.shape && this.shape.source().id === this.shape.target().id ? 20 : 1;
-    },
-  },
-  methods: {
-    beforeLoadInspector(node) {
-      return node.definition && node.definition.targetRef && node.definition.targetRef.id;
-    },
-    setBodyColor(color, target = this.target) {
-      target.attr('body/fill', color);
-      target.attr('.body/fill', color);
-    },
-    updateDefinitionLinks() {
-      const targetShape = this.shape.getTargetElement();
-      this.node.definition.targetRef = targetShape.component.node.definition;
-    },
-    completeLink() {
-      this.shape.stopListening(this.paper, 'cell:mouseleave');
-      this.shape.stopListening(this.paper, 'blank:pointerclick link:pointerclick', this.removeLink);
-      this.$emit('set-cursor', null);
-
-      this.resetPaper();
-
-      this.updateWaypoints();
-
-      const targetShape = this.shape.getTargetElement();
-      this.setBodyColor(defaultNodeColor, targetShape);
-
-      this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
-      this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
-      this.$emit('set-cursor', 'grab');
-    },
-    updateWaypoints() {
-      const connections = this.shape.findView(this.paper).getConnection();
-      const points = connections.segments.map(segment => segment.end);
-
-      this.node.diagram.waypoint = points.map(point => this.moddle.create('dc:Point', point));
-      this.updateCrownPosition();
-    },
     isValidConnection() {
       const targetType = get(this.target, 'component.node.type');
 
@@ -101,83 +45,14 @@ export default {
 
       return true;
     },
+  },
+  methods: {
     updateRouter() {
       this.shape.router('normal', { elementPadding: this.elementPadding });
     },
-    updateLinkTarget({ clientX, clientY }) {
-      const localMousePosition = this.paper.clientToLocalPoint({ x: clientX, y: clientY });
-
-      /* Sort shapes by z-index descending; grab the shape on top (with the highest z-index) */
-      this.target = this.graph.findModelsFromPoint(localMousePosition).sort((shape1, shape2) => {
-        return shape2.get('z') - shape1.get('z');
-      })[0];
-
-      if (!this.isValidConnection()) {
-        this.$emit('set-cursor', 'not-allowed');
-        this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-
-        this.shape.target({
-          x: localMousePosition.x,
-          y: localMousePosition.y,
-        });
-
-        if (this.target) {
-          this.setBodyColor(invalidNodeColor);
-        }
-
-        return;
-      }
-
-      this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-
-      this.shape.target(this.target, {
-        anchor: {
-          name: this.target instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
-          args: { padding: this.anchorPadding },
-        },
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.updateRouter();
-
-      this.$emit('set-cursor', 'default');
-      this.setBodyColor(validNodeColor);
-
-      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
-      this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {
-        this.completeLink();
-        this.updateDefinitionLinks();
-      });
-
-      this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
-        this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
-        this.shape.stopListening(this.paper, 'cell:pointerclick');
-        this.setBodyColor(defaultNodeColor);
-        this.$emit('set-cursor', 'not-allowed');
-      });
-    },
-    removeLink() {
-      this.removeShape();
-      this.resetPaper();
-    },
-    resetPaper() {
-      this.$emit('set-cursor', null);
-      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
-      this.paper.setInteractivity(this.graph.get('interactiveFunc'));
-
-      if (this.target) {
-        this.setBodyColor(defaultNodeColor);
-      }
-    },
-  },
-  created() {
-    this.updateWaypoints = debounce(this.updateWaypoints, 100);
-  },
-  watch: {
-    target(target, previousTarget) {
-      if (previousTarget && previousTarget !== target) {
-        this.setBodyColor(defaultNodeColor, previousTarget);
-      }
+    updateDefinitionLinks() {
+      const targetShape = this.shape.getTargetElement();
+      this.node.definition.targetRef = targetShape.component.node.definition;
     },
   },
   mounted() {
@@ -197,52 +72,6 @@ export default {
         },
       },
     });
-
-    this.sourceShape = this.graph.getElements().find(element => {
-      return element.component && element.component.node.definition === this.node.definition.get('sourceRef');
-    });
-
-    this.shape.source(this.sourceShape, {
-      anchor: { name: 'modelCenter' },
-      connectionPoint: { name: 'boundary' },
-    });
-
-    this.sourceShape.embed(this.shape);
-
-    this.shape.addTo(this.graph);
-    this.shape.component = this;
-
-    const targetRef = this.node.definition.get('targetRef');
-
-    if (targetRef.id) {
-      const targetShape = this.graph.getElements().find(element => {
-        return element.component && element.component.node.definition === targetRef;
-      });
-
-      this.shape.target(targetShape, {
-        anchor: {
-          name: targetShape instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
-          args: { padding: this.anchorPadding },
-        },
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.completeLink();
-    } else {
-      this.shape.target(targetRef, {
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.paper.setInteractivity(false);
-      this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
-
-      this.$emit('set-cursor', 'not-allowed');
-    }
-
-    this.updateRouter();
-  },
-  destroyed() {
-    this.updateWaypoints.cancel();
   },
 };
 </script>

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -1,7 +1,9 @@
 import component from './association.vue';
 
+export const id  = 'processmaker-modeler-association';
+
 export default {
-  id: 'processmaker-modeler-association',
+  id,
   component,
   bpmnType: 'bpmn:Association',
   control: false,

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -6,41 +6,19 @@
 <script>
 import joint from 'jointjs';
 import crownConfig from '@/mixins/crownConfig';
+import linkConfig from '@/mixins/linkConfig';
 import get from 'lodash/get';
-import debounce from 'lodash/debounce';
-import pull from 'lodash/pull';
-import data from './index';
-import { gatewayDirectionOptions } from '../exclusiveGateway/index';
-import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
 import { id as laneId } from '../poolLane';
 
 export default {
   props: ['graph', 'node', 'id', 'moddle', 'nodeRegistry'],
-  mixins: [crownConfig],
+  mixins: [crownConfig, linkConfig],
   data() {
     return {
       shape: null,
-      definition: null,
-      sourceShape: null,
-      target: null,
     };
   },
   computed: {
-    sourceNode() {
-      return get(this.sourceShape, 'component.node');
-    },
-    targetNode() {
-      return get(this.target, 'component.node');
-    },
-    sourceConfig() {
-      return this.sourceNode && this.nodeRegistry[this.sourceNode.type];
-    },
-    targetConfig() {
-      return this.targetNode && this.nodeRegistry[this.targetNode.type];
-    },
-    elementPadding() {
-      return this.shape && this.shape.source().id === this.shape.target().id ? 20 : 1;
-    },
     isValidConnection() {
       const targetType = get(this.target, 'component.node.type');
 
@@ -75,9 +53,8 @@ export default {
     },
   },
   methods: {
-    setBodyColor(color, target = this.target) {
-      target.attr('body/fill', color);
-      target.attr('.body/fill', color);
+    updateRouter() {
+      this.shape.router('orthogonal');
     },
     updateDefinitionLinks() {
       const targetShape = this.shape.getTargetElement();
@@ -85,128 +62,6 @@ export default {
       this.node.definition.targetRef = targetShape.component.node.definition;
       this.sourceShape.component.node.definition.get('outgoing').push(this.node.definition);
       targetShape.component.node.definition.get('incoming').push(this.node.definition);
-
-    },
-    completeLink() {
-      this.inspectorConfigItems = data.inspectorConfig[0].items;
-      this.shape.stopListening(this.paper, 'cell:mouseleave');
-      this.$emit('set-cursor', null);
-
-      this.resetPaper();
-
-      this.updateWaypoints();
-
-      const targetShape = this.shape.getTargetElement();
-      this.setBodyColor(defaultNodeColor, targetShape);
-
-      this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
-      this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
-    },
-    isValidGatewayConnection() {
-      const definition = this.target.component.node.definition;
-      const gatewayDirection = definition.get('gatewayDirection');
-      const incomingFlowCount = definition.get('incoming').length;
-
-      if (gatewayDirection == gatewayDirectionOptions.Converging) {
-        return true;
-      }
-
-      // Exclusive gateway can only recieve one incoming link
-      if (incomingFlowCount === 0) {
-        return true;
-      }
-
-      return false;
-    },
-    updateWaypoints() {
-      const connections = this.shape.findView(this.paper).getConnection();
-      const points = connections.segments.map(segment => segment.end);
-
-      this.node.diagram.waypoint = points.map(point => this.moddle.create('dc:Point', point));
-      this.updateCrownPosition();
-    },
-    updateRouter() {
-      this.shape.router('orthogonal');
-    },
-    updateLinkTarget({ clientX, clientY }) {
-      const localMousePosition = this.paper.clientToLocalPoint({ x: clientX, y: clientY });
-
-      /* Sort shapes by z-index descending; grab the shape on top (with the highest z-index) */
-      this.target = this.graph.findModelsFromPoint(localMousePosition).sort((shape1, shape2) => {
-        return shape2.get('z') - shape1.get('z');
-      })[0];
-
-      if (!this.isValidConnection) {
-        this.$emit('set-cursor', 'not-allowed');
-
-        this.shape.target({
-          x: localMousePosition.x,
-          y: localMousePosition.y,
-        });
-
-        if (this.target) {
-          this.setBodyColor(invalidNodeColor);
-        }
-
-        return;
-      }
-
-      this.shape.target(this.target, {
-        anchor: {
-          name: this.target instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
-          args: { padding: this.anchorPadding },
-        },
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.updateRouter();
-
-      this.$emit('set-cursor', 'default');
-      this.setBodyColor(validNodeColor);
-
-      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
-      this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {
-        this.completeLink();
-        this.updateDefinitionLinks();
-        this.$emit('save-state');
-      });
-
-      this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
-        this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
-        this.shape.stopListening(this.paper, 'cell:pointerclick');
-        this.setBodyColor(defaultNodeColor);
-        this.$emit('set-cursor', 'not-allowed');
-      });
-    },
-    removeLink() {
-      this.resetPaper();
-      this.$emit('remove-node', this.node);
-    },
-    resetPaper() {
-      this.$emit('set-cursor', null);
-      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
-      this.paper.setInteractivity(this.graph.get('interactiveFunc'));
-
-      if (this.target) {
-        this.setBodyColor(defaultNodeColor);
-      }
-    },
-  },
-  created() {
-    this.updateWaypoints = debounce(this.updateWaypoints, 100);
-  },
-  watch: {
-    target(target, previousTarget) {
-      if (previousTarget && previousTarget !== target) {
-        this.setBodyColor(defaultNodeColor, previousTarget);
-      }
-    },
-    isValidConnection(isValid) {
-      if (isValid) {
-        this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-      } else {
-        this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-      }
     },
   },
   mounted() {
@@ -215,71 +70,6 @@ export default {
         name: 'orthogonal',
       },
     });
-
-    this.sourceShape = this.graph.getElements().find(element => {
-      return element.component && element.component.node.definition === this.node.definition.get('sourceRef');
-    });
-
-    this.shape.source(this.sourceShape, {
-      anchor: { name: 'modelCenter' },
-      connectionPoint: { name: 'boundary' },
-    });
-
-    this.sourceShape.embed(this.shape);
-
-    this.shape.addTo(this.graph);
-    this.shape.component = this;
-
-    const targetRef = this.node.definition.get('targetRef');
-
-    if (targetRef.id) {
-      const targetShape = this.graph.getElements().find(element => {
-        return element.component && element.component.node.definition === targetRef;
-      });
-
-      this.shape.target(targetShape, {
-        anchor: {
-          name: targetShape instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
-          args: { padding: this.anchorPadding },
-        },
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.completeLink();
-    } else {
-      this.shape.target(targetRef, {
-        connectionPoint: { name: 'boundary' },
-      });
-
-      this.paper.setInteractivity(false);
-      this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
-
-      this.$emit('set-cursor', 'not-allowed');
-
-      if (this.isValidConnection) {
-        this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-      } else {
-        this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
-      }
-    }
-
-    this.updateRouter();
-  },
-  destroyed() {
-    /* Modify source and target refs to remove incoming and outgoing properties pointing to this link */
-    const { sourceRef, targetRef } = this.node.definition;
-    if (sourceRef) {
-      pull(sourceRef.get('outgoing'), this.node.definition);
-    }
-
-    /* If targetRef is defined, it could be a point or another element.
-     * If targetRef has an id, that means it's an element and the reference to it
-     * can be safely removed. */
-    if (targetRef.id) {
-      pull(targetRef.get('incoming'), this.node.definition);
-    }
-
-    this.updateWaypoints.cancel();
   },
 };
 </script>

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -1,6 +1,5 @@
 import joint from 'jointjs';
 import trashIcon from '@/assets/trash-alt-solid.svg';
-import store from '@/store';
 import pull from 'lodash/pull';
 
 export const highlightPadding = 3;
@@ -82,6 +81,7 @@ export default {
       });
     },
     addAssociation(cellView, evt, x, y) {
+      this.removeCrown();
       const associationLink = this.moddle.create('bpmn:Association', {
         sourceRef: this.shape.component.node.definition,
         targetRef: { x, y },
@@ -128,7 +128,6 @@ export default {
 
         this.shape.embed(button);
         button.addTo(this.graph);
-        this.updateCrownPosition();
       });
 
       this.shape.listenTo(this.paper, 'cell:mouseenter', cellView => {
@@ -203,14 +202,15 @@ export default {
       }
     },
     setNodePosition() {
-      if (!this.allowSetNodePosition) {
+      const { x, y } = this.shape.getBBox();
+      const { x: nodeX, y: nodeY } = this.node.diagram.bounds;
+
+      if (!this.allowSetNodePosition || (x === nodeX && y === nodeY)) {
         return;
       }
 
-      store.commit('updateNodeBounds', {
-        node: this.node,
-        bounds: this.shape.getBBox(),
-      });
+      this.node.diagram.bounds.set('x', x);
+      this.node.diagram.bounds.set('y', y);
 
       this.$emit('save-state');
     },

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -1,0 +1,209 @@
+import joint from 'jointjs';
+import pull from 'lodash/pull';
+import get from 'lodash/get';
+import debounce from 'lodash/debounce';
+import { validNodeColor, invalidNodeColor, defaultNodeColor } from '@/components/nodeColors';
+
+export default {
+  data() {
+    return {
+      sourceShape: null,
+      target: null,
+      anchorPadding: 25,
+    };
+  },
+  watch: {
+    target(target, previousTarget) {
+      if (previousTarget && previousTarget !== target) {
+        this.setBodyColor(defaultNodeColor, previousTarget);
+      }
+    },
+    isValidConnection(isValid) {
+      if (isValid) {
+        this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
+      } else {
+        this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
+      }
+    },
+  },
+  computed: {
+    sourceNode() {
+      return get(this.sourceShape, 'component.node');
+    },
+    targetNode() {
+      return get(this.target, 'component.node');
+    },
+    sourceConfig() {
+      return this.sourceNode && this.nodeRegistry[this.sourceNode.type];
+    },
+    targetConfig() {
+      return this.targetNode && this.nodeRegistry[this.targetNode.type];
+    },
+    elementPadding() {
+      return this.shape && this.shape.source().id === this.shape.target().id ? 20 : 1;
+    },
+  },
+  methods: {
+    setBodyColor(color, target = this.target) {
+      target.attr('body/fill', color);
+      target.attr('.body/fill', color);
+    },
+    completeLink() {
+      this.shape.stopListening(this.paper, 'cell:mouseleave');
+      this.$emit('set-cursor', null);
+
+      this.resetPaper();
+
+      this.updateWaypoints();
+
+      const targetShape = this.shape.getTargetElement();
+      this.setBodyColor(defaultNodeColor, targetShape);
+
+      this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
+      this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
+    },
+    updateWaypoints() {
+      const connections = this.shape.findView(this.paper).getConnection();
+      const points = connections.segments.map(segment => segment.end);
+
+      this.node.diagram.waypoint = points.map(point => this.moddle.create('dc:Point', point));
+      this.updateCrownPosition();
+    },
+    updateLinkTarget({ clientX, clientY }) {
+      const localMousePosition = this.paper.clientToLocalPoint({ x: clientX, y: clientY });
+
+      /* Sort shapes by z-index descending; grab the shape on top (with the highest z-index) */
+      this.target = this.graph.findModelsFromPoint(localMousePosition).sort((shape1, shape2) => {
+        return shape2.get('z') - shape1.get('z');
+      })[0];
+
+      if (!this.isValidConnection) {
+        this.$emit('set-cursor', 'not-allowed');
+
+        this.shape.target({
+          x: localMousePosition.x,
+          y: localMousePosition.y,
+        });
+
+        if (this.target) {
+          this.setBodyColor(invalidNodeColor);
+        }
+
+        return;
+      }
+
+      this.shape.target(this.target, {
+        anchor: {
+          name: this.target instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
+          args: { padding: this.anchorPadding },
+        },
+        connectionPoint: { name: 'boundary' },
+      });
+
+      this.updateRouter();
+
+      this.$emit('set-cursor', 'default');
+      this.setBodyColor(validNodeColor);
+
+      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
+      this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {
+        this.completeLink();
+        this.updateDefinitionLinks();
+        this.$emit('save-state');
+      });
+
+      this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
+        this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
+        this.shape.stopListening(this.paper, 'cell:pointerclick');
+        this.setBodyColor(defaultNodeColor);
+        this.$emit('set-cursor', 'not-allowed');
+      });
+    },
+    removeLink() {
+      this.$emit('remove-node', this.node);
+      this.resetPaper();
+    },
+    resetPaper() {
+      this.$emit('set-cursor', null);
+      this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
+      this.paper.setInteractivity(this.graph.get('interactiveFunc'));
+
+      if (this.target) {
+        this.setBodyColor(defaultNodeColor);
+      }
+    },
+  },
+  created() {
+    this.updateWaypoints = debounce(this.updateWaypoints, 100);
+  },
+  async mounted() {
+    await this.$nextTick();
+    /* Use nextTick to ensure this code runs after the component it is mixed into mounts.
+     * This will ensure this.shape is defined. */
+
+    this.sourceShape = this.graph.getElements().find(element => {
+      return element.component && element.component.node.definition === this.node.definition.get('sourceRef');
+    });
+
+    this.shape.source(this.sourceShape, {
+      anchor: { name: 'modelCenter' },
+      connectionPoint: { name: 'boundary' },
+    });
+
+    this.sourceShape.embed(this.shape);
+
+    this.shape.addTo(this.graph);
+    this.shape.component = this;
+
+    const targetRef = this.node.definition.get('targetRef');
+
+    if (targetRef.id) {
+      const targetShape = this.graph.getElements().find(element => {
+        return element.component && element.component.node.definition === targetRef;
+      });
+
+      this.shape.target(targetShape, {
+        anchor: {
+          name: targetShape instanceof joint.shapes.standard.Rectangle ? 'perpendicular' : 'modelCenter',
+          args: { padding: this.anchorPadding },
+        },
+        connectionPoint: { name: 'boundary' },
+      });
+
+      this.completeLink();
+    } else {
+      this.shape.target(targetRef, {
+        connectionPoint: { name: 'boundary' },
+      });
+
+      this.paper.setInteractivity(false);
+      this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
+
+      this.$emit('set-cursor', 'not-allowed');
+
+      if (this.isValidConnection) {
+        this.shape.stopListening(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
+      } else {
+        this.shape.listenToOnce(this.paper, 'blank:pointerdown link:pointerdown element:pointerdown', this.removeLink);
+      }
+    }
+
+    this.updateRouter();
+  },
+  destroyed() {
+    /* Modify source and target refs to remove incoming and outgoing properties pointing to this link */
+    const { sourceRef, targetRef } = this.node.definition;
+    if (sourceRef) {
+      pull(sourceRef.get('outgoing'), this.node.definition);
+    }
+
+    /* If targetRef is defined, it could be a point or another element.
+     * If targetRef has an id, that means it's an element and the reference to it
+     * can be safely removed. */
+    if (targetRef.id) {
+      pull(targetRef.get('incoming'), this.node.definition);
+    }
+
+    this.updateWaypoints.cancel();
+  },
+};


### PR DESCRIPTION
Fixes #165.

**To test:**
 * Add a text annotation and delete it.
* Undo the delete.

**Important changes:**
The sequence flow and association flow components shared a lot of logic which has now been moved to the linkConfig.js mixin.