### PR TITLE
Implement rounded flows

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -127,6 +127,7 @@ export default {
   },
   mounted() {
     this.shape = new joint.shapes.standard.Link();
+    this.shape.connector('rounded', { radius: 5 });
     this.createLabel();
 
     const conditionExpression = this.node.definition.conditionExpression;

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -92,9 +92,9 @@ export default {
       this.shape.getSourceElement().embed(this.shape);
     },
     updateWaypoints() {
-      const connections = this.shape.findView(this.paper).getConnection();
-      const points = connections.segments.map(segment => segment.end);
-      this.node.diagram.waypoint = points.map(point => this.moddle.create('dc:Point', point));
+      const { start, end } = this.shape.findView(this.paper).getConnection();
+
+      this.node.diagram.waypoint = [start, ...this.shape.vertices(), end].map(point => this.moddle.create('dc:Point', point));
       this.updateCrownPosition();
 
       if (!this.listeningToMouseup) {


### PR DESCRIPTION
Fixes #455.

**Screenshots of fix:**

Before:
<img width="525" alt="Screen Shot 2019-07-03 at 4 11 01 PM" src="https://user-images.githubusercontent.com/7561061/60621990-3116ed80-9dad-11e9-8985-17a0c11c2c01.png">

After:
<img width="397" alt="Screen Shot 2019-07-03 at 4 09 27 PM" src="https://user-images.githubusercontent.com/7561061/60621934-0cbb1100-9dad-11e9-91f3-5a49ea2b8da4.png">

**Note:**

This PR fixes an issue when saving processes that include sequence flows. After saving a process and reloading (or undoing and redoing), sequence flow vertices would be added back as custom vertices. This now works as expected (custom vertices only appear if explicitly added by the user).

However, **from the point of view of BPMN, there is no difference between custom "fixed" vertices and "fluid" ones automatically generated by JointJS**. To keep it working this way, automatically generated vertices are not exported in the BPMN; only the start and end points are. This is to avoid the bug described in the paragraph above. I think this is a fair tradeoff, as there's no way to export the underlying BPMN from modeler, and we do not explicitly support other modeler programs (this change will only create a visual difference outside of PM modeler anyway).