### PR TITLE
Update styles to make controls and inspector flush with edges

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -37,7 +37,7 @@
         </div>
       </b-card-header>
 
-      <b-card-body class="overflow-hidden position-relative" data-test="body-container">
+      <b-card-body class="overflow-hidden position-relative p-0" data-test="body-container">
         <modeler ref="modeler" @validate="validationErrors = $event" />
       </b-card-body>
 

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -15,7 +15,7 @@
         :allowDrop="allowDrop"
         @drag="validateDropTarget"
         @handleDrop="handleDrop"
-        class="controls h-100"
+        class="controls h-100 rounded-0 border-top-0 border-bottom-0 border-left-0"
       />
     </b-col>
 
@@ -25,7 +25,7 @@
       :class="cursor"
       :style="{ width: parentWidth, height: parentHeight }"
     >
-      <div class="btn-toolbar tool-buttons d-flex mb-1 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
+      <div class="btn-toolbar tool-buttons d-flex mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -7,7 +7,7 @@
 
       <b-form-input ref="filter"
         :placeholder="`${$t('Filter Controls')}`"
-        class="sticky-top border-top-0 border-right-0 rounded-0"
+        class="border-top-0 border-right-0 rounded-0"
         type="text"
         v-model="filterQuery"
       />

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -1,14 +1,13 @@
 <template>
   <b-card no-body class="controls">
-    <b-card-header class="border-bottom-0">{{ $t('Controls') }}</b-card-header>
     <b-input-group size="sm">
       <b-input-group-prepend>
-        <span class="input-group-text"><i class="fas fa-filter"/></span>
+        <span class="input-group-text border-left-0 border-top-0 rounded-0"><i class="fas fa-filter"/></span>
       </b-input-group-prepend>
 
       <b-form-input ref="filter"
-        :placeholder="`${$t('Filter')}...`"
-        class="sticky-top"
+        :placeholder="`${$t('Filter Controls')}`"
+        class="sticky-top border-top-0 border-right-0 rounded-0"
         type="text"
         v-model="filterQuery"
       />

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -1,6 +1,5 @@
 <template>
-  <b-card no-body class="inspector-container" data-test="inspector-container">
-    <div class="card-header">{{ $t('Inspector') }}</div>
+  <b-card no-body class="inspector-container border-top-0 border-bottom-0 border-right-0 rounded-0" data-test="inspector-container">
     <vue-form-renderer
       v-if="highlightedNode"
       :data="data"


### PR DESCRIPTION
Fixes #453.

Screenshot of fix: 
<img width="1440" alt="Screen Shot 2019-06-27 at 3 19 08 PM" src="https://user-images.githubusercontent.com/7561061/60294271-04675f80-98ef-11e9-93e7-8053ded6ff52.png">

Associated PR on `processmaker`: https://github.com/ProcessMaker/processmaker/pull/2048