### PR TITLE
Base Boundary Event 

### DIFF
--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -6,7 +6,6 @@
 import crownConfig from '@/mixins/crownConfig';
 import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
-import timerEventIcon from '@/assets/timer-event-icon.svg';
 import { id as taskId } from '@/components/nodes/task';
 import { id as callActivityId } from '@/components/nodes/callActivity';
 import { id as manualTaskId } from '@/components/nodes/manualTask';
@@ -33,9 +32,6 @@ export default {
     'node.definition.name'(name) {
       this.shape.attr('label/text', name);
     },
-    'node.definition.cancelActivity'(value) {
-      this.renderInterruptingShape(value);
-    },
   },
   methods: {
     getTaskUnderShape() {
@@ -51,29 +47,13 @@ export default {
         .filter(model => model.component)
         .find(model => taskIds.includes(model.component.node.type));
     },
-    updateBoundaryShape(dashLength) {
-      this.shape.attr({
-        body: {
-          'strokeDasharray': dashLength,
-        },
-        body2: {
-          'strokeDasharray': dashLength,
-        },
-      });
-    },
-    renderInterruptingShape(isCancelActivity) {
-      const dashedLine = 5;
-      const solidLine = 0;
-      isCancelActivity ? this.updateBoundaryShape(solidLine) : this.updateBoundaryShape(dashedLine);
-    },
   },
-  async mounted() {
+  mounted() {
     // Now, let's add a rounded rect to the graph
     this.shape = new EventShape();
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.get('x'), bounds.get('y'));
     this.shape.resize(bounds.get('width'), bounds.get('height'));
-
     this.shape.attr({
       body: {
         stroke: '#212529',
@@ -96,18 +76,15 @@ export default {
         'height': bounds.get('height') - 10,
       },
     });
-    await this.$nextTick();
-
     this.shape.addTo(this.graph);
     this.shape.component = this;
 
     const task = this.getTaskUnderShape();
 
-    if (task) {
+    if(task) {
       task.embed(this.shape);
       this.node.definition.set('attachedToRef', task.component.node.definition);
     }
-
   },
 };
 </script>

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -32,6 +32,9 @@ export default {
     'node.definition.name'(name) {
       this.shape.attr('label/text', name);
     },
+    'node.definition.cancelActivity'(value) {
+      this.renderInterrupting(value);
+    },
   },
   methods: {
     getTaskUnderShape() {
@@ -46,6 +49,21 @@ export default {
         .findModelsUnderElement(this.shape)
         .filter(model => model.component)
         .find(model => taskIds.includes(model.component.node.type));
+    },
+    updateBoundaryShape(dashLength) {
+      this.shape.attr({
+        body: {
+          'strokeDasharray': dashLength,
+        },
+        body2: {
+          'strokeDasharray': dashLength,
+        },
+      });
+    },
+    renderInterrupting(isCancelActivity) {
+      const dashedLine = 5;
+      const solidLine = 0;
+      isCancelActivity ? this.updateBoundaryShape(solidLine) : this.updateBoundaryShape(dashedLine);
     },
   },
   mounted() {
@@ -81,9 +99,10 @@ export default {
 
     const task = this.getTaskUnderShape();
 
-    if(task) {
+    if (task) {
       task.embed(this.shape);
       this.node.definition.set('attachedToRef', task.component.node.definition);
+      this.renderInterrupting(this.node.definition.cancelActivity);
     }
   },
 };

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -6,6 +6,7 @@
 import crownConfig from '@/mixins/crownConfig';
 import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
+import timerEventIcon from '@/assets/timer-event-icon.svg';
 import { id as taskId } from '@/components/nodes/task';
 import { id as callActivityId } from '@/components/nodes/callActivity';
 import { id as manualTaskId } from '@/components/nodes/manualTask';
@@ -32,6 +33,9 @@ export default {
     'node.definition.name'(name) {
       this.shape.attr('label/text', name);
     },
+    'node.definition.cancelActivity'(value) {
+      this.renderInterruptingShape(value);
+    },
   },
   methods: {
     getTaskUnderShape() {
@@ -47,13 +51,29 @@ export default {
         .filter(model => model.component)
         .find(model => taskIds.includes(model.component.node.type));
     },
+    updateBoundaryShape(dashLength) {
+      this.shape.attr({
+        body: {
+          'strokeDasharray': dashLength,
+        },
+        body2: {
+          'strokeDasharray': dashLength,
+        },
+      });
+    },
+    renderInterruptingShape(isCancelActivity) {
+      const dashedLine = 5;
+      const solidLine = 0;
+      isCancelActivity ? this.updateBoundaryShape(solidLine) : this.updateBoundaryShape(dashedLine);
+    },
   },
-  mounted() {
+  async mounted() {
     // Now, let's add a rounded rect to the graph
     this.shape = new EventShape();
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.get('x'), bounds.get('y'));
     this.shape.resize(bounds.get('width'), bounds.get('height'));
+
     this.shape.attr({
       body: {
         stroke: '#212529',
@@ -76,15 +96,18 @@ export default {
         'height': bounds.get('height') - 10,
       },
     });
+    await this.$nextTick();
+
     this.shape.addTo(this.graph);
     this.shape.component = this;
 
     const task = this.getTaskUnderShape();
 
-    if(task) {
+    if (task) {
       task.embed(this.shape);
       this.node.definition.set('attachedToRef', task.component.node.definition);
     }
+
   },
 };
 </script>

--- a/src/components/nodes/boundaryEvent/index.js
+++ b/src/components/nodes/boundaryEvent/index.js
@@ -6,7 +6,7 @@ export default {
   id: 'processmaker-modeler-boundary-event',
   component,
   bpmnType: 'bpmn:BoundaryEvent',
-  control: true,
+  control: false,
   category: 'BPMN',
   label: 'Boundary Event',
   definition(moddle, $t) {

--- a/src/components/nodes/boundaryEvent/index.js
+++ b/src/components/nodes/boundaryEvent/index.js
@@ -6,12 +6,13 @@ export default {
   id: 'processmaker-modeler-boundary-event',
   component,
   bpmnType: 'bpmn:BoundaryEvent',
-  control: false,
+  control: true,
   category: 'BPMN',
   label: 'Boundary Event',
   definition(moddle, $t) {
     return moddle.create('bpmn:BoundaryEvent', {
       name: $t('New Boundary Event'),
+      cancelActivity: true,
     });
   },
   diagram(moddle) {
@@ -45,6 +46,14 @@ export default {
               config: {
                 ...nameConfigSettings,
                 helper: 'The Name of the Boundary Event',
+              },
+            },
+            {
+              component: 'FormCheckbox',
+              config: {
+                label: 'Interrupting',
+                name: 'cancelActivity',
+                helper: 'Boundary Event Type',
               },
             },
             {

--- a/src/components/nodes/boundaryEvent/index.js
+++ b/src/components/nodes/boundaryEvent/index.js
@@ -6,13 +6,12 @@ export default {
   id: 'processmaker-modeler-boundary-event',
   component,
   bpmnType: 'bpmn:BoundaryEvent',
-  control: true,
+  control: false,
   category: 'BPMN',
   label: 'Boundary Event',
   definition(moddle, $t) {
     return moddle.create('bpmn:BoundaryEvent', {
       name: $t('New Boundary Event'),
-      cancelActivity: true,
     });
   },
   diagram(moddle) {
@@ -46,14 +45,6 @@ export default {
               config: {
                 ...nameConfigSettings,
                 helper: 'The Name of the Boundary Event',
-              },
-            },
-            {
-              component: 'FormCheckbox',
-              config: {
-                label: 'Interrupting',
-                name: 'cancelActivity',
-                helper: 'Boundary Event Type',
               },
             },
             {

--- a/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
+++ b/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
@@ -5,53 +5,11 @@
 <script>
 import BoundaryEvent from '@/components/nodes/boundaryEvent/boundaryEvent';
 import timerEventIcon from '@/assets/timer-event-icon.svg';
-import boundaryEventSwitcher from '@/mixins/boundaryEventSwitcher';
-import { portGroups } from '@/mixins/portsConfig';
-import portsConfig from '@/mixins/portsConfig';
 import crownConfig from '@/mixins/crownConfig';
-import { g } from 'jointjs';
-
-function getPointFromGroup(model, group) {
-  const { x: shapeX, y: shapeY } = model.position();
-  const { x, y } = Object.values(model.getPortsPositions(group))[0];
-
-  return new g.Point(shapeX + x, shapeY + y);
-}
-
-function getPortPoints(model) {
-  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
-}
-
-function closestPort(model, anchorReference) {
-  return getPortPoints(model).sort((p1, p2) => {
-    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
-    return referencePoint.distance(p1) - referencePoint.distance(p2);
-  })[0];
-}
-
-function hasPorts(model) {
-  return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
-}
-
-function snapToAnchor(coords, model) {
-  if (!hasPorts(model)) {
-    const { x, y } = model.position();
-    const { width, height } = model.size();
-
-    return new g.Point(x - (width / 2), y - (height / 2));
-  }
-
-  return closestPort(model, coords);
-}
 
 export default {
   extends: BoundaryEvent,
-  mixins: [boundaryEventSwitcher, portsConfig, crownConfig],
-  watch: {
-    'node.definition.cancelActivity'(value) {
-      this.renderBoundaryTimer(value);
-    },
-  },
+  mixins: [crownConfig],
   methods: {
     updateBoundaryShape(dashLength) {
       this.shape.attr({
@@ -86,27 +44,6 @@ export default {
         'height': bounds.get('height') - 10,
       },
     });
-
-    await this.$nextTick();
-
-    const task = this.getTaskUnderShape();
-
-    if (task) {
-      task.embed(this.shape);
-      this.updateSnappingPosition(task);
-      this.renderBoundaryTimer(this.node.definition.cancelActivity);
-
-      this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
-        if (cellView.model !== this.shape) {
-          return;
-        }
-
-        this.updateSnappingPosition(task);
-        this.updateCrownPosition();
-      });
-    } else {
-      this.$emit('remove-node', this.node);
-    }
   },
 };
 </script>

--- a/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
+++ b/src/components/nodes/boundaryTimerEvent/boundaryTimerEvent.vue
@@ -5,53 +5,54 @@
 <script>
 import BoundaryEvent from '@/components/nodes/boundaryEvent/boundaryEvent';
 import timerEventIcon from '@/assets/timer-event-icon.svg';
-import boundaryEventSwitcher from '@/mixins/boundaryEventSwitcher';
-import { portGroups } from '@/mixins/portsConfig';
 import portsConfig from '@/mixins/portsConfig';
 import crownConfig from '@/mixins/crownConfig';
-import { g } from 'jointjs';
 
-function getPointFromGroup(model, group) {
-  const { x: shapeX, y: shapeY } = model.position();
-  const { x, y } = Object.values(model.getPortsPositions(group))[0];
+// import boundaryEventSwitcher from '@/mixins/boundaryEventSwitcher';
+// import { portGroups } from '@/mixins/portsConfig';
+// import { g } from 'jointjs';
 
-  return new g.Point(shapeX + x, shapeY + y);
-}
+// function getPointFromGroup(model, group) {
+//   const { x: shapeX, y: shapeY } = model.position();
+//   const { x, y } = Object.values(model.getPortsPositions(group))[0];
 
-function getPortPoints(model) {
-  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
-}
+//   return new g.Point(shapeX + x, shapeY + y);
+// }
 
-function closestPort(model, anchorReference) {
-  return getPortPoints(model).sort((p1, p2) => {
-    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
-    return referencePoint.distance(p1) - referencePoint.distance(p2);
-  })[0];
-}
+// function getPortPoints(model) {
+//   return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
+// }
 
-function hasPorts(model) {
-  return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
-}
+// function closestPort(model, anchorReference) {
+//   return getPortPoints(model).sort((p1, p2) => {
+//     const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
+//     return referencePoint.distance(p1) - referencePoint.distance(p2);
+//   })[0];
+// }
 
-function snapToAnchor(coords, model) {
-  if (!hasPorts(model)) {
-    const { x, y } = model.position();
-    const { width, height } = model.size();
+// function hasPorts(model) {
+//   return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
+// }
 
-    return new g.Point(x - (width / 2), y - (height / 2));
-  }
+// function snapToAnchor(coords, model) {
+//   if (!hasPorts(model)) {
+//     const { x, y } = model.position();
+//     const { width, height } = model.size();
 
-  return closestPort(model, coords);
-}
+//     return new g.Point(x - (width / 2), y - (height / 2));
+//   }
+
+//   return closestPort(model, coords);
+// }
 
 export default {
   extends: BoundaryEvent,
-  mixins: [boundaryEventSwitcher, portsConfig, crownConfig],
-  watch: {
-    'node.definition.cancelActivity'(value) {
-      this.renderBoundaryTimer(value);
-    },
-  },
+  mixins: [portsConfig, crownConfig],
+  // watch: {
+  //   'node.definition.cancelActivity'(value) {
+  //     this.renderBoundaryTimer(value);
+  //   },
+  // },
   methods: {
     updateBoundaryShape(dashLength) {
       this.shape.attr({
@@ -89,24 +90,24 @@ export default {
 
     await this.$nextTick();
 
-    const task = this.getTaskUnderShape();
+    // const task = this.getTaskUnderShape();
 
-    if (task) {
-      task.embed(this.shape);
-      this.updateSnappingPosition(task);
-      this.renderBoundaryTimer(this.node.definition.cancelActivity);
+    // if (task) {
+    //   task.embed(this.shape);
+    //   this.updateSnappingPosition(task);
+    //   this.renderBoundaryTimer(this.node.definition.cancelActivity);
 
-      this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
-        if (cellView.model !== this.shape) {
-          return;
-        }
+    //   this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
+    //     if (cellView.model !== this.shape) {
+    //       return;
+    //     }
 
-        this.updateSnappingPosition(task);
-        this.updateCrownPosition();
-      });
-    } else {
-      this.$emit('remove-node', this.node);
-    }
+    //     this.updateSnappingPosition(task);
+    //     this.updateCrownPosition();
+    //   });
+    // } else {
+    //   this.$emit('remove-node', this.node);
+    // }
   },
 };
 </script>

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -8,14 +8,13 @@ export default {
   id: 'processmaker-modeler-boundary-timer-event',
   component,
   bpmnType: 'bpmn:BoundaryEvent',
-  control: true,
+  control: false,
   category: 'BPMN',
   label: 'Boundary Timer Event',
   icon: require('@/assets/toolpanel/boundary-timer-event.svg'),
   definition(moddle, $t) {
     return moddle.create('bpmn:BoundaryEvent', {
       name: $t('New Boundary Timer Event'),
-      cancelActivity: true,
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -8,13 +8,14 @@ export default {
   id: 'processmaker-modeler-boundary-timer-event',
   component,
   bpmnType: 'bpmn:BoundaryEvent',
-  control: false,
+  control: true,
   category: 'BPMN',
   label: 'Boundary Timer Event',
   icon: require('@/assets/toolpanel/boundary-timer-event.svg'),
   definition(moddle, $t) {
     return moddle.create('bpmn:BoundaryEvent', {
       name: $t('New Boundary Timer Event'),
+      cancelActivity: true,
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {

--- a/src/components/nodes/index.js
+++ b/src/components/nodes/index.js
@@ -22,3 +22,4 @@ export { default as ValidationStatus } from '../ValidationStatus';
 export { default as Modeler } from '../Modeler';
 export { default as manualTask } from './manualTask';
 export { default as boundaryEvent } from './boundaryEvent';
+export { default as boundaryTimerEvent } from './boundaryTimerEvent';

--- a/src/components/nodes/index.js
+++ b/src/components/nodes/index.js
@@ -21,3 +21,4 @@ export { default as Statusbar } from '../Statusbar';
 export { default as ValidationStatus } from '../ValidationStatus';
 export { default as Modeler } from '../Modeler';
 export { default as manualTask } from './manualTask';
+export { default as boundaryEvent } from './boundaryEvent';

--- a/src/components/nodes/index.js
+++ b/src/components/nodes/index.js
@@ -22,4 +22,3 @@ export { default as ValidationStatus } from '../ValidationStatus';
 export { default as Modeler } from '../Modeler';
 export { default as manualTask } from './manualTask';
 export { default as boundaryEvent } from './boundaryEvent';
-export { default as boundaryTimerEvent } from './boundaryTimerEvent';

--- a/src/setup/defaultNodes.js
+++ b/src/setup/defaultNodes.js
@@ -24,7 +24,6 @@ import {
   pool,
   poolLane,
   boundaryEvent,
-  boundaryTimerEvent,
 } from '@/components/nodes';
 
 const nodeTypes = [
@@ -45,7 +44,6 @@ const nodeTypes = [
   pool,
   poolLane,
   boundaryEvent,
-  boundaryTimerEvent,
 ];
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode, registerBpmnExtension })  => {

--- a/src/setup/defaultNodes.js
+++ b/src/setup/defaultNodes.js
@@ -24,6 +24,7 @@ import {
   pool,
   poolLane,
   boundaryEvent,
+  boundaryTimerEvent,
 } from '@/components/nodes';
 
 const nodeTypes = [
@@ -44,6 +45,7 @@ const nodeTypes = [
   pool,
   poolLane,
   boundaryEvent,
+  boundaryTimerEvent,
 ];
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode, registerBpmnExtension })  => {

--- a/src/setup/defaultNodes.js
+++ b/src/setup/defaultNodes.js
@@ -23,6 +23,7 @@ import {
   textAnnotation,
   pool,
   poolLane,
+  boundaryEvent,
 } from '@/components/nodes';
 
 const nodeTypes = [
@@ -42,6 +43,7 @@ const nodeTypes = [
   association,
   pool,
   poolLane,
+  boundaryEvent,
 ];
 
 window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode, registerBpmnExtension })  => {


### PR DESCRIPTION
The purpose of this PR is to identified what functionality we can use from the first iteration of boundary events to create a base boundary event component that other boundary types will inherent.

**Currently Boundary Events can**
- Drag on to task elements (task, manual task, script task, connector and call activity)
   - In Camunda, you cannot render boundary events on connects(needs to be clarified with Alan)
- Crown for deleting boundary event
- Support for solid and dashed borders
- Name

**Boundary Events cannot**
- Reposition around the border of the element with 3 connection points per side (for a total of 12)
- Crown for add flow elements
   - issues with rendering flows when uploading
- Inspector configuration
   - clarify to identify the base inspector properties
- Icon
   - Icon does not load for the chosen boundary event type ex. if you upload diagram with a boundary timer event, the icon is missing
- Can be moved between connection points 
- Can be moved between other tasks

This list can be broken out into their own issues.

Reference #581 