### PR TITLE
Fix missing reference of x and y in Microsoft Edge

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -646,8 +646,8 @@ export default {
       this.paper.setDimensions(clientWidth, clientHeight);
     },
     isPointOverPaper(mouseX, mouseY) {
-      const { x, y, width, height } = this.$refs['paper-container'].getBoundingClientRect();
-      const rect = new joint.g.rect(x, y, width, height);
+      const { left, top, width, height } = this.$refs['paper-container'].getBoundingClientRect();
+      const rect = new joint.g.rect(left, top, width, height);
       const point = new joint.g.point(mouseX, mouseY);
 
       return rect.containsPoint(point);


### PR DESCRIPTION
The valid drop areas were not being respected because in edge there is no reference of client `x and y`. Instead, edges uses `left` and `top` properties for the client position.

**Video of fix**
https://drive.google.com/open?id=1SHBOwqoFXS62sZi_rMOStxc_rIexaAfS

Fixes #496 