### PR TITLE
Remove reference to bpmnlint-plugin-spark

### DIFF
--- a/.bpmnlintrc
+++ b/.bpmnlintrc
@@ -1,7 +1,7 @@
 {
   "extends": [
     "bpmnlint:recommended",
-    "plugin:spark/all"
+    "plugin:processmaker/all"
   ],
   "rules": {
     "no-inclusive-gateway": "off",


### PR DESCRIPTION
Remove the reference to the bpmnlint-plugin-spark package and replaced it with the new package name bpmnlint-plugin-processmaker.

**IMPORTANT NOTE:**
This branch is dependent on the [bpmnlint-plugin PR](https://github.com/ProcessMaker/bpmnlint-plugin/compare/bug/491?expand=1) **BEFORE** merging. 

closes #491 