### PR TITLE
Fix z-index with sequence flows

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -364,6 +364,7 @@ export default {
           this.shape.embed(component.shape);
           component.shape.toFront({ deep: true });
           component.node.pool = this.shape;
+          component.node.pool.toBack();
         });
 
       this.resizePool();

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -107,6 +107,7 @@ export default {
       }
 
       this.$emit('add-node', {
+        id: 'sequence-flow-button',
         type: 'processmaker-modeler-sequence-flow',
         definition: sequenceLink,
         diagram: this.moddle.create('bpmndi:BPMNEdge'),

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -107,7 +107,6 @@ export default {
       }
 
       this.$emit('add-node', {
-        id: 'sequence-flow-button',
         type: 'processmaker-modeler-sequence-flow',
         definition: sequenceLink,
         diagram: this.moddle.create('bpmndi:BPMNEdge'),

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -1,7 +1,7 @@
 import {
   dragFromSourceToDest,
   getElementAtPosition,
-  connectNodesWithMessageFlow,
+  connectNodesWithFlow,
   getLinksConnectedToElement,
 } from '../support/utils';
 
@@ -17,7 +17,7 @@ describe('Message Flows', () => {
     const pool2Position = { x: 250, y: 500 };
     dragFromSourceToDest('processmaker-modeler-pool', '.paper-container', pool2Position);
 
-    connectNodesWithMessageFlow(pool1Position, pool2Position);
+    connectNodesWithFlow('message-flow-button', pool1Position, pool2Position);
 
     const numberOfMessageFlowsAdded = 1;
     getElementAtPosition(pool2Position)
@@ -39,7 +39,7 @@ describe('Message Flows', () => {
     dragFromSourceToDest('processmaker-modeler-task', '.paper-container', taskPosition);
 
     const startEventPosition = { x: 150, y: 150 };
-    connectNodesWithMessageFlow(startEventPosition, taskPosition);
+    connectNodesWithFlow('message-flow-button', startEventPosition, taskPosition);
 
     const numberOfMessageFlowsAdded = 1;
     getElementAtPosition(taskPosition)

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -1,23 +1,9 @@
 import {
   dragFromSourceToDest,
   getElementAtPosition,
-  getCrownButtonForElement,
+  connectNodesWithMessageFlow,
   getLinksConnectedToElement,
 } from '../support/utils';
-
-function connectNodesWithMessageFlow(startPosition, endPosition) {
-  getElementAtPosition(startPosition)
-    .click()
-    .then($element => {
-      getCrownButtonForElement($element, 'message-flow-button')
-        .click();
-    })
-    .then(() => {
-      getElementAtPosition(endPosition)
-        .trigger('mousemove')
-        .click();
-    });
-}
 
 describe('Message Flows', () => {
   beforeEach(() => {

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -26,4 +26,24 @@ describe('Sequence Flows', () => {
         expect($links.length).to.eq(numberOfSequenceFlowsAdded);
       });
   });
+
+  it('Have the highest z-index', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    const taskPosition = { x: 250, y: 250 };
+    const poolPosition = { x: 150, y: 150 };
+
+    dragFromSourceToDest('processmaker-modeler-task', '.paper-container', taskPosition);
+
+    connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
+
+    dragFromSourceToDest('processmaker-modeler-pool', '.paper-container', poolPosition);
+
+    // getLastCell - will get the highest cell (element or link) with the highest z property
+    cy.window().its('store.state.graph')
+      .invoke('getLastCell').
+      then(cell => {
+        const sequenceFlow = 'processmaker-modeler-sequence-flow';
+        expect(cell.component.node.type).to.eq(sequenceFlow);
+      });
+  });
 });

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -1,6 +1,8 @@
 import {
   dragFromSourceToDest,
   connectNodesWithFlow,
+  getElementAtPosition,
+  getLinksConnectedToElement,
 } from '../support/utils';
 
 describe('Sequence Flows', () => {
@@ -15,5 +17,13 @@ describe('Sequence Flows', () => {
     dragFromSourceToDest('processmaker-modeler-task', '.paper-container', taskPosition);
 
     connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
+
+    const numberOfSequenceFlowsAdded = 1;
+
+    getElementAtPosition(taskPosition)
+      .then(getLinksConnectedToElement)
+      .should($links => {
+        expect($links.length).to.eq(numberOfSequenceFlowsAdded);
+      });
   });
 });

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -9,4 +9,11 @@ describe('Sequence Flows', () => {
   beforeEach(() => {
     cy.loadModeler();
   });
+
+  it('Can connect two elements', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    const taskPosition = { x: 250, y: 250 };
+
+    dragFromSourceToDest('processmaker-modeler-tast', '.paper-container', taskPosition);
+  });
 });

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -1,0 +1,12 @@
+import {
+  dragFromSourceToDest,
+  getElementAtPosition,
+  getCrownButtonForElement,
+  getLinksConnectedToElement,
+} from '../support/utils';
+
+describe('Sequence Flows', () => {
+  beforeEach(() => {
+    cy.loadModeler();
+  });
+});

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -1,8 +1,6 @@
 import {
   dragFromSourceToDest,
-  getElementAtPosition,
-  getCrownButtonForElement,
-  getLinksConnectedToElement,
+  connectNodesWithFlow,
 } from '../support/utils';
 
 describe('Sequence Flows', () => {
@@ -14,6 +12,8 @@ describe('Sequence Flows', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest('processmaker-modeler-tast', '.paper-container', taskPosition);
+    dragFromSourceToDest('processmaker-modeler-task', '.paper-container', taskPosition);
+
+    connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
   });
 });

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -57,11 +57,11 @@ export function waitToRenderAllShapes() {
   cy.wait(100);
 }
 
-export function connectNodesWithMessageFlow(startPosition, endPosition) {
+export function connectNodesWithFlow(flowType,startPosition, endPosition,) {
   getElementAtPosition(startPosition)
     .click()
     .then($element => {
-      getCrownButtonForElement($element, 'message-flow-button')
+      getCrownButtonForElement($element, flowType)
         .click();
     })
     .then(() => {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -56,3 +56,17 @@ export function getCrownButtonForElement($element, crownButton) {
 export function waitToRenderAllShapes() {
   cy.wait(100);
 }
+
+export function connectNodesWithMessageFlow(startPosition, endPosition) {
+  getElementAtPosition(startPosition)
+    .click()
+    .then($element => {
+      getCrownButtonForElement($element, 'message-flow-button')
+        .click();
+    })
+    .then(() => {
+      getElementAtPosition(endPosition)
+        .trigger('mousemove')
+        .click();
+    });
+}


### PR DESCRIPTION
**Bug**
When dragging a pool onto the paper, the sequences flows are hidden behind the pool.

1. Drag any element
2. Connect Start Event to element to create a `sequence flow`
3. Drag a pool

![sequence-flow](https://user-images.githubusercontent.com/26545455/53026702-68ee4b80-3431-11e9-8c92-d47bfcc4856a.gif)

**Fix**

![sequence-flow-fix](https://user-images.githubusercontent.com/26545455/53026888-d7330e00-3431-11e9-8738-752f475d09d2.gif)






Fixes #231 