### PR TITLE
Ensure rendering is complete before running view dependant code

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -87,6 +87,7 @@
       :moddle="moddle"
       :nodeRegistry="nodeRegistry"
       :root-elements="definitions.get('rootElements')"
+      :isRendering="isRendering"
       @add-node="addNode"
       @remove-node="removeNode"
       @set-cursor="cursor = $event"
@@ -181,6 +182,7 @@ export default {
       scaleStep: 0.1,
       toggleMiniMap: false,
       isGrabbing: false,
+      isRendering: false,
     };
   },
   watch: {
@@ -549,6 +551,8 @@ export default {
 
           this.$nextTick(() => {
             this.paper.freeze();
+            this.isRendering = true;
+            this.paper.once('render:done', () => this.isRendering = false);
             this.parse();
             this.paper.unfreeze();
             this.$emit('parsed');

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -58,6 +58,10 @@ export default {
       }
     },
     hasError() {
+      if (this.isRendering) {
+        return;
+      }
+
       this.setErrorHighlight();
     },
   },

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -27,7 +27,17 @@ const errorHighlighter = {
 };
 
 export default {
-  props: ['highlighted', 'paper', 'processNode', 'planeElements', 'moddle', 'hasError', 'collaboration', 'nodeRegistry'],
+  props: [
+    'highlighted',
+    'paper',
+    'processNode',
+    'planeElements',
+    'moddle',
+    'hasError',
+    'collaboration',
+    'nodeRegistry',
+    'isRendering',
+  ],
   data() {
     return {
       buttons: [],
@@ -70,6 +80,7 @@ export default {
       if (!this.shapeView) {
         return;
       }
+
       if (this.hasError) {
         this.shapeView.highlight(null, { highlighter: errorHighlighter });
       } else {
@@ -293,11 +304,7 @@ export default {
 
       this.$emit('save-state');
     },
-  },
-  mounted() {
-    this.$nextTick(() => {
-      /* Use nextTick to ensure this code runs after the component it is mixed into mounts.
-       * This will ensure this.shape is defined. */
+    setUpCrownConfig() {
       this.$once('click', () => {
         this.configureCrown();
         this.configurePoolLane();
@@ -329,6 +336,18 @@ export default {
       }
 
       this.setErrorHighlight();
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      /* Use nextTick to ensure this code runs after the component it is mixed into mounts.
+       * This will ensure this.shape is defined. */
+
+      if (this.isRendering) {
+        this.paper.once('render:done', this.setUpCrownConfig);
+      } else {
+        this.setUpCrownConfig();
+      }
     });
   },
   created() {

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -263,7 +263,7 @@ describe('Modeler', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     getElementAtPosition(startEventPosition).then($startEvent => {
-      cy.wrap($startEvent).get('[stroke=red]').should('exist');
+      cy.wrap($startEvent).find('[stroke=red]').should('exist');
     });
 
     const taskPosition = { x: 150, y: 300 };
@@ -278,7 +278,7 @@ describe('Modeler', () => {
     waitToRenderAllShapes();
 
     getElementAtPosition(startEventPosition).then($startEvent => {
-      cy.wrap($startEvent).get('[stroke=red]').should('exist');
+      cy.wrap($startEvent).find('[stroke=red]').should('exist');
     });
 
     cy.get('[data-test=validation-list]').children()
@@ -293,11 +293,11 @@ describe('Modeler', () => {
       .should('contain', 'node_2');
 
     getElementAtPosition(startEventPosition).then($startEvent => {
-      cy.wrap($startEvent).get('[stroke=red]').should('exist');
+      cy.wrap($startEvent).find('[stroke=red]').should('exist');
     });
 
     getElementAtPosition(taskPosition).then($task => {
-      cy.wrap($task).get('[stroke=red]').should('exist');
+      cy.wrap($task).find('[stroke=red]').should('exist');
     });
   });
 


### PR DESCRIPTION
Fixes #538.

The issue appeared to be that when the code which sets the error highlighting ran, the view for the shape wasn't fully rendered. There is no way in JointJS to determine if rendering is in progress, and `paper.isFrozen()` returns `false` even though rendering of the views is not compete.

This PR passes a flag to components that can be used to conditionally run view-dependant code after rendering is complete; this resolves the issue for setting the highlighting on the shape.