### PR TITLE
Fix CallActivity failing test

### DIFF
--- a/src/components/nodes/callActivity/callActivity.vue
+++ b/src/components/nodes/callActivity/callActivity.vue
@@ -49,6 +49,10 @@ export default {
       }
     },
     'node.definition.calledElement'(calledElement) {
+      if (!calledElement) {
+        return;
+      }
+
       const [ownerProcessId, processId] = calledElement.split('-');
 
       const calledProcess = store.getters.globalProcesses

--- a/src/store.js
+++ b/src/store.js
@@ -4,6 +4,14 @@ import flatten from 'lodash/flatten';
 
 Vue.use(Vuex);
 
+function makeDefinitionPropertyReactive(definition, key, value) {
+  if (definition.hasOwnProperty(key)) {
+    return;
+  }
+
+  Vue.set(definition, key, value);
+}
+
 export default new Vuex.Store({
   state: {
     graph: null,
@@ -43,6 +51,9 @@ export default new Vuex.Store({
     },
     updateNodeProp(state, { node, key, value }) {
       node.definition.set(key, value);
+
+
+      makeDefinitionPropertyReactive(node.definition, key, value);
     },
     clearNodes(state) {
       state.nodes = [];


### PR DESCRIPTION
This PR fixes the failing test, "Can create call activity flow",  on `develop`.

It appears that the `calledElement` property on the moddle definition doesn't get set on the object as an actual property until it's value is truthy. However, Vue doesn't pick up changes to new property additions. Using [`Vue.set`](https://vuejs.org/v2/api/#Vue-set) ensures that new property additions are recognized by Vue's reactivity system.