### PR TITLE
Crown Buttons: Hide tooltip if title is undefined

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -4,7 +4,7 @@
       v-if="tooltipTarget"
       :key="tooltipTarget.id"
       :target="getTooltipTarget"
-      :title="tooltipTitle || ''"
+      :title="tooltipTitle"
     />
 
     <b-col class="h-100 overflow-hidden controls-column" :class="{ 'ignore-pointer': canvasDragPosition }">

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -4,7 +4,7 @@
       v-if="tooltipTarget"
       :key="tooltipTarget.id"
       :target="getTooltipTarget"
-      :title="tooltipTitle"
+      :title="tooltipTitle || ''"
     />
 
     <b-col class="h-100 overflow-hidden controls-column" :class="{ 'ignore-pointer': canvasDragPosition }">

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -64,6 +64,9 @@ export default {
     isValidMessageFlowSource() {
       return validMessageFlowSources.includes(this.node.type);
     },
+    hideTooltip() {
+      return this.tooltipTitle === false;
+    },
   },
   methods: {
     setErrorHighlight() {
@@ -181,7 +184,7 @@ export default {
           root: {
             display: 'none',
             'data-test': id,
-            'data-title': title || 'Crown Button',
+            'data-title': title || this.hideTooltip,
           },
           body: {
             fill: '#fff',

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -64,9 +64,6 @@ export default {
     isValidMessageFlowSource() {
       return validMessageFlowSources.includes(this.node.type);
     },
-    hideTooltip() {
-      return this.tooltipTitle === false;
-    },
   },
   methods: {
     setErrorHighlight() {
@@ -184,7 +181,7 @@ export default {
           root: {
             display: 'none',
             'data-test': id,
-            'data-title': title || this.hideTooltip,
+            'data-title': title || '',
           },
           body: {
             fill: '#fff',


### PR DESCRIPTION
If crown button titles are undefined; do not show a tooltip.

**Spark Video Demo**
https://drive.google.com/open?id=1-ScaCjrG68R7N-nM4Qc2o3Be9o8k1sRK

**Start Event, sequence flow button's title was set to undefined for testing purposes.

Fixes #442 