### PR TITLE
Fix overlapping sequence flows

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -51,8 +51,8 @@
       @set-cursor="cursor = $event"
       @set-pool-target="poolTarget = $event"
       @click="highlightNode(node)"
-      @unsetPools="unsetPools"
-      @setPools="setPools"
+      @unset-pools="unsetPools"
+      @set-pools="setPools"
       @save-state="pushToUndoStack"
       @set-shape-stacking="setShapeStacking"
     />

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -444,7 +444,7 @@ export default {
     },
   },
   mounted() {
-    this.$emit('setPools', this.node.definition);
+    this.$emit('set-pools', this.node.definition);
     this.laneSet = this.containingProcess.get('laneSets')[0];
 
     this.shape = new joint.shapes.processmaker.modeler.bpmn.pool();
@@ -574,7 +574,7 @@ export default {
     pull(participants, this.node.definition);
 
     if (! this.hasPools()) {
-      this.$emit('unsetPools');
+      this.$emit('unset-pools');
     } else {
       pull(this.rootElements, this.containingProcess);
     }

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-  </div>
+  <div/>
 </template>
 
 <script>
@@ -141,6 +140,7 @@ export default {
       lanes.push(this.pushNewLane());
 
       await Promise.all(lanes);
+      this.$emit('set-shape-stacking', this.shape);
       this.$emit('save-state');
     },
     createLaneSet() {
@@ -183,12 +183,6 @@ export default {
 
         if (elementBounds.x && elementBounds.y) {
           /* If lane already has a position, don't re-position or re-size it. */
-          this.shape.getEmbeddedCells()
-            .filter(cell => {
-              return cell.component && cell.component.node.type !== laneId;
-            })
-            .forEach(cell => cell.toFront());
-
           return;
         }
 
@@ -223,8 +217,6 @@ export default {
             this.shape.unembed(laneElement);
             this.shape.embed(laneElement);
           }
-
-          laneElement.toFront({ deep: true });
         });
 
         const { x, y } = element.position();
@@ -362,11 +354,10 @@ export default {
         .filter(({ component }) => component && component !== this)
         .forEach(({ component }) => {
           this.shape.embed(component.shape);
-          component.shape.toFront({ deep: true });
           component.node.pool = this.shape;
-          component.node.pool.toBack();
         });
 
+      this.$emit('set-shape-stacking', this.shape);
       this.resizePool();
     },
     fitEmbeds() {
@@ -540,7 +531,6 @@ export default {
           cellView.model.component && ![poolId, laneId].includes(cellView.model.component.node.type)
         ) {
           draggingElement = cellView.model;
-          draggingElement.toFront({ deep: true });
         }
       });
 

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -6,6 +6,9 @@ import {
   getElementAtPosition,
   typeIntoTextInput,
   waitToRenderNodeUpdates,
+  getLinksConnectedToElement,
+  isElementCovered,
+  getCrownButtonForElement,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
@@ -190,5 +193,35 @@ describe('Modeler', () => {
     cy.get('[data-test=validation-list]').then($lsit => {
       expect($lsit).to.contain('Gateway must have multiple incoming Sequence Flows');
     });
+  });
+
+  it('Adding a pool and lanes does not overlap sequence flow', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    const taskPosition = { x: 250, y: 250 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
+
+    const poolPosition = { x: 150, y: 300 };
+    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(startEventPosition)
+      .then(getLinksConnectedToElement)
+      .then($links => $links[0])
+      .then(isElementCovered)
+      .should(isCovered => expect(isCovered).to.be.false);
+
+    getElementAtPosition(poolPosition)
+      .click({ force: true })
+      .then($pool => getCrownButtonForElement($pool, 'lane-above-button'))
+      .click();
+
+    getElementAtPosition(startEventPosition)
+      .then(getLinksConnectedToElement)
+      .then($links => $links[0])
+      .then(isElementCovered)
+      .should(isCovered => expect(isCovered).to.be.false);
   });
 });

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -30,26 +30,6 @@ describe('Sequence Flows', () => {
       });
   });
 
-  it('Have the highest z-index', () => {
-    const startEventPosition = { x: 150, y: 150 };
-    const taskPosition = { x: 250, y: 250 };
-    const poolPosition = { x: 150, y: 150 };
-
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
-
-    connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
-
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
-
-    // getLastCell - will get the highest cell (element or link) with the highest z property
-    cy.window().its('store.state.graph')
-      .invoke('getLastCell').
-      then(cell => {
-        const sequenceFlow = 'processmaker-modeler-sequence-flow';
-        expect(cell.component.node.type).to.eq(sequenceFlow);
-      });
-  });
-
   it('Update Condition expression', () => {
     const exclusiveGatewayPosition = { x: 400, y: 300 };
     dragFromSourceToDest(

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -82,3 +82,22 @@ export function connectNodesWithFlow(flowType, startPosition, endPosition) {
         .click({ force: true });
     });
 }
+
+export function isElementCovered($element) {
+  return cy.window()
+    .its('store.state.paper')
+    .invoke('findViewsInArea', $element[0].getBBox())
+    .then(shapeViews => {
+      const zIndexes = shapeViews.filter(shapeView => shapeView.model.component)
+        .map(shapeView => shapeView.model.get('z'));
+
+      return cy.window()
+        .its('store.state.paper')
+        .invoke('findViewByModel', { id: $element.attr('model-id') })
+        .then(shapeView => {
+          const shapeZIndex = shapeView.model.get('z');
+
+          return zIndexes.some(zIndex => shapeZIndex < zIndex);
+        });
+    });
+}

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -93,9 +93,9 @@ export function isElementCovered($element) {
 
       return cy.window()
         .its('store.state.paper')
-        .invoke('findViewByModel', { id: $element.attr('model-id') })
-        .then(shapeView => {
-          const shapeZIndex = shapeView.model.get('z');
+        .invoke('getModelById', $element.attr('model-id'))
+        .then(shape => {
+          const shapeZIndex = shape.get('z');
 
           return zIndexes.some(zIndex => shapeZIndex < zIndex);
         });


### PR DESCRIPTION
Fixes #283.

**How to test:**
* Drag a task onto the grid and connect the start event to it with a sequence flow.
* Drag a pool onto the grid. Ensure the sequence flow is still visible.
* Add a lane to the pool. Ensure the sequence flow is still visible.
