### PR TITLE
Add ProcessMaker test for task user assignment

### DIFF
--- a/tests/e2e/plugins/index.js
+++ b/tests/e2e/plugins/index.js
@@ -15,7 +15,7 @@ module.exports = (on, config) => {
   // }))
 
   if (config.env.inProcessmaker) {
-    config.baseUrl = 'https://spark.local.processmaker.com/modeler/1';
+    config.baseUrl = 'https://processmaker.local.processmaker.com';
   }
 
   return Object.assign({}, config, {

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -91,4 +91,25 @@ describe('Tasks', () => {
         expect(xml).to.contain(callActivityXML.trim());
       });
   });
+
+  it('Shows secondary dropdown for task user assignment', function() {
+    if (!Cypress.env('inProcessmaker')) {
+      this.skip();
+    }
+
+    const taskPosition = { x: 200, y: 200 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    getElementAtPosition(taskPosition).click();
+
+    cy.contains('Task Assignment').next().select('User');
+    cy.contains('Assigned User')
+      .should('exist')
+      .next().find('.multiselect').should('exist');
+
+    cy.contains('Task Assignment').next().select('Group');
+    cy.contains('Assigned Group')
+      .should('exist')
+      .next().find('.multiselect').should('exist');
+  });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -26,8 +26,12 @@
 import { defaultViewportDimensions } from './constants';
 
 Cypress.Commands.add('loadModeler', () => {
+  const url = Cypress.env('inProcessmaker')
+    ? '/modeler/1'
+    : '/';
+
   cy.viewport(defaultViewportDimensions.width, defaultViewportDimensions.height);
-  cy.visit('/');
+  cy.visit(url);
   cy.reload();
 });
 
@@ -78,7 +82,7 @@ Cypress.Commands.add('getType', {
 Cypress.Commands.add('login', () => {
   cy.request({
     method: 'POST',
-    url: 'https://spark.local.processmaker.com/login',
+    url: '/login',
     body: {
       username: 'admin',
       password: 'admin',


### PR DESCRIPTION
Fixes #461.

To test, ensure `https://processmaker.local.processmaker.com/modeler/1` points to a process with a single start event at position `x: 150 y: 150`. Then, in modeler, run `npm run test-processmaker`, and select `Tasks.spec.js` from the list of tests to run.

Note: Keep https://github.com/ProcessMaker/modeler/issues/463 in mind when running tests against processmaker.