### PR TITLE
Fix bug with node inspector updates

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -117,10 +117,23 @@ export default {
     processNodeInspectorHandler(value) {
       return this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']));
     },
-    setNodeProp: debounce(function(node, key, value) {
+    setNodeProp(node, key, value) {
       store.commit('updateNodeProp', { node, key, value });
       this.$emit('save-state');
-    }, saveDebounce),
+    },
+    debounceIfSameKey(func) {
+      const debouncedFunction = debounce(func, saveDebounce);
+      let lastKey;
+
+      return (node, key, value) => {
+        if (key !== lastKey) {
+          debouncedFunction.flush();
+        }
+
+        lastKey = key;
+        debouncedFunction(node, key, value);
+      };
+    },
     defaultInspectorHandler(value) {
       /* Go through each property and rebind it to our data */
       for (const key in omit(value, ['$type', 'eventDefinitions'])) {
@@ -129,6 +142,9 @@ export default {
         }
       }
     },
+  },
+  created() {
+    this.setNodeProp = this.debounceIfSameKey(this.setNodeProp);
   },
 };
 </script>

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -83,9 +83,12 @@ export default {
         return value => this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']), this.processNode, this.setNodeProp);
       }
 
-      return this.nodeRegistry[this.highlightedNode.type].inspectorHandler
+      return this.hasCustomInspectorHandler
         ? value => this.nodeRegistry[this.highlightedNode.type].inspectorHandler(value, this.highlightedNode, this.setNodeProp, this.moddle)
         : value => this.defaultInspectorHandler(value, this.highlightedNode, this.setNodeProp);
+    },
+    hasCustomInspectorHandler() {
+      return this.nodeRegistry[this.highlightedNode.type].inspectorHandler;
     },
     isProcessNodeActive() {
       return this.highlightedNode === this.processNode;

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -80,7 +80,7 @@ export default {
       }
 
       if (this.isProcessNodeActive) {
-        return value => this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']), this.processNode, this.setNodeProp);
+        return this.processNodeInspectorHandler;
       }
 
       return this.hasCustomInspectorHandler
@@ -109,6 +109,9 @@ export default {
     },
   },
   methods: {
+    processNodeInspectorHandler(value) {
+      return this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']), this.processNode, this.setNodeProp)
+    },
     setNodeProp: debounce(function(node, key, value) {
       store.commit('updateNodeProp', { node, key, value });
       this.$emit('save-state');

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -76,13 +76,16 @@ export default {
         return noop;
       }
 
-      if (this.highlightedNode === this.processNode) {
+      if (this.isProcessNodeActive) {
         return value => this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']), this.processNode, this.setNodeProp);
       }
 
       return this.nodeRegistry[this.highlightedNode.type].inspectorHandler
         ? value => this.nodeRegistry[this.highlightedNode.type].inspectorHandler(value, this.highlightedNode, this.setNodeProp, this.moddle)
         : value => this.defaultInspectorHandler(value, this.highlightedNode, this.setNodeProp);
+    },
+    isProcessNodeActive() {
+      return this.highlightedNode === this.processNode;
     },
     data() {
       if (!this.highlightedNode) {

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -115,7 +115,7 @@ export default {
       return this.nodeRegistry[this.highlightedNode.type].inspectorHandler(value, this.highlightedNode, this.setNodeProp, this.moddle);
     },
     processNodeInspectorHandler(value) {
-      return this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']))
+      return this.defaultInspectorHandler(omit(value, ['artifacts', 'flowElements', 'laneSets']));
     },
     setNodeProp: debounce(function(node, key, value) {
       store.commit('updateNodeProp', { node, key, value });

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -71,8 +71,11 @@ export default {
 
       return this.nodeRegistry[type].inspectorConfig;
     },
+    isAnyNodeActive() {
+      return this.highlightedNode;
+    },
     updateDefinition() {
-      if (!this.highlightedNode) {
+      if (!this.isAnyNodeActive) {
         return noop;
       }
 

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -20,13 +20,14 @@ import {
   FormRadioButtonGroup,
   FormCodeEditor,
 } from '@processmaker/vue-form-elements';
-import store, { saveDebounce } from '@/store';
+import store from '@/store';
 import { id as sequenceFlowId } from '@/components/nodes/sequenceFlow';
 import noop from 'lodash/noop';
 import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 import processInspectorConfig from './process';
 import sequenceExpressionInspectorConfig from './sequenceExpression';
+import { saveDebounce } from './inspectorConstants';
 
 Vue.component('FormText', renderer.FormText);
 Vue.component('FormInput', FormInput);

--- a/src/components/inspectors/inspectorConstants.js
+++ b/src/components/inspectors/inspectorConstants.js
@@ -1,0 +1,1 @@
+export const saveDebounce = 300;

--- a/src/setup/extensions/testTaskInspectorExtension.js
+++ b/src/setup/extensions/testTaskInspectorExtension.js
@@ -25,6 +25,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerInspectorExtension }
       helper: 'Assign user to task',
       name: 'assignedUsers',
       options: [
+        {},
         { value: 'John Smith', content: 'John Smith' },
         { value: 'Jane Smith', content: 'Jane Smith' },
       ],

--- a/src/store.js
+++ b/src/store.js
@@ -4,8 +4,6 @@ import uniqueId from 'lodash/uniqueId';
 
 Vue.use(Vuex);
 
-export const saveDebounce = 300;
-
 export default new Vuex.Store({
   state: {
     graph: null,

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -45,6 +45,7 @@ describe('Modeler', () => {
       '.paper-container',
       taskPosition,
     );
+    waitToRenderAllShapes();
 
     const startEventPosition = { x: 150, y: 150 };
     connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
@@ -56,6 +57,7 @@ describe('Modeler', () => {
       '.paper-container',
       task2Position,
     );
+    waitToRenderAllShapes();
     connectNodesWithFlow('sequence-flow-button', taskPosition, task2Position);
 
     const task3Position = { x: 100, y: 350 };
@@ -64,6 +66,7 @@ describe('Modeler', () => {
       '.paper-container',
       task3Position,
     );
+    waitToRenderAllShapes();
     connectNodesWithFlow('sequence-flow-button', task2Position, task3Position);
 
     const endEventPosition = { x: 100, y: 500 };
@@ -72,6 +75,7 @@ describe('Modeler', () => {
       '.paper-container',
       endEventPosition,
     );
+    waitToRenderAllShapes();
     connectNodesWithFlow('sequence-flow-button', task3Position, endEventPosition);
 
     dragFromSourceToDest(

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -8,6 +8,7 @@ import {
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
+import { saveDebounce } from '../../../src/components/inspectors/inspectorConstants';
 
 describe('Undo/redo', () => {
   beforeEach(() => {
@@ -211,5 +212,22 @@ describe('Undo/redo', () => {
     getElementAtPosition(startEventPosition).click();
     typeIntoTextInput('[name=name]', testString);
     cy.get('[name=name]').should('have.value', testString);
+  });
+
+  it('Can update two properties at the same time', () => {
+    const startEventPosition = { x: 150, y: 150 };
+
+    waitToRenderAllShapes();
+    getElementAtPosition(startEventPosition).click();
+
+    const newId = '1234';
+    const newName = 'foobar';
+    cy.get('[name=id]').clear().type(newId);
+    cy.get('[name=name]').clear().type(newName);
+
+    cy.wait(saveDebounce);
+
+    cy.get('[name=id]').should('have.value', newId);
+    cy.get('[name=name]').should('have.value', newName);
   });
 });

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -14,7 +14,7 @@ describe('Undo/redo', () => {
     cy.loadModeler();
   });
 
-  xit('Can undo and redo sequence flow condition expression', () => {
+  it('Can undo and redo sequence flow condition expression', () => {
     const exclusiveGatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest('processmaker-modeler-exclusive-gateway', '.paper-container', exclusiveGatewayPosition);
 
@@ -28,27 +28,26 @@ describe('Undo/redo', () => {
       .then($links => $links[0])
       .click({ force: true });
 
+    const defaultExpressionValue = '';
     const testString = 'foo > 7';
-    typeIntoTextInput('[name=conditionExpression.body]', testString);
 
-    cy.get('[name=conditionExpression.body]').should('have.value', testString);
-
-    waitToRenderAllShapes();
+    cy.get('[name="conditionExpression.body"]').should('have.value', defaultExpressionValue);
+    typeIntoTextInput('[name="conditionExpression.body"]', testString);
+    cy.get('[name="conditionExpression.body"]').should('have.value', testString);
 
     cy.get('[data-test=undo]').click();
+
+    waitToRenderAllShapes();
 
     getElementAtPosition(taskPosition)
       .then(getLinksConnectedToElement)
       .then($links => $links[0])
       .click({ force: true });
 
-    waitToRenderAllShapes();
+    cy.get('[name="conditionExpression.body"]').should('have.value', defaultExpressionValue);
 
-    const emptyString = '';
-    cy.get('[name=conditionExpression.body]').should('have.value', emptyString);
+    cy.get('[data-test=redo]').click();
 
-    waitToRenderAllShapes();
-    cy.get('[data-test=redo]').click({ force: true });
     waitToRenderAllShapes();
 
     getElementAtPosition(exclusiveGatewayPosition)
@@ -56,9 +55,7 @@ describe('Undo/redo', () => {
       .then($links => $links[0])
       .click({ force: true });
 
-    cy.wait(500);
-
-    cy.get('[name=conditionExpression.body]').should('have.value', testString);
+    cy.get('[name="conditionExpression.body"]').should('have.value', testString);
   });
 
   it('Can undo and redo adding a task', () => {

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -29,9 +29,9 @@ describe('Undo/redo', () => {
       .click({ force: true });
 
     const testString = 'foo > 7';
-    typeIntoTextInput('[name=\'conditionExpression.body\']', testString);
+    typeIntoTextInput('[name=conditionExpression.body]', testString);
 
-    cy.get('[name=\'conditionExpression.body\']').should('have.value', testString);
+    cy.get('[name=conditionExpression.body]').should('have.value', testString);
 
     waitToRenderAllShapes();
 
@@ -45,7 +45,7 @@ describe('Undo/redo', () => {
     waitToRenderAllShapes();
 
     const emptyString = '';
-    cy.get('[name=\'conditionExpression.body\']').should('have.value', emptyString);
+    cy.get('[name=conditionExpression.body]').should('have.value', emptyString);
 
     waitToRenderAllShapes();
     cy.get('[data-test=redo]').click({ force: true });
@@ -58,7 +58,7 @@ describe('Undo/redo', () => {
 
     cy.wait(500);
 
-    cy.get('[name=\'conditionExpression.body\']').should('have.value', testString);
+    cy.get('[name=conditionExpression.body]').should('have.value', testString);
   });
 
   it('Can undo and redo adding a task', () => {

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -201,4 +201,18 @@ describe('Undo/redo', () => {
       .its('xml')
       .then(xml => xml.trim()).should('eq', validMessageFlowXML.trim());
   });
+
+  it('Can update start event name after undo', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    const testString = 'foo bar';
+
+    waitToRenderAllShapes();
+    getElementAtPosition(startEventPosition)
+      .moveTo(startEventPosition.x + 50, startEventPosition.y + 50);
+    cy.get('[data-test=undo]').click();
+
+    getElementAtPosition(startEventPosition).click();
+    typeIntoTextInput('[name=name]', testString);
+    cy.get('[name=name]').should('have.value', testString);
+  });
 });

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -80,7 +80,7 @@ export function waitToRenderAllShapes() {
   cy.wait(100);
 }
 
-export function connectNodesWithFlow(flowType, startPosition, endPosition,) {
+export function connectNodesWithFlow(flowType, startPosition, endPosition) {
   getElementAtPosition(startPosition)
     .click()
     .then($element => {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -1,3 +1,5 @@
+import { saveDebounce } from '../../../src/components/inspectors/inspectorConstants';
+
 export function getGraphElements() {
   return cy.window()
     .its('store.state.graph')
@@ -54,11 +56,9 @@ export function getCrownButtonForElement($element, crownButton) {
 }
 
 export function typeIntoTextInput(selector, value) {
-  const timeToUpdateInspectorInput = 100;
-
-  cy.wait(timeToUpdateInspectorInput);
+  cy.wait(saveDebounce);
   cy.get(selector).focus().clear().type(value, { force: true });
-  cy.wait(timeToUpdateInspectorInput);
+  cy.wait(saveDebounce);
 }
 
 export const generateXML = (nodeName) => {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -56,8 +56,7 @@ export function getCrownButtonForElement($element, crownButton) {
 }
 
 export function typeIntoTextInput(selector, value) {
-  cy.wait(saveDebounce);
-  cy.get(selector).focus().clear().type(value, { force: true });
+  cy.get(selector).clear().type(value);
   cy.wait(saveDebounce);
 }
 


### PR DESCRIPTION
Fixes #255.

Visit the issue linked above and ensure you cannot reproduce the issue:
* Click on the start event, and change both its ID and name within 300 ms of each other (type into ID, hit tab and type name right away). Wait 300 ms and ensure neither of the two inputs get reset.