### PR TITLE
Fix call activity related dropdown options

### DIFF
--- a/src/components/inspectors/SequenceFlowFormSelect.vue
+++ b/src/components/inspectors/SequenceFlowFormSelect.vue
@@ -36,8 +36,8 @@ export default {
   computed: {
     dropdownList() {
       return this.eventList.length > 0
-        ? [{ value: '', content: '[Select Start Event]' }, ...this.eventList]
-        : null;
+        ? this.eventList
+        : [];
     },
     eventList() {
       const list = [];

--- a/src/components/nodes/callActivity/CallActivityFormSelect.vue
+++ b/src/components/nodes/callActivity/CallActivityFormSelect.vue
@@ -15,8 +15,8 @@ export default {
   computed: {
     dropdownList() {
       return this.processList.length > 0
-        ? [{ value: '', content: this.$t('[Select Active Process]') }, ...this.processList]
-        : null;
+        ? this.processList
+        : [];
     },
     processList() {
       const list = [];


### PR DESCRIPTION
Fixes #555.

Video of fix: https://www.dropbox.com/s/tim2m65n1uca1wf/call-activity-working.mov?dl=0.

The code that makes the API call for the list of processes is already wrapped in a `try`/`catch` block, and works as expected when testing in processmaker. So the `net::ERR_NAME_NOT_RESOLVED` error in standalone is expected and can safely be ignored.