### PR TITLE
Run Cypress against local spark app

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "pluginsFile": "tests/e2e/plugins/index.js",
-  "baseUrl": "https://spark.local.processmaker.com/modeler/2",
+  "baseUrl": "http://localhost:8080",
   "video": false,
   "numTestsKeptInMemory": 0
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,6 @@
 {
   "pluginsFile": "tests/e2e/plugins/index.js",
-  "baseUrl": "http://localhost:8080",
+  "baseUrl": "https://spark.local.processmaker.com/modeler/2",
   "video": false,
   "numTestsKeptInMemory": 0
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint --no-fix",
     "lint-fix": "vue-cli-service lint",
     "test": "vue-cli-service test:e2e",
+    "test-spark": "cypress open --env spark=true",
     "test-ci": "vue-cli-service test:e2e --headless --browser chrome"
   },
   "main": "./dist/modeler.common.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint --no-fix",
     "lint-fix": "vue-cli-service lint",
     "test": "vue-cli-service test:e2e",
-    "test-spark": "cypress open --env spark=true",
+    "test-processmaker": "cypress open --env inProcessmaker=true",
     "test-ci": "vue-cli-service test:e2e --headless --browser chrome"
   },
   "main": "./dist/modeler.common.js",

--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -74,10 +74,7 @@ import Statusbar from './components/Statusbar.vue';
 import FileUpload from 'vue-upload-component';
 import FilerSaver from 'file-saver';
 import ValidationStatus from '@/components/ValidationStatus';
-import store from '@/store';
-
-/* Add reference to store on window–this is used in testing to verify rendered nodes */
-window.store = store;
+import runningInCypressTest from '@/runningInCypressTest';
 
 const reader = new FileReader();
 
@@ -105,15 +102,12 @@ export default {
     },
   },
   methods: {
-    runningInCypressTest() {
-      return !!window.Cypress;
-    },
     download() {
       this.$refs.modeler.toXML((err, xml) => {
         if (err) {
           alert(err);
         } else {
-          if (this.runningInCypressTest()) {
+          if (runningInCypressTest()) {
             /* Save XML string to window–this is used in testing to compare against known valid XML */
             window.xml = xml;
             return;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -108,7 +108,7 @@ import { Linter } from 'bpmnlint';
 import linterConfig from '../../.bpmnlintrc';
 import NodeIdGenerator from '../NodeIdGenerator';
 import Process from './inspectors/process';
-
+import runningInCypressTest from '@/runningInCypressTest';
 
 import { faPlus, faMinus, faMapMarked } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -741,6 +741,11 @@ export default {
     },
   },
   created() {
+    if (runningInCypressTest()) {
+      /* Add reference to store on window; this is used in testing to verify rendered nodes */
+      window.store = store;
+    }
+
     this.$t = this.$t.bind(this);
     this.registerNode(Process);
 

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -1,7 +1,4 @@
 import component from './textAnnotation.vue';
-
-export const textAnnotationWidth = 150;
-export const labelPadding = 15;
 import { configId } from '@/components/inspectors/configId';
 
 export default {

--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -7,7 +7,9 @@ import joint from 'jointjs';
 import connectIcon from '@/assets/connect-artifacts.svg';
 import crownConfig from '@/mixins/crownConfig';
 import { highlightPadding } from '@/mixins/crownConfig';
-import { textAnnotationWidth, labelPadding } from './index';
+
+export const maxTextAnnotationWidth = 160;
+export const textAnnotationLabelPadding = 15;
 
 export default {
   props: ['graph', 'node', 'id'],
@@ -28,6 +30,11 @@ export default {
   },
   watch: {
     'node.definition.text'(text) {
+      this.updateNodeText(text);
+    },
+  },
+  methods: {
+    updateNodeText(text) {
       let { height } = this.shape.findView(this.paper).getBBox();
       const refPoints = `25 ${height} 3 ${height} 3 3 25 3`;
       const bounds = this.node.diagram.bounds;
@@ -38,7 +45,7 @@ export default {
         body: { refPoints },
         label: {
           text: joint.util.breakText(text, {
-            width: textAnnotationWidth,
+            width: maxTextAnnotationWidth,
           }),
           fill: 'black',
           textAnchor: 'left',
@@ -47,20 +54,22 @@ export default {
 
       const shapeView = this.shape.findView(this.paper);
       const labelHeight = shapeView.selectors.label.getBBox().height;
-      if (labelHeight + labelPadding !== height) {
-        height = labelHeight + labelPadding;
+      if (labelHeight + textAnnotationLabelPadding !== height) {
+        height = labelHeight + textAnnotationLabelPadding;
         this.shape.resize(this.nodeWidth, height - highlightPadding);
       }
 
       if (textAnnotationLength === 0) {
         this.shape.resize(this.nodeWidth, bounds.height);
-        this.updateCrownPosition();
       }
+
+      this.updateCrownPosition();
     },
   },
   mounted() {
+    const bounds = this.node.diagram.bounds;
+
     this.shape = new joint.shapes.standard.Polyline();
-    let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(this.nodeWidth, bounds.height);
     this.shape.attr({
@@ -68,9 +77,6 @@ export default {
         refPoints: '25 10 3 10 3 3 25 3',
       },
       label: {
-        text: joint.util.breakText(this.node.definition.get('text'), {
-          width: bounds.width,
-        }),
         fill: 'black',
         yAlignment: 'left',
         xAlignment: 'left',
@@ -85,6 +91,7 @@ export default {
 
     this.shape.addTo(this.graph);
     this.shape.component = this;
+    this.updateNodeText(this.node.definition.get('text'));
   },
 };
 </script>

--- a/src/runningInCypressTest.js
+++ b/src/runningInCypressTest.js
@@ -1,0 +1,3 @@
+export default function runningInCypressTest() {
+  return !!window.Cypress;
+}

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -14,6 +14,10 @@ module.exports = (on, config) => {
   //  watchOptions: {}
   // }))
 
+  if (config.env.spark) {
+    config.baseUrl = 'https://spark.local.processmaker.com/modeler/1';
+  }
+
   return Object.assign({}, config, {
     fixturesFolder: 'tests/e2e/fixtures',
     integrationFolder: 'tests/e2e/specs',

--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -14,7 +14,7 @@ module.exports = (on, config) => {
   //  watchOptions: {}
   // }))
 
-  if (config.env.spark) {
+  if (config.env.inProcessmaker) {
     config.baseUrl = 'https://spark.local.processmaker.com/modeler/1';
   }
 

--- a/tests/e2e/specs/InclusiveGateway.spec.js
+++ b/tests/e2e/specs/InclusiveGateway.spec.js
@@ -23,7 +23,11 @@ describe('Inclusive Gateway', () => {
     cy.get('[name=name]').should('have.value', testString);
   });
 
-  it('Detects gateway direction of converging or diverging', () => {
+  it('Detects gateway direction of converging or diverging', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const inclusivePosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.inclusiveGateway, inclusivePosition);
 

--- a/tests/e2e/specs/InclusiveGateway.spec.js
+++ b/tests/e2e/specs/InclusiveGateway.spec.js
@@ -24,7 +24,7 @@ describe('Inclusive Gateway', () => {
   });
 
   it('Detects gateway direction of converging or diverging', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -12,7 +12,7 @@ describe('Intermediate Catch Event', () => {
   });
 
   it('Update delay field on Intermediate Catch Event', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -11,7 +11,11 @@ describe('Intermediate Catch Event', () => {
     cy.loadModeler();
   });
 
-  it('Update delay field on Intermediate Catch Event', () => {
+  it('Update delay field on Intermediate Catch Event', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const intermediateCatchEventPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
 

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -15,7 +15,7 @@ describe('Intermediate Message Catch Event', () => {
   });
 
   it('Update properties', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 
@@ -53,7 +53,7 @@ describe('Intermediate Message Catch Event', () => {
   });
 
   it('Message Event Definition Ids are unique on render', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 
@@ -101,7 +101,7 @@ describe('Intermediate Message Catch Event', () => {
 
     cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_4');
 
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageCatchEvent.spec.js
@@ -14,7 +14,11 @@ describe('Intermediate Message Catch Event', () => {
     cy.loadModeler();
   });
 
-  it('Update properties', () => {
+  it('Update properties', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const intermediateMessageCatchEventPosition = { x: 200, y: 200 };
 
     dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventPosition);
@@ -48,7 +52,11 @@ describe('Intermediate Message Catch Event', () => {
       .should('contain', validXML.trim());
   });
 
-  it('Message Event Definition Ids are unique on render', () => {
+  it('Message Event Definition Ids are unique on render', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const intermediateMessageCatchEventPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.intermediateMessageCatchEvent, intermediateMessageCatchEventPosition);
 
@@ -70,7 +78,7 @@ describe('Intermediate Message Catch Event', () => {
       .should('contain', validXML.trim());
   });
 
-  it('Generates sequential, unique messageEvent IDs', () => {
+  it('Generates sequential, unique messageEvent IDs', function() {
     waitToRenderAllShapes();
 
     const intermediateMessageCatchEventPosition = { x: 200, y: 200 };
@@ -92,6 +100,10 @@ describe('Intermediate Message Catch Event', () => {
     getElementAtPosition(intermediateMessageCatchEvent3Position).click();
 
     cy.get('[name=eventDefinitionId]').should('have.value', 'message_event_4');
+
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
 
     cy.contains('Upload XML').click();
 

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -20,10 +20,6 @@ describe('Modeler', () => {
     cy.loadModeler();
   });
 
-  it('Renders the application without errors', () => {
-    cy.get('.header').should('contain', 'ProcessMaker Modeler');
-  });
-
   it('Create a simple process', () => {
     /* Only the initial start element should exist */
     const initialNumberOfElements = 1;
@@ -55,7 +51,7 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements + numberOfNewElementsAdded);
   });
 
-  it('Updates element name and validates xml', () => {
+  it('Updates element name and validates xml', function() {
     waitToRenderAllShapes();
 
     const startEventPosition = { x: 150, y: 150 };
@@ -64,6 +60,10 @@ describe('Modeler', () => {
     const testString = 'testing';
     typeIntoTextInput('[name=name]', testString);
     cy.get('[name=name]').should('have.value', testString);
+
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
 
     cy.get('[data-test=downloadXMLBtn]').click();
 
@@ -102,7 +102,7 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements + numberOfNewElementsAdded);
   });
 
-  it('Generates sequential, unique node IDs', () => {
+  it('Generates sequential, unique node IDs', function() {
     waitToRenderAllShapes();
 
     const startEventPosition = { x: 150, y: 150 };
@@ -129,6 +129,10 @@ describe('Modeler', () => {
     getElementAtPosition(task3Position).click();
 
     cy.get('[name=id]').should('have.value', 'node_5');
+
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
 
     cy.contains('Upload XML').click();
 
@@ -231,6 +235,10 @@ describe('Modeler', () => {
   });
 
   it('Runs custom parser before default parser', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     cy.contains('Upload XML').click();
 
     /* Wait for modal to open */

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -61,7 +61,7 @@ describe('Modeler', () => {
     typeIntoTextInput('[name=name]', testString);
     cy.get('[name=name]').should('have.value', testString);
 
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 
@@ -130,7 +130,7 @@ describe('Modeler', () => {
 
     cy.get('[name=id]').should('have.value', 'node_5');
 
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 
@@ -235,7 +235,7 @@ describe('Modeler', () => {
   });
 
   it('Runs custom parser before default parser', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -46,7 +46,7 @@ describe('Pools', () => {
   });
 
   it('Can drag elements between pools', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -31,7 +31,7 @@ describe('Pools', () => {
   });
 
   it('Can add top and bottom lane', () => {
-    const poolPosition = { x: 200, y: 200 };
+    const poolPosition = { x: 300, y: 300 };
 
     // cy.get('[data-test=mini-map-btn]').click({ force: true});
 
@@ -45,7 +45,11 @@ describe('Pools', () => {
       });
   });
 
-  it('Can drag elements between pools', () => {
+  it('Can drag elements between pools', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const startEventPosition = { x: 150, y: 150 };
 
     const pool1Position = { x: 200, y: 200 };

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -73,7 +73,7 @@ describe('Tasks', () => {
     cy.get('.inspector-container').should('not.contain', 'A process has not been configred in the connnected Call Acitivty task.');
     cy.get('[name=startEvent]').select('awesome start event');
 
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -38,12 +38,11 @@ describe('Tasks', () => {
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.task);
   });
 
-  it('Can create call activity flow', () => {
+  it('Can create call activity flow', function() {
     const startEventPosition = { x: 150, y: 150 };
     const callActivityPosition = { x: 250, y: 250 };
 
     dragFromSourceToDest(nodeTypes.callActivity, callActivityPosition);
-
 
     getElementAtPosition(callActivityPosition).should('exist');
 
@@ -73,6 +72,10 @@ describe('Tasks', () => {
 
     cy.get('.inspector-container').should('not.contain', 'A process has not been configred in the connnected Call Acitivty task.');
     cy.get('[name=startEvent]').select('awesome start event');
+
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
 
     const sequneceFlowML = '<bpmn:sequenceFlow id="node_3" name="New Sequence Flow" sourceRef="node_1" targetRef="node_2" pm:startEvent="node_2" />';
     const callActivityXML = `<bpmn:callActivity id="node_2" name="Process with start event" calledElement="ProcessId-3">

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -164,7 +164,7 @@ describe('Undo/redo', () => {
   });
 
   it('Does not include intermediate message flow definition in XML', function() {
-    if (Cypress.env('spark')) {
+    if (Cypress.env('inProcessmaker')) {
       this.skip();
     }
 

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -63,7 +63,7 @@ describe('Undo/redo', () => {
   });
 
   it('Can undo and redo adding a task', () => {
-    const taskPosition = { x: 300, y: 500 };
+    const taskPosition = { x: 300, y: 300 };
 
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
@@ -79,7 +79,7 @@ describe('Undo/redo', () => {
   });
 
   it('Can undo and redo deleting a task', () => {
-    const taskPosition = { x: 300, y: 500 };
+    const taskPosition = { x: 300, y: 300 };
 
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
@@ -163,7 +163,11 @@ describe('Undo/redo', () => {
     });
   });
 
-  it('Does not include intermediate message flow definition in XML', () => {
+  it('Does not include intermediate message flow definition in XML', function() {
+    if (Cypress.env('spark')) {
+      this.skip();
+    }
+
     const validMessageFlowXML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
   <bpmn:process id="Process_1" isExecutable="true">

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -74,3 +74,15 @@ Cypress.Commands.add('getType', {
     .invoke('getModelById', element.attr('model-id'))
     .then(shape => shape.component.node.type);
 });
+
+Cypress.Commands.add('login', () => {
+  cy.request({
+    method: 'POST',
+    url: 'https://spark.local.processmaker.com/login',
+    body: {
+      username: 'admin',
+      password: 'admin',
+      remember: 'on',
+    },
+  });
+});

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -21,3 +21,9 @@ import './commands';
 
 // Disable saving screenshots
 Cypress.Screenshot.defaults({ screenshotOnRunFailure: false });
+
+Cypress.Cookies.defaults({
+  whitelist: ['processmaker_session', /remember_web_.*/],
+});
+
+before(() => cy.login());

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -26,4 +26,6 @@ Cypress.Cookies.defaults({
   whitelist: ['processmaker_session', /remember_web_.*/],
 });
 
-before(() => cy.login());
+if (Cypress.env('spark')) {
+  before(() => cy.login());
+}

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -26,6 +26,6 @@ Cypress.Cookies.defaults({
   whitelist: ['processmaker_session', /remember_web_.*/],
 });
 
-if (Cypress.env('spark')) {
+if (Cypress.env('inProcessmaker')) {
   before(() => cy.login());
 }

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -10,19 +10,9 @@ export function getGraphElements() {
 }
 
 export function getElementAtPosition(position) {
-  /* clickOffset is used to ensure click happens inside of element;
-   * clicking right at the element boundry may result in clicking
-   * just outside of the element. 10 is the current paper grid size. */
-  const clickOffset = 10;
-
-  const offsetPosition = {
-    x: position.x + clickOffset,
-    y: position.y + clickOffset,
-  };
-
   return cy.window()
     .its('store.state.paper')
-    .invoke('findViewsFromPoint', offsetPosition)
+    .invoke('findViewsFromPoint', position)
     .then(views => views.filter(view => view.model.component))
     .then(views => views.sort((view1, view2) => {
       /* Sort shape views by z-index descending; the shape "on top" will be first in array. */
@@ -84,7 +74,7 @@ export function connectNodesWithFlow(flowType, startPosition, endPosition) {
   getElementAtPosition(startPosition)
     .click()
     .then($element => {
-      getCrownButtonForElement($element, flowType)
+      return getCrownButtonForElement($element, flowType)
         .click({ force: true });
     })
     .then(() => {


### PR DESCRIPTION
Fixes #419.

To run tests against processmaker, instead of the standalone app, run `npm run test-processmaker`. This assumes you have the processmaker app running locally at https://spark.local.processmaker.com/modeler/1; `modeler/1` should point to an already created process with a start event at position `{ x: 150, y: 150 }`.

Certain tests rely on features only available in the standalone app, such as import and download of the BPMN XML; these tests are programmatically skipped when running against processmaker.

Test annotations have been fixed to behave the same in both standalone and in processmaker.

Note: Running tests against processmaker is currently slower than running against standalone, and is not yet available on the CI. This is a good first step in increasing the confidence of our tests.