### PR TITLE
Fix Task converted to CallActivity bug

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -383,10 +383,9 @@ export default {
         return;
       }
 
-      const type = this.parsers[definition.$type]
-        .reduce((type, parser) => {
-          return parser(definition, this.moddle) || type;
-        }, null);
+      const type = this.parsers[definition.$type].reduce((type, parser) => {
+        return parser(definition, this.moddle) || type;
+      }, null);
 
       const unnamedElements = ['bpmn:TextAnnotation'];
       const requireName = unnamedElements.indexOf(definition.$type) === -1;

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -6,7 +6,7 @@ export const taskHeight = 76;
 export default {
   id: 'processmaker-modeler-call-activity',
   component,
-  bpmnType: ['bpmn:Task', 'bpmn:CallActivity'],
+  bpmnType: 'bpmn:CallActivity',
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/callActivity.svg'),

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -16,13 +16,26 @@ describe('Tasks', () => {
     const testString = 'testing';
 
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task,taskPosition);
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     waitToRenderAllShapes();
     getElementAtPosition(taskPosition).click();
 
     typeIntoTextInput('[name=name]', testString);
     cy.get('[name=name]').should('have.value', testString);
+  });
+
+  it('Correctly renders task after undo/redo', () => {
+    const taskPosition = { x: 200, y: 200 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    waitToRenderAllShapes();
+    cy.get('[data-test=undo]').click();
+    waitToRenderAllShapes();
+    cy.get('[data-test=redo]').click();
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.task);
   });
 
   it('Can create call activity', () => {

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -65,3 +65,12 @@ Cypress.Commands.add('getPosition', {
       };
     });
 });
+
+Cypress.Commands.add('getType', {
+  prevSubject: 'element',
+}, element => {
+  cy.window()
+    .its('store.state.paper')
+    .invoke('getModelById', element.attr('model-id'))
+    .then(shape => shape.component.node.type);
+});


### PR DESCRIPTION
Fixes #288.

**How to test:**
* Drag a task onto the grid, click Undo to remove it, then Redo to add it back. The task should still render as a regular task (and not as a call activity) when added back .