### PR TITLE
Remove “New” from task name

### DIFF
--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -12,7 +12,7 @@ export default {
   label: 'Task',
   definition(moddle) {
     return moddle.create('bpmn:Task', {
-      name: 'New Task',
+      name: 'Task',
     });
   },
   diagram(moddle) {


### PR DESCRIPTION
Fixes #300.

This PR removes the "New" work from created Tasks.