### PR TITLE
Auto-validation off by default

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -10,7 +10,7 @@ export default new Vuex.Store({
     highlightedNode: null,
     nodes: [],
     rootElements: [],
-    autoValidate: true,
+    autoValidate: false,
   },
   getters: {
     nodes: state => state.nodes,

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -167,7 +167,7 @@ describe('Modeler', () => {
     cy.get('[name=id]').should('have.value', 'node_1');
   });
 
-  it.only('Validates gateway direction', () => {
+  it('Validates gateway direction', () => {
     const gatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.inclusiveGateway, gatewayPosition);
     waitToRenderAllShapes();

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -167,12 +167,13 @@ describe('Modeler', () => {
     cy.get('[name=id]').should('have.value', 'node_1');
   });
 
-  it('Validates gateway direction', () => {
+  it.only('Validates gateway direction', () => {
     const gatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.inclusiveGateway, gatewayPosition);
     waitToRenderAllShapes();
 
     cy.get('[data-test=validation-list-toggle]').click();
+    cy.get('[type=checkbox]').check({ force: true });
 
     cy.get('[data-test=validation-list]').then($lsit => {
       expect($lsit).to.contain('Gateway must have multiple outgoing Sequence Flows');


### PR DESCRIPTION
Auto-validation is set off by default.

- No red-highlighting of the nodes will appear when validation is off.
- To enable auto-validation, check the checkbox and validation will behave as per usual.

Fixes #306 