### PR TITLE
Displayed warning that name fields are required where frontend validation would fail

### DIFF
--- a/src/components/inspectors/nameConfigSettings.js
+++ b/src/components/inspectors/nameConfigSettings.js
@@ -1,0 +1,7 @@
+const nameConfigSettings  = {
+  label: 'Name',
+  name: 'name',
+  validation: 'required',
+};
+
+export default nameConfigSettings;

--- a/src/components/nodes/boundaryErrorEvent/index.js
+++ b/src/components/nodes/boundaryErrorEvent/index.js
@@ -1,5 +1,6 @@
 import component from './boundaryErrorEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-boundary-error-event',
@@ -48,9 +49,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Boundary Timer Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/boundaryEvent/index.js
+++ b/src/components/nodes/boundaryEvent/index.js
@@ -1,5 +1,6 @@
 import component from './boundaryEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-boundary-event',
@@ -42,9 +43,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Boundary Event',
-                name: 'name',
               },
             },
             {

--- a/src/components/nodes/boundarySignalEvent/index.js
+++ b/src/components/nodes/boundarySignalEvent/index.js
@@ -1,5 +1,6 @@
 import component from './boundarySignalEvent';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-boundary-signal-event',
@@ -48,9 +49,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Boundary Timer Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -1,5 +1,6 @@
 import component from './boundaryTimerEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
 export const defaultDurationValue = 'PT1H';
 
@@ -94,9 +95,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Boundary Timer Event',
-                name: 'name',
               },
             },
             {

--- a/src/components/nodes/callActivity/index.js
+++ b/src/components/nodes/callActivity/index.js
@@ -1,6 +1,7 @@
 import component from './callActivity';
 import CallActivityFormSelect from './CallActivityFormSelect';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-call-activity';
@@ -62,9 +63,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Call Activity',
-                name: 'name',
               },
             },
             {

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,5 +1,6 @@
 import component from './endEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-end-event',
@@ -53,9 +54,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the End Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -1,6 +1,7 @@
 import component from './inclusiveGateway.vue';
 import { gatewayDirection } from '../gateway/gatewayConfig';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-inclusive-gateway',
@@ -45,9 +46,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Gateway',
-                name: 'name',
               },
             },
             {

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -1,6 +1,7 @@
 import component from './intermediateMessageCatchEvent.vue';
 import omit from 'lodash/omit';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import MessageEventIdGenerator from '../../../MessageEventIdGenerator';
 
 const messageEventIdGenerator = new MessageEventIdGenerator();
@@ -91,9 +92,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Intermediate Message Catch Event',
-                name: 'name',
               },
             },
             {

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -1,6 +1,7 @@
 import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const defaultDurationValue = 'PT1H';
 
@@ -98,9 +99,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Intermediate Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -1,5 +1,6 @@
 import component from './manualTask.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-manual-task';
@@ -46,9 +47,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The name of the manual task',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -1,5 +1,6 @@
 import component from './pool';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const id = 'processmaker-modeler-pool';
 
@@ -45,9 +46,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Pool',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -1,5 +1,6 @@
 import component from './poolLane';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const id = 'processmaker-modeler-lane';
 export const minLaneHeight = 100;
@@ -41,9 +42,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Lane',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -1,5 +1,6 @@
 import component from './scriptTask.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-script-task';
@@ -45,9 +46,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The name of the script task',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -1,5 +1,6 @@
 import component from './startEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-start-event',
@@ -53,9 +54,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Start Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -2,6 +2,7 @@ import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import { DateTime } from 'luxon';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export default {
   id: 'processmaker-modeler-start-timer-event',
@@ -94,9 +95,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Start Event',
-                name: 'name',
               },
             },
           ],

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -1,5 +1,6 @@
 import component from './task.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
+import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-task';
@@ -46,9 +47,8 @@ export default {
             {
               component: 'FormInput',
               config: {
-                label: 'Name',
+                ...nameConfigSettings,
                 helper: 'The Name of the Task',
-                name: 'name',
               },
             },
           ],


### PR DESCRIPTION
Process, segments and most gateways didn't fail validation when `name` was empty, so I didn't include them.

It doesn't prevent saving, but it does show a warning now when the name field is left empty.
<img width="687" alt="Screen Shot 2019-08-13 at 4 57 16 PM" src="https://user-images.githubusercontent.com/6653340/62976822-75a19a00-bdeb-11e9-9f85-e2c42ef83b78.png">

A pr for proccessmaker adds a fallback on empty task names in the request details. https://github.com/ProcessMaker/processmaker/pull/2281
<img width="780" alt="Screen Shot 2019-08-13 at 4 59 25 PM" src="https://user-images.githubusercontent.com/6653340/62977065-04aeb200-bdec-11e9-91f2-de7fab112836.png">

Relates #501 