### PR TITLE
Fixes issue with setting the label for a text annotation introduced by async rendering

### DIFF
--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -6,11 +6,8 @@
 import { shapes, util } from 'jointjs';
 import connectIcon from '@/assets/connect-artifacts.svg';
 import crownConfig from '@/mixins/crownConfig';
-import { highlightPadding } from '@/mixins/crownConfig';
 
 export const maxTextAnnotationWidth = 160;
-export const textAnnotationLabelPadding = 15;
-
 export default {
   props: ['graph', 'node', 'id'],
   mixins: [crownConfig],
@@ -35,12 +32,24 @@ export default {
     },
   },
   methods: {
+    setElementHeight(previousHeight, currentBoundsHeight, labelText) {
+      const labelPadding = 15;
+      let newHeight = previousHeight;
+      const shapeView = this.shape.findView(this.paper);
+      const newLabelHeight = shapeView.selectors.label.getBBox().height + labelPadding;
+      if (newLabelHeight !== previousHeight) {
+        newHeight = newLabelHeight;
+      }
+      if (labelText.length === 0) {
+        newHeight = currentBoundsHeight;
+      }
+
+      this.shape.resize(this.nodeWidth, newHeight);
+    },
     updateNodeText(text) {
       let { height } = this.shape.findView(this.paper).getBBox();
       const refPoints = `25 ${height} 3 ${height} 3 3 25 3`;
       const bounds = this.node.diagram.bounds;
-      const textAnnotationLength = text.length;
-
       this.shape.position(bounds.x, bounds.y);
       this.shape.attr({
         body: { refPoints },
@@ -52,19 +61,10 @@ export default {
           textAnchor: 'left',
         },
       });
-
-      const shapeView = this.shape.findView(this.paper);
-      const labelHeight = shapeView.selectors.label.getBBox().height;
-      if (labelHeight + textAnnotationLabelPadding !== height) {
-        height = labelHeight + textAnnotationLabelPadding;
-        this.shape.resize(this.nodeWidth, height - highlightPadding);
-      }
-
-      if (textAnnotationLength === 0) {
-        this.shape.resize(this.nodeWidth, bounds.height);
-      }
-
-      this.updateCrownPosition();
+      this.paper.once('render:done', () => {
+        this.setElementHeight(height, bounds.height, text);
+        this.updateCrownPosition();
+      });
     },
   },
   mounted() {


### PR DESCRIPTION
This fixes #546.

<img width="199" alt="Screen Shot 2019-08-21 at 4 46 09 PM" src="https://user-images.githubusercontent.com/858371/63467419-71046380-c433-11e9-99ab-661541a7b308.png">

There's a possibility that fixing this issue and switching to async rendering has made the text in the annotation a little off centre vertically (see screenshot). I think there are three possible ways forward if this is the case:

1. Put more time into this now to see if we can work out what has changed.
2. Log an issue to investigate it further later and close this for now.
3. Leave things as they are as if things are off centre it's only by a very small amount, a few pixels.

@velkymx could you comment on if the vertical alignment has changed and how you would like us to proceed if so?