### PR TITLE
Set timer default value

### DIFF
--- a/src/components/inspectors/DurationExpression.vue
+++ b/src/components/inspectors/DurationExpression.vue
@@ -22,6 +22,7 @@
 
 <script>
 import last from 'lodash/last';
+import { defaultDurationValue } from '@/components/nodes/intermediateTimerEvent';
 
 const periodNames = {
   minute: 'minute',
@@ -49,13 +50,16 @@ export default {
   watch: {
     value: {
       handler(value) {
-        this.periodicity = this.getPeriodFromDelayString(value);
-        this.repeat = this.getRepeatNumberFromDelayString(value);
+        this.periodicity = this.getPeriodFromDelayString(value || defaultDurationValue);
+        this.repeat = this.getRepeatNumberFromDelayString(value || defaultDurationValue);
       },
       immediate: true,
     },
-    durationExpression(durationExpression) {
-      this.$emit('input', durationExpression);
+    durationExpression: {
+      handler(durationExpression) {
+        this.$emit('input', durationExpression);
+      },
+      immediate: true,
     },
   },
   computed: {

--- a/src/components/inspectors/DurationExpression.vue
+++ b/src/components/inspectors/DurationExpression.vue
@@ -22,7 +22,6 @@
 
 <script>
 import last from 'lodash/last';
-import { defaultDurationValue } from '@/components/nodes/intermediateTimerEvent';
 
 const periodNames = {
   minute: 'minute',
@@ -50,8 +49,8 @@ export default {
   watch: {
     value: {
       handler(value) {
-        this.periodicity = this.getPeriodFromDelayString(value || defaultDurationValue);
-        this.repeat = this.getRepeatNumberFromDelayString(value || defaultDurationValue);
+        this.periodicity = this.getPeriodFromDelayString(value);
+        this.repeat = this.getRepeatNumberFromDelayString(value);
       },
       immediate: true,
     },

--- a/src/components/inspectors/IntermediateTimer.vue
+++ b/src/components/inspectors/IntermediateTimer.vue
@@ -15,6 +15,8 @@
 <script>
 import DurationExpression from './DurationExpression';
 import DateTimeExpression from './DateTimeExpression';
+import { DateTime } from 'luxon';
+import { defaultDurationValue } from '@/components/nodes/intermediateTimerEvent';
 
 const types = {
   timeDuration: 'DurationExpression',
@@ -44,8 +46,15 @@ export default {
     },
   },
   methods: {
-    changeType(value) {
-      this.emitChange(value, this.timerProperty);
+    changeType(type) {
+      const defaultValue = this.isDelayType(type)
+        ? defaultDurationValue
+        : DateTime.local();
+
+      this.emitChange(type, defaultValue);
+    },
+    isDelayType(type) {
+      return types[type] === types.timeDuration;
     },
     emitChange(type, body) {
       this.$emit('input', { type, body });

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -2,6 +2,8 @@ import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
 import { configId } from '@/components/inspectors/configId';
 
+export const defaultDurationValue = 'PT1H';
+
 export default {
   id: 'processmaker-modeler-intermediate-catch-timer-event',
   component,
@@ -16,7 +18,7 @@ export default {
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {
-            body: 'PT1H',
+            body: defaultDurationValue,
           }),
         }),
       ],

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -2,8 +2,8 @@ import {
   dragFromSourceToDest,
   typeIntoTextInput,
   getElementAtPosition,
+  removeIndentationAndLinebreaks,
 } from '../support/utils';
-
 import { nodeTypes } from '../support/constants';
 
 describe('Intermediate Catch Event', () => {
@@ -71,5 +71,43 @@ describe('Intermediate Catch Event', () => {
       .its('xml')
       .then(xml => xml.trim())
       .should('have', validIntermediateCatchEventXML.trim());
+  });
+
+  it('Sets default values when switching between types', function() {
+    if (Cypress.env('inProcessmaker')) {
+      this.skip();
+    }
+
+    cy.clock();
+
+    const intermediateCatchEventPosition = { x: 250, y: 250 };
+    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+
+    getElementAtPosition(intermediateCatchEventPosition).click();
+    cy.contains('Timing Control').click();
+    cy.get('[data-test=intermediateTypeSelect]').select('Date/Time');
+
+    const defaultTimeDate = '<bpmn:timeDate>1970-01-01T00:00:00.000Z</bpmn:timeDate>';
+
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window()
+      .its('xml')
+      .then(removeIndentationAndLinebreaks)
+      .should(xml => {
+        expect(xml).to.contain(defaultTimeDate);
+      });
+
+    cy.get('[data-test=intermediateTypeSelect]').select('Delay');
+
+    cy.get('[data-test=downloadXMLBtn]').click();
+
+    const defaultTimeDuration = '<bpmn:timeDuration>PT1H</bpmn:timeDuration>';
+
+    cy.window()
+      .its('xml')
+      .then(removeIndentationAndLinebreaks)
+      .should(xml => {
+        expect(xml).to.contain(defaultTimeDuration);
+      });
   });
 });


### PR DESCRIPTION
Fixes #450.

This PR allows switching between the Type property for the Intermediate Timer Event without causing errors, by setting a default value on switch.

Video of fix: https://www.dropbox.com/s/w3sfyux3qxs8vnc/timer_event_working.mov?dl=0