### PR TITLE
Add missing translation

### DIFF
--- a/src/components/inspectors/TimerExpression.vue
+++ b/src/components/inspectors/TimerExpression.vue
@@ -48,7 +48,7 @@
           <b-form-radio v-model="ends" class="pl-3" name="optradio" value="never">{{ $t('Never') }}</b-form-radio>
         </b-form-group>
 
-        <b-form-group class="p-0 mb-1" description="Please click On to select a date.">
+        <b-form-group class="p-0 mb-1" :description="`${$t('Please click On to select a date')}.`">
           <b-form-radio v-model="ends" class="pl-3 ml-2 mb-1" name="optradio" value="ondate">{{ $t('On') }}</b-form-radio>
           <form-date-picker
             type="date"
@@ -305,50 +305,50 @@ export default {
 </script>
 
 <style scoped="scoped">
-  .periodicity {
-    margin-top: -3px;
-  }
-  .weekday {
-    padding: 1em;
-    margin-left: 0.2em;
-    margin-bottom: 0.5em;
-    cursor: pointer;
-  }
+.periodicity {
+  margin-top: -3px;
+}
+.weekday {
+  padding: 1em;
+  margin-left: 0.2em;
+  margin-bottom: 0.5em;
+  cursor: pointer;
+}
 </style>
 
 <style>
-  .calendar {
-    width: 16em;
-  }
+.calendar {
+  width: 16em;
+}
 
-  .calendaron {
-    margin-left: 0.75rem;
-  }
+.calendaron {
+  margin-left: 0.75rem;
+}
 
-  .calendar .cell {
-    height: 2em;
-    line-height: 2em;
-  }
+.calendar .cell {
+  height: 2em;
+  line-height: 2em;
+}
 
-  .start-date {
-    background-color: white !important;
-    width: 8em !important;
-  }
+.start-date {
+  background-color: white !important;
+  width: 8em !important;
+}
 
-  .end-date {
-    background-color: white !important;
-  }
+.end-date {
+  background-color: white !important;
+}
 
-  .date-disabled .end-date {
-    background-color: #e9ecef !important;
-    color: transparent;
-  }
+.date-disabled .end-date {
+  background-color: #e9ecef !important;
+  color: transparent;
+}
 
-  .form-date-picker label {
-    display: none;
-  }
+.form-date-picker label {
+  display: none;
+}
 
-  .occurrences-text {
-    pointer-events: none;
-  }
+.occurrences-text {
+  pointer-events: none;
+}
 </style>

--- a/src/components/inspectors/configId.js
+++ b/src/components/inspectors/configId.js
@@ -1,5 +1,0 @@
-export const configId  = {
-  id: 'id',
-  validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
-  helper: 'The id field should be unique across all elements in the diagram, ex. id_1.',
-};

--- a/src/components/inspectors/idConfigSettings.js
+++ b/src/components/inspectors/idConfigSettings.js
@@ -1,0 +1,8 @@
+const idConfigSettings  = {
+  label: 'Identifier',
+  helper: 'The id field should be unique across all elements in the diagram',
+  name: 'id',
+  validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
+};
+
+export default idConfigSettings;

--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -1,4 +1,4 @@
-import { configId } from './configId';
+import idConfigSettings from './idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-process',
@@ -21,12 +21,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -1,6 +1,6 @@
 import component from './association.vue';
 import { direction } from './associationConfig';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const id  = 'processmaker-modeler-association';
 
@@ -30,12 +30,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormSelect',

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -1,8 +1,9 @@
 import component from './callActivity';
 import CallActivityFormSelect from './CallActivityFormSelect';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
+
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-call-activity';
-import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -56,12 +57,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,6 +1,5 @@
-
 import component from './endEvent.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-end-event',
@@ -49,12 +48,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -1,5 +1,5 @@
 import component from './eventBasedGateway.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-event-based-gateway',
@@ -38,12 +38,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -1,5 +1,5 @@
 import component from './exclusiveGateway.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-exclusive-gateway',
@@ -38,12 +38,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -1,5 +1,5 @@
 import component from './gateway.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-gateway',
@@ -37,12 +37,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -1,6 +1,6 @@
 import component from './inclusiveGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-inclusive-gateway',
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,6 +1,6 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import MessageEventIdGenerator from '../../../MessageEventIdGenerator';
 
 const messageEventIdGenerator = new MessageEventIdGenerator();
@@ -86,12 +86,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',
@@ -105,7 +100,7 @@ export default {
               component: 'FormInput',
               config: {
                 label: 'Message Event Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
+                helper: idConfigSettings.helper,
                 name: 'eventDefinitionId',
                 validation: 'required',
               },

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -1,6 +1,6 @@
 import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const defaultDurationValue = 'PT1H';
 
@@ -93,12 +93,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -1,5 +1,5 @@
 import component from './manualTask.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const taskHeight = 76;
 
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -1,5 +1,5 @@
 import component from './messageFlow.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const id = 'processmaker-modeler-message-flow';
 
@@ -27,12 +27,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -1,6 +1,6 @@
 import component from './parallelGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-parallel-gateway',
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -1,5 +1,5 @@
 import component from './pool';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const id = 'processmaker-modeler-pool';
 
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -1,8 +1,8 @@
 import component from './poolLane';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const id = 'processmaker-modeler-lane';
 export const minLaneHeight = 100;
-import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -36,12 +36,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: configId.helper,
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -1,7 +1,7 @@
 import component from './scriptTask.vue';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const taskHeight = 76;
-import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-script-task',
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: 'The id field should be unique across all elements in the diagram',
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -1,7 +1,7 @@
 import component from './sequenceFlow.vue';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const id = 'processmaker-modeler-sequence-flow';
-import { configId } from '@/components/inspectors/configId';
 
 export default {
   id,
@@ -65,12 +65,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -1,5 +1,5 @@
 import component from './startEvent.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-start-event',
@@ -48,12 +48,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -1,7 +1,7 @@
 import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import { DateTime } from 'luxon';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export default {
   id: 'processmaker-modeler-start-timer-event',
@@ -89,12 +89,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -1,7 +1,7 @@
 import component from './task.vue';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 export const taskHeight = 76;
-import { configId } from '@/components/inspectors/configId';
 
 export default {
   id: 'processmaker-modeler-task',
@@ -40,12 +40,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -1,5 +1,5 @@
 import component from './textAnnotation.vue';
-import { configId } from '@/components/inspectors/configId';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 export const id = 'processmaker-modeler-text-annotation';
 
 export default {
@@ -55,12 +55,7 @@ export default {
           items: [
             {
               component: 'FormInput',
-              config: {
-                label: 'Identifier',
-                helper: configId.helper,
-                name: configId.id,
-                validation: configId.validation,
-              },
+              config: idConfigSettings,
             },
             {
               component: 'FormInput',

--- a/src/setup/extensions/scriptTask.js
+++ b/src/setup/extensions/scriptTask.js
@@ -1,6 +1,7 @@
 import {
   task,
 } from '@/components/nodes';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
   /* Add a custom node example */
@@ -48,12 +49,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
           },
           {
             component: 'FormInput',
-            config: {
-              label: 'Identifier',
-              helper: 'The id field should be unique across all elements in the diagram',
-              name: 'id',
-              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
-            },
+            config: idConfigSettings,
           },
           {
             component: 'FormTextArea',

--- a/src/setup/extensions/testCustomConnector.js
+++ b/src/setup/extensions/testCustomConnector.js
@@ -2,6 +2,7 @@ import {
   task,
 } from '@/components/nodes';
 import testIcon from '@/assets/connect-artifacts.svg';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
   /* Add a custom node example */
@@ -88,12 +89,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
           },
           {
             component: 'FormInput',
-            config: {
-              label: 'Identifier',
-              helper: 'The id field should be unique across all elements in the diagram',
-              name: 'id',
-              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
-            },
+            config: idConfigSettings,
           },
           {
             component: 'FormTextArea',

--- a/src/setup/extensions/twitterConnector.js
+++ b/src/setup/extensions/twitterConnector.js
@@ -1,6 +1,7 @@
 import {
   task,
 } from '@/components/nodes';
+import idConfigSettings from '@/components/inspectors/idConfigSettings';
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
   /* Add a custom node example */
@@ -84,12 +85,7 @@ window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode }) => {
           },
           {
             component: 'FormInput',
-            config: {
-              label: 'Identifier',
-              helper: 'The id field should be unique across all elements in the diagram',
-              name: 'id',
-              validation: ['required', 'regex:/^[a-zA-Z][^\\s][a-zA-Z0-9_]+$/'],
-            },
+            config: idConfigSettings,
           },
           {
             component: 'FormTextArea',

--- a/src/setup/translations.json
+++ b/src/setup/translations.json
@@ -7,5 +7,6 @@
   "Filter": "Filter",
   "Auto validate": "Auto validate",
   "Problems": "Problems",
-  "no problems to report": "no problems to report"
+  "no problems to report": "no problems to report",
+  "Please click On to select a date": "Please click On to select a date"
 }


### PR DESCRIPTION
Fixes #435.

This PR adds one missing translation, for `Please click On to select a date`, and replaces all ID configs with a same one, ensuring the same copy is used; this change eliminates one instance that used `The id field should be unique across all elements in the diagram, ex. id_1.` instead of just `The id field should be unique across all elements in the diagram` for the ID helper text.