### PR TITLE
Fix toolbar blocking canvas

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -946,6 +946,7 @@ $cursors: default, not-allowed;
     user-select: none;
 
     .tool-buttons {
+      width: fit-content;
       z-index: 1;
 
       > button {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -25,7 +25,7 @@
       :class="[cursor, { 'grabbing-cursor' : isGrabbing }]"
       :style="{ width: parentWidth, height: parentHeight }"
     >
-      <div class="btn-toolbar tool-buttons d-flex mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
+      <div class="btn-toolbar tool-buttons d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>
@@ -946,7 +946,6 @@ $cursors: default, not-allowed;
     user-select: none;
 
     .tool-buttons {
-      width: fit-content;
       z-index: 1;
 
       > button {

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -136,12 +136,14 @@ describe('Boundary Timer Event', () => {
 
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
+    const initialPositionXML = '<bpmn:boundaryEvent id="node_4" name="New Boundary Timer Event" attachedToRef="node_2"><bpmn:timerEventDefinition><bpmn:timeDuration>PT1H</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:boundaryEvent>';
+
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
       .its('xml')
       .then(removeIndentationAndLinebreaks)
       .then(xml => {
-        // expect(xml).to.contain(initialPositionXML);
+        expect(xml).to.contain(initialPositionXML);
       });
 
     moveElementRelativeTo({x: 400, y: 400}, 150, 150);
@@ -151,7 +153,7 @@ describe('Boundary Timer Event', () => {
       .its('xml')
       .then(removeIndentationAndLinebreaks)
       .then(xml => {
-        // expect(xml).to.contain(initialPositionXML);
+        expect(xml).to.contain(initialPositionXML);
       });
   });
 });


### PR DESCRIPTION
The toolbar div was taking 100% width of the paper container which prevented users to move the canvas near the toolbar.

With this PR the width of the toolbar will now be computed by the number of elements inside of it,

https://drive.google.com/open?id=1UBNG7ZNrIQnYynQ9Mwa8f65qFg_LHdnN

Fixes #487 