### PR TITLE
Wrap expensive renders in freeze / unfreeze

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -548,7 +548,9 @@ export default {
           store.commit('clearNodes');
 
           this.$nextTick(() => {
+            this.paper.freeze();
             this.parse();
+            this.paper.unfreeze();
             this.$emit('parsed');
           });
         }
@@ -870,7 +872,9 @@ export default {
         return;
       }
 
+      this.paper.freeze();
       this.setShapeStacking(shape);
+      this.paper.unfreeze();
 
       shape.component.$emit('click');
     });

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -298,8 +298,10 @@ export default {
     this.$nextTick(() => {
       /* Use nextTick to ensure this code runs after the component it is mixed into mounts.
        * This will ensure this.shape is defined. */
-      this.configureCrown();
-      this.configurePoolLane();
+      this.$once('click', () => {
+        this.configureCrown();
+        this.configurePoolLane();
+      });
 
       if (!this.planeElements.includes(this.node.diagram)) {
         this.planeElements.push(this.node.diagram);


### PR DESCRIPTION
Fixes #532.

There are two places where performance suffers due to a large number of JointJS nodes being (re)rendered; those functions are now wrapped in an async block to ensure only a single render occurs.

Another improvement is the loading of the crown. This section is wrapped in a [`$once`](https://vuejs.org/v2/api/#vm-once) listener to ensure the crown is only configured once per component, as oppose to 123 times on initial load when testing with the large process linked below.

Performance can be tested using this large BPMN process:
https://www.dropbox.com/s/n3a8tjctv1pw1r2/large_process.bpmn?dl=0