### PR TITLE
Allow messages flows to connect to other elements in other pools

### DIFF
--- a/src/components/nodes/messageFlow/messageFlow.vue
+++ b/src/components/nodes/messageFlow/messageFlow.vue
@@ -38,7 +38,6 @@ export default {
       return this.hasTargetType() &&
         this.targetIsNotALane() &&
         this.targetIsNotContainingPool() &&
-        this.targetIsInDifferentPool() &&
         this.targetIsNotSource() &&
         this.validateOutgoing();
     },
@@ -56,20 +55,6 @@ export default {
     },
     targetIsPool() {
       return this.targetType === poolId;
-    },
-    targetIsInDifferentPool() {
-      if (this.targetIsPool()) {
-        return true;
-      }
-
-      if (this.targetIsIntermediateCatchEvent()) {
-        return true;
-      }
-
-      const targetPool = this.target.component.node.pool;
-      const sourcePool = this.sourceShape.component.node.pool;
-
-      return sourcePool != null && sourcePool !== targetPool;
     },
     targetIsNotSource() {
       return this.targetNode.definition.id !== this.sourceNode.definition.id;

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -54,4 +54,25 @@ describe('Message Flows', () => {
         expect($links.length).to.eq(numberOfMessageFlowsAdded);
       });
   });
+
+  it('Can connect to elements in different pools', () => {
+    const pool1Position = { x: 250, y: 250 };
+    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+
+    const pool2Position = { x: 250, y: 500 };
+    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+
+    const offset = 100;
+    const taskPosition = { x: pool2Position.x + offset, y: pool2Position.y + offset };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    connectNodesWithFlow('message-flow-button', pool1Position, taskPosition);
+
+    const numberOfMessageFlowsAdded = 1;
+    getElementAtPosition(taskPosition)
+      .then(getLinksConnectedToElement)
+      .should($links => {
+        expect($links.length).to.eq(numberOfMessageFlowsAdded);
+      });
+  });
 });


### PR DESCRIPTION
The purpose of this PR is to allow pool message flows to connect to elements in different pools.

**How to test**
- Drag two pool onto paper
- Drag a task onto one pool
- Connect with message flow from pool B to task in Pool A

**Behaviour** 
- Elements are connected with a message flow

**Note**
- There is a layering issue with message flows

Fixes #611 