### PR TITLE
Revert ProcessMaker dependencies to previous versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1971,45 +1971,37 @@
       }
     },
     "@processmaker/processmaker-bpmn-moddle": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.4.tgz",
-      "integrity": "sha512-CQM5ZaSKMaN/7GHMUdCARjUyuJCzS6KvifRm+Tq5ndZSteVZR5ZzkI2JJgl76Kw4za4oGocoDG4MLXYQYldymQ==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.3.tgz",
+      "integrity": "sha512-yHWEcMf7C0DQqB2MSNF0wepVDbU/UtdyXvbYxGQwKyZc4Ce4J0K6XWxh0keFNP+qENzl6bgHoPfPaMvZ3UqSSA==",
       "dev": true,
       "requires": {
         "min-dash": "^3.0.0"
       }
     },
     "@processmaker/screen-builder": {
-      "version": "0.17.81",
-      "resolved": "https://registry.npmjs.org/@processmaker/screen-builder/-/screen-builder-0.17.81.tgz",
-      "integrity": "sha512-amfLJQHLsv8Ru+xck+hrcDOGeLWTF3VjBSE0EhIgQIxqGBftFX/hi4xuQCv9PzxBarQwOfH2y8Tw918cqV2geQ==",
+      "version": "0.17.78",
+      "resolved": "https://registry.npmjs.org/@processmaker/screen-builder/-/screen-builder-0.17.78.tgz",
+      "integrity": "sha512-vX+UQuKHoNzytnKuZhsYF4QcktNS88yJk9NwV0XxbzOLt601OZgyg9Wn+n1xFKWUkrlE1Z0Krd2WBG46/B9NOg==",
       "dev": true
     },
     "@processmaker/vue-form-elements": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.10.8.tgz",
-      "integrity": "sha512-TaPGVtELkkmFEfKoXN+eFiCx0FJOZ4ga/IALA+bsWj9rCvIVdeZDjKcZ0yRHujCHiGRQ+uUlWWD3ESfwdM0nxA==",
+      "version": "0.10.6",
+      "resolved": "https://registry.npmjs.org/@processmaker/vue-form-elements/-/vue-form-elements-0.10.6.tgz",
+      "integrity": "sha512-2XHFWJff6MTxvsYa6nLF8xjujr68dp0jZRtT2Oxdgl4PnLZVjoSuYW+vJIUrVmmDO130tF4u6NsPgOs48Vjo6g==",
       "dev": true,
       "requires": {
         "@tinymce/tinymce-vue": "^2.0.0",
         "bootstrap": "^4.2.1",
         "jquery": "^3.3.1",
-        "luxon": "^1.17.2",
-        "moment-timezone": "^0.5.26",
+        "luxon": "^1.11.3",
         "popper.js": "^1.14.4",
         "tinymce": "^5.0.1",
         "v-calendar": "^0.9.7",
         "validatorjs": "^3.14.2",
         "vue": "^2.5.16",
-        "vue-bootstrap-datetimepicker": "^5.0.1"
-      },
-      "dependencies": {
-        "luxon": {
-          "version": "1.17.2",
-          "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.17.2.tgz",
-          "integrity": "sha512-qELKtIj3HD41N+MvgoxArk8DZGUb4Gpiijs91oi+ZmKJzRlxY6CoyTwNoUwnogCVs4p8HuxVJDik9JbnYgrCng==",
-          "dev": true
-        }
+        "vue-datetime": "^1.0.0-beta.10",
+        "weekstart": "^1.0.0"
       }
     },
     "@soda/friendly-errors-webpack-plugin": {
@@ -14479,15 +14471,6 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "dev": true
     },
-    "moment-timezone": {
-      "version": "0.5.26",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
-      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
-      "dev": true,
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
-    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -15876,29 +15859,6 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "pc-bootstrap4-datetimepicker": {
-      "version": "4.17.50",
-      "resolved": "https://registry.npmjs.org/pc-bootstrap4-datetimepicker/-/pc-bootstrap4-datetimepicker-4.17.50.tgz",
-      "integrity": "sha512-76y2McdmiGWdgwPUim72/otNcDUva05B/VoyJVgIRv2dd+g4GO9gPfvvPvCH4LXyKNvtAzKHQSTSyC+4PKq/FQ==",
-      "dev": true,
-      "requires": {
-        "bootstrap": "^4.0.0-beta.2",
-        "jquery": "^1.8.3 || ^2.0 || ^3.0",
-        "moment": "^2.10",
-        "moment-timezone": "^0.4.0"
-      },
-      "dependencies": {
-        "moment-timezone": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-          "dev": true,
-          "requires": {
-            "moment": ">= 2.6.0"
-          }
-        }
       }
     },
     "pend": {
@@ -20465,14 +20425,11 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
     },
-    "vue-bootstrap-datetimepicker": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vue-bootstrap-datetimepicker/-/vue-bootstrap-datetimepicker-5.0.1.tgz",
-      "integrity": "sha512-jao7sWXHgKzjbOio97u7kEfB/FJMWJ5rhsc4q8iNTOLCULfSJ5m3AZ2qZh62dNcMA4/uuTW6m6tONYIith/2XQ==",
-      "dev": true,
-      "requires": {
-        "pc-bootstrap4-datetimepicker": "^4.17.50"
-      }
+    "vue-datetime": {
+      "version": "1.0.0-beta.10",
+      "resolved": "https://registry.npmjs.org/vue-datetime/-/vue-datetime-1.0.0-beta.10.tgz",
+      "integrity": "sha512-/wJkj95JSzWqH0Ja4JpXX6I+fXo2A34GCtsx00vR5RjNxk3++93rg7G4ZlI3MFo807zH9bIxXfIohbAZgnAWbQ==",
+      "dev": true
     },
     "vue-deepset": {
       "version": "0.6.3",
@@ -21191,6 +21148,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+      "dev": true
+    },
+    "weekstart": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-1.0.0.tgz",
+      "integrity": "sha1-4K7jWNRa2ZgCJUdp17KjTJOA9Tk=",
       "dev": true
     },
     "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   "devDependencies": {
     "@cypress/code-coverage": "^1.9.0",
     "@panter/vue-i18next": "^0.15.0",
-    "@processmaker/processmaker-bpmn-moddle": "0.4.4",
-    "@processmaker/screen-builder": "0.17.81",
-    "@processmaker/vue-form-elements": "0.10.8",
+    "@processmaker/processmaker-bpmn-moddle": "0.4.3",
+    "@processmaker/screen-builder": "0.17.78",
+    "@processmaker/vue-form-elements": "0.10.6",
     "@vue/cli-plugin-babel": "^3.8.0",
     "@vue/cli-plugin-e2e-cypress": "^3.8.0",
     "@vue/cli-plugin-eslint": "^3.8.0",
@@ -71,8 +71,8 @@
     "vue-template-compiler": "^2.5.17"
   },
   "peerDependencies": {
-    "@processmaker/screen-builder": "0.17.81",
-    "@processmaker/vue-form-elements": "0.10.8",
+    "@processmaker/screen-builder": "0.17.78",
+    "@processmaker/vue-form-elements": "0.10.6",
     "@panter/vue-i18next": "^0.15.0",
     "i18next": "^15.0.9",
     "bootstrap": "^4.3.1",


### PR DESCRIPTION
## Changes
- Downgrades **processmaker-bpmn-moddle** from v0.4.4 to v0.4.3
- Downgrades **screen-builder** from 0.17.81 to 0.17.78
- Downgrades **vue-form-elements** from 0.10.8 to 0.10.6
- Updates package-lock.json with latest dependencies

Fixes #562.