### PR TITLE
Fix startTimerEvent definition to update name

### DIFF
--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -10,16 +10,17 @@ export default {
   icon: require('@/assets/toolpanel/start-timer-event.svg'),
   label: 'Start Timer Event',
   definition(moddle) {
-    return moddle.create('bpmn:StartEvent', {
+    let startEventDefinition = moddle.create('bpmn:StartEvent', {
       name: 'Start Timer Event',
-      eventDefinitions: [
-        moddle.create('bpmn:TimerEventDefinition', {
-          timeCycle: moddle.create('bpmn:Expression', {
-            body: '',
-          }),
-        }),
-      ],
     });
+
+    startEventDefinition.eventDefinitions = moddle.create('bpmn:TimerEventDefinition', {
+      timeCycle: moddle.create('bpmn:Expression', {
+        body: '',
+      }),
+    });
+
+    return startEventDefinition;
   },
   diagram(moddle) {
     return moddle.create('bpmndi:BPMNShape', {


### PR DESCRIPTION
Fix start timer event definition to update name attribute.

![start-timer-event-fix](https://user-images.githubusercontent.com/26545455/53118125-73d0db00-351a-11e9-8f42-ca9ed328a644.gif)


Fixes #238 