### PR TITLE
Exact sorting breaks when updating after undo/redo

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -806,6 +806,7 @@ export default {
       async: true,
       el: this.$refs.paper,
       model: this.graph,
+      sorting: 'sorting-approximate',
       gridSize: 10,
       drawGrid: true,
       clickThreshold: 10,


### PR DESCRIPTION
The sort options in jointjs v3 are:
- sorting-none
- sorting-approximate
- sorting-exact (default)

The exact sort loses the cells to compare against when doing undo/redo. For now, do an approximate sort.