### PR TITLE
Fix Parallel Gateways result in a 'BPM definition is not valid'

### DIFF
--- a/processmaker-plugin/rules/gateway-direction.js
+++ b/processmaker-plugin/rules/gateway-direction.js
@@ -13,11 +13,11 @@ module.exports = function() {
   let gateway = null;
 
   function isDiverging() {
-    return gateway.gatewayDirection === 'diverging';
+    return gateway.gatewayDirection === 'Diverging';
   }
 
   function isConverging() {
-    return gateway.gatewayDirection === 'converging';
+    return gateway.gatewayDirection === 'Converging';
   }
 
   function hasMultipleIncomingFlows() {

--- a/src/components/nodes/gateway/gatewayConfig.js
+++ b/src/components/nodes/gateway/gatewayConfig.js
@@ -1,1 +1,1 @@
-export const gatewayDirection = { diverging: 'diverging', converging: 'converging' };
+export const gatewayDirection = { diverging: 'Diverging', converging: 'Converging' };

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -179,7 +179,7 @@ describe('Modeler', () => {
 
     getElementAtPosition(gatewayPosition).click();
 
-    cy.get('[name=gatewayDirection]').select('converging');
+    cy.get('[name=gatewayDirection]').select('Converging');
 
     waitToRenderNodeUpdates();
 


### PR DESCRIPTION
To Test
- Create a Process with parallel gateway in bpm
- Click save

Expected Behaviour
- Errors should not appear

Fixes #287 