### PR TITLE
Persist Sequence flow on boundary events in XML

### DIFF
--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -4,6 +4,7 @@
 
 <script>
 import crownConfig from '@/mixins/crownConfig';
+import portsConfig from '@/mixins/portsConfig';
 import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
 import { id as taskId } from '@/components/nodes/task';
@@ -13,7 +14,7 @@ import { id as scriptTaskId } from '@/components/nodes/scriptTask';
 
 export default {
   props: ['graph', 'node'],
-  mixins: [crownConfig],
+  mixins: [crownConfig, portsConfig],
   data() {
     return {
       shape: null,

--- a/tests/e2e/fixtures/boundaryEvent.xml
+++ b/tests/e2e/fixtures/boundaryEvent.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:sequenceFlow id="node_4" name="New Sequence Flow" sourceRef="node_5" targetRef="node_3" pm:startEvent="" />
+    <bpmn:task id="node_1" name="Task" />
+    <bpmn:task id="node_2" name="Task">
+      <bpmn:incoming>node_5</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:boundaryEvent id="node_3" name="New Boundary Event" attachedToRef="node_1">
+      <bpmn:outgoing>node_5</bpmn:outgoing>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="node_5" name="New Sequence Flow" sourceRef="node_3" targetRef="node_2" pm:startEvent="" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNEdge id="node_4_di" bpmnElement="node_4">
+        <di:waypoint x="348" y="228" />
+        <di:waypoint x="310.5" y="430.5" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="151" y="239" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="160" y="440" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="201" y="303" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_5_di" bpmnElement="node_5">
+        <di:waypoint x="219" y="321" />
+        <di:waypoint x="219" y="478.5" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -336,14 +336,12 @@ describe('Modeler', () => {
   it('persist boundary event with sequence flow in XML', () => {
     uploadXml('../fixtures/boundaryEvent.xml');
 
-    const sequneceFlowXML = '<bpmn:sequenceFlow id="node_4" name="New Sequence Flow" sourceRef="node_5" targetRef="node_3" pm:startEvent="" />';
+    const sequenceFlowXML = '<bpmn:sequenceFlow id="node_4" name="New Sequence Flow" sourceRef="node_5" targetRef="node_3" pm:startEvent="" />';
 
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
       .its('xml')
       .then(xml => removeIndentationAndLinebreaks(xml))
-      .then(xml => {
-        expect(xml).to.contain(sequneceFlowXML);
-      });
+      .then(xml => expect(xml).to.contain(sequenceFlowXML));
   });
 });

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -10,6 +10,7 @@ import {
   isElementCovered,
   getCrownButtonForElement,
   uploadXml,
+  removeIndentationAndLinebreaks,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
@@ -330,5 +331,19 @@ describe('Modeler', () => {
     cy.get('[data-tool-name=vertices]').trigger('mouseup', 'bottomLeft', { force: true });
     cy.get('[data-tool-name=vertices]').trigger('mouseover', 'bottomLeft', { force: true });
     cy.get('.joint-marker-vertex').should('be.visible');
+  });
+
+  it('persist boundary event with sequence flow in XML', () => {
+    uploadXml('../fixtures/boundaryEvent.xml');
+
+    const sequneceFlowXML = '<bpmn:sequenceFlow id="node_4" name="New Sequence Flow" sourceRef="node_5" targetRef="node_3" pm:startEvent="" />';
+
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window()
+      .its('xml')
+      .then(xml => removeIndentationAndLinebreaks(xml))
+      .then(xml => {
+        expect(xml).to.contain(sequneceFlowXML);
+      });
   });
 });


### PR DESCRIPTION
The purpose of this PR is to fix the bug where sequence flows(boundary event) were not saving in the XML. This caused undo/redo and uploading to be broken.

**How to test**

a. Upload a XML with a boundary event and sequence flow
b. Create a diagram with boundary event and sequence flow
     - undo / redo adding sequence flow

Boundary events with sequence flows behave normally like the other elements with sequence flows.


Test was added to cover this bug.

Fixes #590  
