### PR TITLE
Create unique node ID generator

### DIFF
--- a/src/NodeIdGenerator.js
+++ b/src/NodeIdGenerator.js
@@ -1,0 +1,31 @@
+const nodeIdPrefix = 'node_';
+
+export default class NodeIdGenerator {
+  constructor(definitions) {
+    this.counter = 1;
+    this.definitions = definitions;
+  }
+
+  generateUniqueNodeId() {
+    let id = this.generateNewNodeId();
+
+    while (!this.isIdUnique(id)) {
+      id = this.generateNewNodeId();
+    }
+
+    return id;
+  }
+
+  generateNewNodeId() {
+    const id = nodeIdPrefix + this.counter;
+    this.counter++;
+
+    return id;
+  }
+
+  isIdUnique(id) {
+    const planeElements = this.definitions.diagrams[0].plane.get('planeElement');
+
+    return planeElements.every(planeElement => id !== planeElement.get('bpmnElement').id);
+  }
+}

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -63,7 +63,6 @@ import joint from 'jointjs';
 import BpmnModdle from 'bpmn-moddle';
 import controls from './controls';
 import { highlightPadding } from '@/mixins/crownConfig';
-import uniqueId from 'lodash/uniqueId';
 import pull from 'lodash/pull';
 import debounce from 'lodash/debounce';
 import { startEvent } from '@/components/nodes';
@@ -72,6 +71,7 @@ import InspectorPanel from '@/components/inspectors/InspectorPanel';
 import undoRedoStore from '@/undoRedoStore';
 import { Linter } from 'bpmnlint';
 import linterConfig from '../../.bpmnlintrc';
+import NodeIdGenerator from '../NodeIdGenerator';
 
 // Our renderer for our inspector
 import { Drop } from 'vue-drag-drop';
@@ -111,7 +111,7 @@ export default {
       paper: null,
 
       definitions: null,
-      context: null,
+      nodeIdGenerator: null,
       planeElements: null,
       canvasDragPosition: null,
       processNode: null,
@@ -406,14 +406,13 @@ export default {
       return hasSource && hasTarget;
     },
     loadXML(xml = this.currentXML) {
-      this.moddle.fromXML(xml, (err, definitions, context) => {
+      this.moddle.fromXML(xml, (err, definitions) => {
         if (!err) {
           // Update definitions export to our own information
           definitions.exporter = 'ProcessMaker Modeler';
           definitions.exporterVersion = version;
           this.definitions = definitions;
-          this.context = context;
-          this.initializeUniqueId(context);
+          this.nodeIdGenerator = new NodeIdGenerator(definitions);
 
           store.commit('clearNodes');
 
@@ -476,7 +475,7 @@ export default {
         }
       }
 
-      const id = uniqueId('node_');
+      const id = this.nodeIdGenerator.generateUniqueNodeId();
       definition.id = id;
 
       if (diagram) {
@@ -498,14 +497,6 @@ export default {
       }
 
       this.poolTarget = null;
-    },
-    initializeUniqueId(context) {
-      let last = uniqueId() * 1;
-      context.references.forEach((ref)=>{
-        const ma = ref.id.match(/^node_(\d+)$/),
-          index = ma && ma[1] * 1;
-        while (last < index) last = uniqueId() * 1;
-      });
     },
     removeNode(node) {
       store.commit('removeNode', node);

--- a/src/store.js
+++ b/src/store.js
@@ -1,6 +1,5 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import uniqueId from 'lodash/uniqueId';
 
 Vue.use(Vuex);
 
@@ -42,7 +41,7 @@ export default new Vuex.Store({
        * (used in v-for when rendering the node). Relying on the
        * definition ID will cause issues as the user can change the
        * ID of elements. */
-      node._modelerId = uniqueId();
+      node._modelerId = '_modelerId_' + node.definition.get('id');
 
       state.nodes.push(node);
     },

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -2,7 +2,6 @@ import {
   dragFromSourceToDest,
   getGraphElements,
   waitToRenderAllShapes,
-  generateXML,
   connectNodesWithFlow,
   getElementAtPosition,
   typeIntoTextInput,
@@ -77,16 +76,34 @@ describe('Modeler', () => {
   });
 
   it('Updates element name and validates xml', () => {
-    const testString = 'testing';
+    waitToRenderAllShapes();
 
-    cy.get('.modeler').children().should('have.length', 2);
-    cy.get('.joint-viewport').click();
-    cy.get('[name=\'name\']').focus().clear().type(testString);
-    cy.get('.joint-viewport').contains(testString);
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition).click();
+
+    const testString = 'testing';
+    typeIntoTextInput('[name=name]', testString);
+    cy.get('[name=name]').should('have.value', testString);
 
     cy.get('[data-test=downloadXMLBtn]').click();
-    const validXML = generateXML(testString);
-    cy.window().its('xml').then(xml => xml.trim()).should('eq', validXML.trim());
+
+    const validXML = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_1" name="${testString}" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="150" y="150" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+    cy.window().its('xml')
+      .then(xml => xml.trim())
+      .should('eq', validXML.trim());
   });
 
   it('Prevent element to connect to self', () => {

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -170,17 +170,17 @@ describe('Undo/redo', () => {
     const validMessageFlowXML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
   <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:startEvent id="node_2" name="Start Event" />
+    <bpmn:startEvent id="node_1" name="Start Event" />
   </bpmn:process>
   <bpmn:collaboration id="collaboration_0">
-    <bpmn:participant id="node_4" name="New Pool" processRef="Process_1" />
+    <bpmn:participant id="node_2" name="New Pool" processRef="Process_1" />
   </bpmn:collaboration>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
-      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
         <dc:Bounds x="150" y="150" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
         <dc:Bounds x="100" y="130" width="600" height="300" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -60,22 +60,6 @@ export function typeIntoTextInput(selector, value) {
   cy.wait(saveDebounce);
 }
 
-export const generateXML = (nodeName) => {
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
-  <bpmn:process id="Process_1" isExecutable="true">
-    <bpmn:startEvent id="node_2" name="${nodeName}" />
-  </bpmn:process>
-  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
-      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
-        <dc:Bounds x="150" y="150" width="36" height="36" />
-      </bpmndi:BPMNShape>
-    </bpmndi:BPMNPlane>
-  </bpmndi:BPMNDiagram>
-</bpmn:definitions>`;
-};
-
 export function waitToRenderAllShapes() {
   cy.wait(100);
 }


### PR DESCRIPTION
Fixes #212.

How to test:
* Drag some elements onto the grid; ensure they each receive a unique ID.
* Refresh the page and change the ID of the start event to `node_2`.
* Drag another element onto the grid and ensure it has an ID of `node_3`.
* Upload a BPMN diagram; drag some more elements onto the paper and ensure no conflicting IDs are generated.