### PR TITLE
Change helper text of condition expression

### DIFF
--- a/src/components/inspectors/sequenceExpression.js
+++ b/src/components/inspectors/sequenceExpression.js
@@ -29,7 +29,7 @@ export default [
         component: 'FormInput',
         config: {
           label: 'Expression',
-          helper: 'The Name of Expression',
+          helper: 'Enter the expression that describes the workflow condition',
           name: 'conditionExpression.body',
         },
       },


### PR DESCRIPTION
Replace helper text of the condition express on inspector panel to 
`Enter the expression that describes the workflow condition`

<img width="319" alt="screen shot 2019-02-19 at 2 05 25 pm" src="https://user-images.githubusercontent.com/26545455/53040475-76b2c980-344f-11e9-8bd3-1c53c74ef9dc.png">

Fixes #233 
