### PR TITLE
Remove references of boundary event when deleting a pool.

### DIFF
--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -138,11 +138,6 @@ export default {
   }
 }
 
-.img-container {
-  width: 1rem;
-  pointer-events: none;
-}
-
 .tool-icon {
   width: 1.5rem;
   pointer-events: none;

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -78,7 +78,7 @@ export default {
     },
     removeShape() {
       this.graph.getConnectedLinks(this.shape).forEach(shape => this.$emit('remove-node', shape.component.node));
-      this.shape.getEmbeddedCells().forEach(cell => {
+      this.shape.getEmbeddedCells({deep: true}).forEach(cell => {
         if (cell.component) {
           this.graph.getConnectedLinks(cell).forEach(shape => this.$emit('remove-node', shape.component.node));
           this.shape.unembed(cell);

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -115,6 +115,45 @@ describe('Boundary Timer Event', () => {
       });
   });
 
+  it('removes references of itself when inside of a pool and deleting the pool', function() {
+    if (Cypress.env('inProcessmaker')) {
+      this.skip();
+    }
+
+    const startEventPosition = { x: 150, y: 150 };
+    const poolPosition = { x: 400, y: 300 };
+    const taskPosition = { x: 250, y: 250 };
+
+    getElementAtPosition(startEventPosition)
+      .click()
+      .then($startEvent => {
+        getCrownButtonForElement($startEvent, 'delete-button').click({ force: true });
+      });
+
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    const boundaryTimerEventPosition = { x: 250, y: 250 };
+    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, boundaryTimerEventPosition);
+
+    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+
+    getElementAtPosition(poolPosition)
+      .click()
+      .then($task => {
+        getCrownButtonForElement($task, 'delete-button').click({ force: true });
+      });
+
+    const boundaryTimerEventInXML = '<bpmn:boundaryEvent id="node_4" name="New Boundary Timer Event" attachedToRef="node_2"><bpmn:timerEventDefinition><bpmn:timeDuration>PT1H</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:boundaryEvent>';
+
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window()
+      .its('xml')
+      .then(removeIndentationAndLinebreaks)
+      .then(xml => {
+        expect(xml).to.not.contain(boundaryTimerEventInXML);
+      });
+  });
+
   it.skip('can stay anchored to task when moving pool', function() {
     if (Cypress.env('inProcessmaker')) {
       this.skip();


### PR DESCRIPTION
When a pool contained a boundary timer event and the user deletes the pool. The XML would still contain references of the boundary timer event even though visually it was 'removed'.

By setting `deep: true` on getEmbeddedCells, it will grab any nested embeddedCells.

**Video of Fix**
https://drive.google.com/open?id=1n2r-JCGyf-GNG_HYt_C58u37LSacccyH

Fixes #513 