### PR TITLE
Allow boundary timer events to be repositioned

### DIFF
--- a/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
+++ b/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
@@ -95,14 +95,18 @@ export default {
       task.embed(this.shape);
       this.updateSnappingPosition(task);
       this.renderBoundaryTimer(this.node.definition.cancelActivity);
+
+      this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
+        if (cellView.model !== this.shape) {
+          return;
+        }
+
+        this.updateSnappingPosition(task);
+        this.updateCrownPosition();
+      });
     } else {
       this.$emit('remove-node', this.node);
     }
-
-    this.shape.listenTo(this.paper, 'element:pointerup', () => {
-      this.updateSnappingPosition(task);
-      this.updateCrownPosition();
-    });
   },
 };
 </script>


### PR DESCRIPTION
This PR will give users the ability to reposition the boundary timer event and it will snap to the closest anchor point when repositioning. 

**Video of enhancement**
https://drive.google.com/open?id=1yrCQI9WAt3Bor735vICqTJWseAZE-q_m

Fixes #511 