### PR TITLE
Clicking on boundary event snaps it to another position

### DIFF
--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -88,7 +88,7 @@ export default {
       this.toggleInterruptingStyle(this.node.definition.cancelActivity);
       this.updateShapePosition(task);
 
-      this.shape.listenTo(this.paper, 'element:pointerup', cellView => {
+      this.shape.listenTo(this.paper, 'element:pointermove', cellView => {
         if (cellView.model !== this.shape) {
           return;
         }


### PR DESCRIPTION
Closes #617

Snapping on drag also seems to make it less janky when trying to get it to snap to the right point.
https://www.dropbox.com/s/lh2q7gbuzkcb6bp/dragToSnap.mov