### PR TITLE
Allow boundary events to snap to edges of tasks

### DIFF
--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -11,38 +11,7 @@ import { id as callActivityId } from '@/components/nodes/callActivity';
 import { id as manualTaskId } from '@/components/nodes/manualTask';
 import { id as scriptTaskId } from '@/components/nodes/scriptTask';
 import portsConfig from '@/mixins/portsConfig';
-import { portGroups } from '@/mixins/portsConfig';
-import { g } from 'jointjs';
-
-function getPointFromGroup(model, group) {
-  const { x: shapeX, y: shapeY } = model.position();
-  const { x, y } = Object.values(model.getPortsPositions(group))[0];
-  return new g.Point(shapeX + x, shapeY + y);
-}
-
-function getPortPoints(model) {
-  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
-}
-
-function closestPort(model, anchorReference) {
-  return getPortPoints(model).sort((p1, p2) => {
-    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
-    return referencePoint.distance(p1) - referencePoint.distance(p2);
-  })[0];
-}
-
-function hasPorts(model) {
-  return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
-}
-
-function snapToAnchor(coords, model) {
-  if (!hasPorts(model)) {
-    const { x, y } = model.position();
-    const { width, height } = model.size();
-    return new g.Point(x - (width / 2), y - (height / 2));
-  }
-  return closestPort(model, coords);
-}
+import { getAnchorCoordinates } from '@/snapToAnchor';
 
 export default {
   props: ['graph', 'node'],
@@ -111,9 +80,9 @@ export default {
       this.shape.attr('label/text', this.node.definition.get('name'));
       this.shape.component = this;
     },
-    updateSnappingPosition(task) {
-      const {x, y} = snapToAnchor(this.shape.position(), task);
-      const {width} = this.shape.size();
+    updateShapePosition(task) {
+      const { x, y } = getAnchorCoordinates(this.shape.position(), task);
+      const { width } = this.shape.size();
       this.shape.position(x - (width / 2), y - (width / 2));
       this.updateCrownPosition();
     },
@@ -127,13 +96,13 @@ export default {
       task.embed(this.shape);
       this.node.definition.set('attachedToRef', task.component.node.definition);
       this.toggleInterruptingStyle(this.node.definition.cancelActivity);
-      this.updateSnappingPosition(task);
+      this.updateShapePosition(task);
 
       this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
         if (cellView.model !== this.shape) {
           return;
         }
-        this.updateSnappingPosition(task);
+        this.updateShapePosition(task);
       });
     },
   },

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -10,10 +10,43 @@ import { id as taskId } from '@/components/nodes/task';
 import { id as callActivityId } from '@/components/nodes/callActivity';
 import { id as manualTaskId } from '@/components/nodes/manualTask';
 import { id as scriptTaskId } from '@/components/nodes/scriptTask';
+import portsConfig from '@/mixins/portsConfig';
+import { portGroups } from '@/mixins/portsConfig';
+import { g } from 'jointjs';
+
+function getPointFromGroup(model, group) {
+  const { x: shapeX, y: shapeY } = model.position();
+  const { x, y } = Object.values(model.getPortsPositions(group))[0];
+  return new g.Point(shapeX + x, shapeY + y);
+}
+
+function getPortPoints(model) {
+  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
+}
+
+function closestPort(model, anchorReference) {
+  return getPortPoints(model).sort((p1, p2) => {
+    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
+    return referencePoint.distance(p1) - referencePoint.distance(p2);
+  })[0];
+}
+
+function hasPorts(model) {
+  return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
+}
+
+function snapToAnchor(coords, model) {
+  if (!hasPorts(model)) {
+    const { x, y } = model.position();
+    const { width, height } = model.size();
+    return new g.Point(x - (width / 2), y - (height / 2));
+  }
+  return closestPort(model, coords);
+}
 
 export default {
   props: ['graph', 'node'],
-  mixins: [crownConfig],
+  mixins: [crownConfig, portsConfig],
   data() {
     return {
       shape: null,
@@ -78,6 +111,12 @@ export default {
       this.shape.attr('label/text', this.node.definition.get('name'));
       this.shape.component = this;
     },
+    updateSnappingPosition(task) {
+      const {x, y} = snapToAnchor(this.shape.position(), task);
+      const {width} = this.shape.size();
+      this.shape.position(x - (width / 2), y - (width / 2));
+      this.updateCrownPosition();
+    },
     attachBoundaryEventToTask() {
       const task = this.getTaskUnderShape();
 
@@ -88,6 +127,14 @@ export default {
       task.embed(this.shape);
       this.node.definition.set('attachedToRef', task.component.node.definition);
       this.toggleInterruptingStyle(this.node.definition.cancelActivity);
+      this.updateSnappingPosition(task);
+
+      this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
+        if (cellView.model !== this.shape) {
+          return;
+        }
+        this.updateSnappingPosition(task);
+      });
     },
   },
   mounted() {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -106,10 +106,11 @@ export default {
       });
     },
   },
-  mounted() {
+  async mounted() {
     this.shape = new EventShape();
     this.setShapeProperties();
     this.shape.addTo(this.graph);
+    await this.$nextTick();
     this.attachBoundaryEventToTask();
   },
 };

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -1,42 +1,9 @@
-import { shapes, linkTools, dia, g } from 'jointjs';
+import { shapes, linkTools, dia } from 'jointjs';
 import pull from 'lodash/pull';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
 import { validNodeColor, invalidNodeColor, defaultNodeColor, poolColor } from '@/components/nodeColors';
-import { portGroups } from '@/mixins/portsConfig';
-
-function getPointFromGroup(view, group) {
-  const { x: shapeX, y: shapeY } = view.model.position();
-  const { x, y } = Object.values(view.model.getPortsPositions(group))[0];
-
-  return new g.Point(shapeX + x, shapeY + y);
-}
-
-function getPortPoints(view) {
-  return portGroups.map(group => getPointFromGroup(view, group));
-}
-
-function closestPort(endView, anchorReference) {
-  return getPortPoints(endView).sort((p1, p2) => {
-    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
-    return referencePoint.distance(p1) - referencePoint.distance(p2);
-  })[0];
-}
-
-function hasPorts(view) {
-  return Object.values(view.model.getPortsPositions(portGroups[0])).length > 0;
-}
-
-function snapToAnchor(coords, endView) {
-  if (!hasPorts(endView)) {
-    const { x, y } = endView.model.position();
-    const { width, height } = endView.model.size();
-
-    return new g.Point(x + (width / 2), y + (height / 2));
-  }
-
-  return closestPort(endView, coords);
-}
+import { snapToAnchor, closestPort } from '@/snapToAnchor';
 
 const endpoints = {
   source: 'source',
@@ -120,7 +87,7 @@ export default {
             y: y + connectionOffset.y,
           };
 
-          return closestPort(shape.findView(this.paper), connectionPoint);
+          return closestPort(shape.findView(this.paper).model, connectionPoint);
         };
       } else {
         anchor = {

--- a/src/snapToAnchor.js
+++ b/src/snapToAnchor.js
@@ -11,7 +11,7 @@ function getPortPoints(model) {
   return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
 }
 
-function closestPort(model, anchorReference) {
+export function closestPort(model, anchorReference) {
   return getPortPoints(model).sort((p1, p2) => {
     const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
     return referencePoint.distance(p1) - referencePoint.distance(p2);
@@ -29,4 +29,8 @@ export function getAnchorCoordinates(coords, model) {
     return new g.Point(x - (width / 2), y - (height / 2));
   }
   return closestPort(model, coords);
+}
+
+export function snapToAnchor(coords, endView) {
+  return getAnchorCoordinates(coords, endView.model);
 }

--- a/src/snapToAnchor.js
+++ b/src/snapToAnchor.js
@@ -1,0 +1,32 @@
+import { portGroups } from '@/mixins/portsConfig';
+import { g } from 'jointjs/dist/joint';
+
+function getPointFromGroup(model, group) {
+  const { x: shapeX, y: shapeY } = model.position();
+  const { x, y } = Object.values(model.getPortsPositions(group))[0];
+  return new g.Point(shapeX + x, shapeY + y);
+}
+
+function getPortPoints(model) {
+  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
+}
+
+function closestPort(model, anchorReference) {
+  return getPortPoints(model).sort((p1, p2) => {
+    const referencePoint = new g.Point(anchorReference.x, anchorReference.y);
+    return referencePoint.distance(p1) - referencePoint.distance(p2);
+  })[0];
+}
+
+function hasPorts(model) {
+  return Object.values(model.getPortsPositions(portGroups[0])).length > 0;
+}
+
+export function getAnchorCoordinates(coords, model) {
+  if (!hasPorts(model)) {
+    const { x, y } = model.position();
+    const { width, height } = model.size();
+    return new g.Point(x - (width / 2), y - (height / 2));
+  }
+  return closestPort(model, coords);
+}

--- a/src/snapToAnchor.js
+++ b/src/snapToAnchor.js
@@ -8,7 +8,7 @@ function getPointFromGroup(model, group) {
 }
 
 function getPortPoints(model) {
-  return portGroups.filter(group => group !== 'absolute').map(group => getPointFromGroup(model, group));
+  return portGroups.map(group => getPointFromGroup(model, group));
 }
 
 export function closestPort(model, anchorReference) {


### PR DESCRIPTION
Related #593 

It snaps to edges but it doesn't have as many connections as required. Need to expand that number.