### PR TITLE
Always save vertex changes

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -66,14 +66,6 @@ export default {
         excludeTypes: ['standard.EmbeddedImage'],
         padding: 20,
       });
-
-      this.shape.listenTo(this.paper, 'link:pointerdown', cellView => {
-        if (cellView.model === this.shape) {
-          this.shape.listenToOnce(this.paper, 'cell:pointerup blank:pointerup', () => {
-            this.$emit('save-state');
-          });
-        }
-      });
     },
     updateDefinitionLinks() {
       const targetShape = this.shape.getTargetElement();

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -163,10 +163,18 @@ export default {
 
       this.shapeView.addTools(toolsView);
       this.shapeView.hideTools();
+
+      document.addEventListener('mouseup', this.emitSave);
+    },
+    emitSave() {
+      if (this.highlighted) {
+        this.$emit('save-state');
+      }
     },
   },
   created() {
     this.updateWaypoints = debounce(this.updateWaypoints, 100);
+    this.emitSave.bind(this);
   },
   async mounted() {
     await this.$nextTick();
@@ -228,6 +236,9 @@ export default {
     }
 
     this.updateRouter();
+  },
+  beforeDestroy() {
+    document.removeEventListener('mouseup', this.emitSave);
   },
   destroyed() {
     /* Modify source and target refs to remove incoming and outgoing properties pointing to this link */

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -11,6 +11,7 @@ export default {
       sourceShape: null,
       target: null,
       anchorPadding: 25,
+      listeningToMouseup: false,
     };
   },
   watch: {
@@ -84,6 +85,11 @@ export default {
       const points = connections.segments.map(segment => segment.end);
       this.node.diagram.waypoint = points.map(point => this.moddle.create('dc:Point', point));
       this.updateCrownPosition();
+
+      if (!this.listeningToMouseup) {
+        this.listeningToMouseup = true;
+        document.addEventListener('mouseup', this.emitSave);
+      }
     },
     updateLinkTarget({ clientX, clientY }) {
       const localMousePosition = this.paper.clientToLocalPoint({ x: clientX, y: clientY });
@@ -125,6 +131,7 @@ export default {
       this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {
         this.completeLink();
         this.updateWaypoints();
+        this.updateWaypoints.flush();
 
         if (this.updateDefinitionLinks) {
           this.updateDefinitionLinks();
@@ -163,12 +170,13 @@ export default {
 
       this.shapeView.addTools(toolsView);
       this.shapeView.hideTools();
-
-      document.addEventListener('mouseup', this.emitSave);
     },
     emitSave() {
       if (this.highlighted) {
+        this.updateWaypoints.flush();
         this.$emit('save-state');
+        document.removeEventListener('mouseup', this.emitSave);
+        this.listeningToMouseup = false;
       }
     },
   },

--- a/src/undoRedoStore.js
+++ b/src/undoRedoStore.js
@@ -40,14 +40,14 @@ export default new Vuex.Store( {
       commit('setState', newState);
       commit('setPosition', state.stack.length - 1);
     },
-    async undo({ state, getters, commit }) {
+    undo({ state, getters, commit }) {
       if (!getters.canUndo) {
         return;
       }
 
       commit('setPosition', state.position - 1);
     },
-    async redo({ state, getters, commit }) {
+    redo({ state, getters, commit }) {
       if (!getters.canRedo) {
         return;
       }

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -28,7 +28,7 @@ describe('Undo/redo', () => {
     cy.loadModeler();
   });
 
-  it.skip('Can undo and redo sequence flow condition expression', () => {
+  it('Can undo and redo sequence flow condition expression', () => {
     const exclusiveGatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
 
@@ -45,9 +45,10 @@ describe('Undo/redo', () => {
     const defaultExpressionValue = '';
     const testString = 'foo > 7';
 
-    cy.get('[name="conditionExpression.body"]').should('have.value', defaultExpressionValue);
-    typeIntoTextInput('[name="conditionExpression.body"]', testString);
-    cy.get('[name="conditionExpression.body"]').should('have.value', testString);
+    const conditionExpressionSelector = '[name=conditionExpression]';
+    cy.get(conditionExpressionSelector).should('have.value', defaultExpressionValue);
+    typeIntoTextInput(conditionExpressionSelector, testString);
+    cy.get(conditionExpressionSelector).should('have.value', testString);
 
     cy.get('.paper-container').click({ force: true });
     cy.get('[data-test=undo]').click();
@@ -59,7 +60,7 @@ describe('Undo/redo', () => {
       .then($links => $links[0])
       .click({ force: true });
 
-    cy.get('[name="conditionExpression.body"]').should('have.value', defaultExpressionValue);
+    cy.get(conditionExpressionSelector).should('have.value', defaultExpressionValue);
 
     cy.get('[data-test=redo]').click();
 
@@ -70,7 +71,7 @@ describe('Undo/redo', () => {
       .then($links => $links[0])
       .click({ force: true });
 
-    cy.get('[name="conditionExpression.body"]').should('have.value', testString);
+    cy.get(conditionExpressionSelector).should('have.value', testString);
   });
 
   it('Can undo and redo adding a task', () => {

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -10,8 +10,18 @@ import {
   waitToRenderNodeUpdates,
   removeIndentationAndLinebreaks,
 } from '../support/utils';
-
 import { nodeTypes } from '../support/constants';
+
+function testNumberOfVertices(numberOfVertices) {
+  cy.get('[data-test=downloadXMLBtn]').click();
+  cy.window()
+    .its('xml')
+    .then(removeIndentationAndLinebreaks)
+    .then(xml => {
+      const waypoints = xml.match(/<di:waypoint x="\d+(?:\.\d+)?" y="\d+(?:\.\d+)?" \/>/gim);
+      expect(waypoints).to.have.length(numberOfVertices);
+    });
+}
 
 describe('Undo/redo', () => {
   beforeEach(() => {
@@ -268,5 +278,69 @@ describe('Undo/redo', () => {
         expect(xml).to.contain(testConnector);
         expect(xml).to.contain(sendTweet);
       });
+  });
+
+  it('Can undo/redo modifying sequence flow vertices', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    const taskPosition = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
+
+    const initialNumberOfWaypoints = 3;
+    testNumberOfVertices(initialNumberOfWaypoints);
+
+    getElementAtPosition(startEventPosition)
+      .then(getLinksConnectedToElement)
+      .then($links => $links[0])
+      .click('topRight');
+
+    waitToRenderAllShapes();
+
+    cy.get('[data-tool-name=vertices]').trigger('mousedown', 'topRight');
+    cy.get('[data-tool-name=vertices]').trigger('mousemove', 'bottomLeft', { force: true });
+    cy.get('[data-tool-name=vertices]').trigger('mouseup', 'bottomLeft', { force: true });
+
+    waitToRenderAllShapes();
+
+    const updatedNumberOfWaypoints = 5;
+    testNumberOfVertices(updatedNumberOfWaypoints);
+
+    cy.get('[data-test=undo]').click({ force: true });
+
+    waitToRenderAllShapes();
+
+    testNumberOfVertices(initialNumberOfWaypoints);
+  });
+
+  it('Can undo/redo modifying association flow vertices', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    const textAnnotationPosition = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    connectNodesWithFlow('association-flow-button', textAnnotationPosition, startEventPosition);
+
+    const initialNumberOfWaypoints = 2;
+    testNumberOfVertices(initialNumberOfWaypoints);
+
+    getElementAtPosition(startEventPosition)
+      .then(getLinksConnectedToElement)
+      .then($links => $links[0])
+      .click();
+
+    waitToRenderAllShapes();
+
+    cy.get('[data-tool-name=vertices]').trigger('mousedown');
+    cy.get('[data-tool-name=vertices]').trigger('mousemove', 'bottomLeft', { force: true });
+    cy.get('[data-tool-name=vertices]').trigger('mouseup', 'bottomLeft', { force: true });
+
+    waitToRenderAllShapes();
+
+    const updatedNumberOfWaypoints = 3;
+    testNumberOfVertices(updatedNumberOfWaypoints);
+
+    cy.get('[data-test=undo]').click({ force: true });
+
+    waitToRenderAllShapes();
+
+    testNumberOfVertices(initialNumberOfWaypoints);
   });
 });

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -18,7 +18,7 @@ describe('Undo/redo', () => {
     cy.loadModeler();
   });
 
-  xit('Can undo and redo sequence flow condition expression', () => {
+  it.skip('Can undo and redo sequence flow condition expression', () => {
     const exclusiveGatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
 


### PR DESCRIPTION
Fixes #396, fixes #439.

This PR ensures that changes to vertices are always saved.

Video of fix: https://www.dropbox.com/s/4fjnhv2mi4jjzoe/vertices_undo_redo_working.mov?dl=0.