### PR TITLE
Update Cypress tests to work against processmaker

### DIFF
--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -302,6 +302,10 @@ describe('Modeler', () => {
   });
 
   it('shows warning for unknown element during parsing', function() {
+    if (Cypress.env('inProcessmaker')) {
+      this.skip();
+    }
+
     uploadXml('unknownElement.xml');
     const warning = 'Unsupported element type in parse: bpmn:IntermediateThrowEvent';
 

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -13,6 +13,19 @@ import {
 import { nodeTypes } from '../support/constants';
 
 function testNumberOfVertices(numberOfVertices) {
+  cy.window()
+    .its('store.state')
+    .then(state => {
+      const { graph, paper } = state;
+      const waypoints = graph.getLinks()[0].findView(paper).getConnectionSubdivisions();
+      expect(waypoints).to.have.length(numberOfVertices);
+    });
+
+
+  if (Cypress.env('inProcessmaker')) {
+    return;
+  }
+
   cy.get('[data-test=downloadXMLBtn]').click();
   cy.window()
     .its('xml')
@@ -246,6 +259,10 @@ describe('Undo/redo', () => {
   });
 
   it('Correctly parses elements after redo', function() {
+    if (Cypress.env('inProcessmaker')) {
+      this.skip();
+    }
+
     const testConnectorPosition = { x: 150, y: 300 };
     dragFromSourceToDest(nodeTypes.testConnector, testConnectorPosition);
 
@@ -284,6 +301,7 @@ describe('Undo/redo', () => {
   it('Can undo/redo modifying sequence flow vertices', function() {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 300, y: 300 };
+
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
 


### PR DESCRIPTION
No functionality changes; this PR updates a couple tests so they work correctly when run with `npm run test-processmaker`.