### PR TITLE
Feature/2296

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9175,7 +9175,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9196,12 +9197,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9216,17 +9219,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9343,7 +9349,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9355,6 +9362,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9369,6 +9377,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9376,12 +9385,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9400,6 +9411,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9480,7 +9492,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9492,6 +9505,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9577,7 +9591,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9613,6 +9628,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9632,6 +9648,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9675,12 +9692,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10711,7 +10730,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -10768,6 +10788,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -17909,7 +17930,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -19569,7 +19591,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
@@ -19629,7 +19652,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
@@ -20822,11 +20845,6 @@
       "version": "2.8.20",
       "resolved": "https://registry.npmjs.org/vue-upload-component/-/vue-upload-component-2.8.20.tgz",
       "integrity": "sha512-zrnJvULu4rnZe36Ib2/AZrI/h/mmNbUJZ+acZD652PyumzbvjCOQeYHe00sGifTdYjzzS66CwhTT+ubZ2D0Aow=="
-    },
-    "vuejs-datepicker": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/vuejs-datepicker/-/vuejs-datepicker-1.5.4.tgz",
-      "integrity": "sha512-AVzgu3pb/fF/Sj3qu8YPnp7KhtsXkm8TSnBEcyYsWb1bMJr5FdPCxuIzISgw5kq0It7HkVJUGXQ4CiCwq9hhww=="
     },
     "vuex": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "vue": "^2.5.17",
     "vue-deepset": "^0.6.3",
     "vue-upload-component": "^2.8.14",
-    "vuejs-datepicker": "^1.5.4",
     "vuex": "^3.0.1"
   },
   "devDependencies": {

--- a/src/components/inspectors/DateTimeExpression.vue
+++ b/src/components/inspectors/DateTimeExpression.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="mt-3">
     <form-date-picker
+      :data-test="'date-time'"
       :label="$t('Wait until specific date/time')"
       control-class="form-control"
-      :format="DateTime.DATETIME_SHORT"
-      :minuteStep="30"
+      :data-format="'datetime'"
+      :format="'MM/DD/YYYY h:mm A'"
       class="p-0"
-      :phrases="{ ok: $t('Save'), cancel: $t('Cancel') }"
       :value="value"
       @input="$emit('input', $event)"
     />

--- a/src/components/inspectors/TimerExpression.vue
+++ b/src/components/inspectors/TimerExpression.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="form-group">
     <form-date-picker
-      data-test="start-date-picker"
+      :data-test="'start-date-picker'"
       :label="$t('Start date')"
       :placeholder="$t('Start date')"
       control-class="form-control"
+      :data-format="'datetime'"
+      format="MM/DD/YYYY h:mm A"
       class="p-0"
       :value="startDate"
       @input="setStartDate"
@@ -50,12 +52,14 @@
         <b-form-group class="p-0 mb-1" :description="`${$t('Please click On to select a date')}.`">
           <b-form-radio v-model="ends" class="pl-3 ml-2 mb-1" name="optradio" value="ondate" data-test="ends-on">{{ $t('On') }}</b-form-radio>
           <form-date-picker
-            data-test="end-date-picker"
+            :data-test="'end-date-picker'"
             class="form-date-picker p-0 m-0"
             :class="{'date-disabled' : ends !== 'ondate'}"
             :disabled="ends !== 'ondate'"
             :placeholder="$t('End date')"
             control-class="form-control"
+            :data-format="'datetime'"
+            :format="'MM/DD/YYYY h:mm A'"
             :value="endDate"
             @input="setEndDate"
           />
@@ -199,7 +203,6 @@ export default {
     getFormattedDateWithWeekdayIntervals() {
       const dateIntervals = [];
       dateIntervals.push(this.startDate);
-
       this.selectedWeekdays.forEach(day => {
         const weekDayDate = this.getWeekDayDate(day);
         const isoDateString = this.getIso8601FormattedDateString(weekDayDate);

--- a/src/components/inspectors/TimerExpression.vue
+++ b/src/components/inspectors/TimerExpression.vue
@@ -6,9 +6,6 @@
       :placeholder="$t('Start date')"
       control-class="form-control"
       class="p-0"
-      :format="DateTime.DATETIME_SHORT"
-      :minuteStep="30"
-      :phrases="{ ok: 'Save', cancel: 'Cancel' }"
       :value="startDate"
       @input="setStartDate"
     />
@@ -54,14 +51,11 @@
           <b-form-radio v-model="ends" class="pl-3 ml-2 mb-1" name="optradio" value="ondate" data-test="ends-on">{{ $t('On') }}</b-form-radio>
           <form-date-picker
             data-test="end-date-picker"
-            type="date"
             class="form-date-picker p-0 m-0"
             :class="{'date-disabled' : ends !== 'ondate'}"
             :disabled="ends !== 'ondate'"
             :placeholder="$t('End date')"
             control-class="form-control"
-            :format="DateTime.DATE_SHORT"
-            phrases='{ok: $t("Save"), cancel: $t("Cancel")}'
             :value="endDate"
             @input="setEndDate"
           />
@@ -163,7 +157,7 @@ export default {
     },
     repeatOnValidationError() {
       const numberOfSelectedWeekdays = this.weekdays.filter(({ selected }) => selected).length;
-
+      
       if (this.periodicity !== 'week' || numberOfSelectedWeekdays > 0) {
         return null;
       }
@@ -189,7 +183,6 @@ export default {
      */
     sameDay() {
       const currentWeekday = DateTime.fromISO(this.startDate, { zone: 'utc' }).toLocal().weekday;
-
       return this.selectedWeekdays.length === 1 &&
         this.weekdays.find(({ day }) => day === currentWeekday).selected;
     },

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -53,11 +53,12 @@ describe('Intermediate Catch Event', () => {
 
     cy.contains('Timing Control').click();
     cy.get('[data-test=intermediateTypeSelect]').select('Date/Time');
-    const startDateValue = '2019-02-27';
-    typeIntoTextInput('.start-date', startDateValue);
-
-    const startTimeValue = '00:30';
-    cy.get('[data-test=startTime]').select(startTimeValue, { force: true });
+    cy.get('[data-test=date-time]').click();
+    cy.get('.bootstrap.datetimepicker-widget').contains('27').click();
+    cy.get('[data-action="togglePicker"]').click();
+    cy.get('[data-action="decrementHours"]').click();
+    cy.get('[data-action="incrementMinutes"]').click();
+    cy.get('[data-action="close"]').click();
 
     const validIntermediateCatchEventXML = `
     <bpmn:intermediateCatchEvent id="node_4" name="testing">
@@ -87,7 +88,7 @@ describe('Intermediate Catch Event', () => {
     cy.contains('Timing Control').click();
     cy.get('[data-test=intermediateTypeSelect]').select('Date/Time');
 
-    const defaultTimeDate = '<bpmn:timeDate>1970-01-01T00:00:00.000Z</bpmn:timeDate>';
+    const defaultTimeDate = '<bpmn:timeDate>1970-01-01T00:00:00+00:00</bpmn:timeDate>';
 
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -113,7 +113,7 @@ describe('Modeler', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     getElementAtPosition(taskPosition).click();
-    cy.get('#accordion-button-advanced').click();
+    cy.get('.button-label').contains('Advanced').click();
 
     cy.get('[name=id]').should('have.value', 'node_2');
 

--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -26,23 +26,26 @@ describe('Start Timer Event', () => {
     cy.get('.border-primary').should('contain', 'T');
 
     cy.get('[data-test=start-date-picker]').click();
-    cy.wait(modalAnimationTime);
-    cy.get('.vdatetime-popup').contains('14').click();
-    cy.get('.vdatetime-time-picker__list--hours').contains('05').click({ force: true });
-    cy.get('.vdatetime-time-picker__list--minutes').contains('30').click();
-    cy.get('.vdatetime-popup').contains('Save').click();
-    cy.get('[data-test=start-date-picker]').should('have.value', '8/14/2019, 5:30 AM');
+    cy.get('.bootstrap-datetimepicker-widget').contains('14').click();
+    cy.get('[data-action="togglePicker"]').click();
+    cy.get('[data-action="decrementHours"]').click();
+    cy.get('[data-action="incrementMinutes"]').click();
+    cy.get('[data-action="close"]').click();
+    cy.get('[data-test=start-date-picker]').should('have.value', '08/14/2019 1:01 PM' );
 
     typeIntoTextInput('[data-test=repeat-input]', 3);
     cy.get('[data-test=day-3]').click();
     cy.contains('You must select at least one day.').should('not.exist');
     cy.get('[data-test=ends-on]').click('left');
     cy.get('[data-test=end-date-picker]').click();
-    cy.wait(modalAnimationTime);
-    cy.get('.vdatetime-popup').contains('22').click();
-    cy.get('[data-test=end-date-picker]').should('have.value', '8/22/2019');
+    cy.get('.bootstrap-datetimepicker-widget').contains('22').click();
+    cy.get('[data-action="togglePicker"]').click();
+    cy.get('[data-action="decrementHours"]').click();
+    cy.get('[data-action="incrementMinutes"]').click();
+    cy.get('[data-action="close"]').click();
+    cy.get('[data-test=end-date-picker]').should('have.value', '08/22/2019 12:02 PM');
 
-    const timerExpression1 = 'R/2019-08-14T05:30:00.000Z/P3W/2019-08-22T05:30:00.000Z';
+    const timerExpression1 = 'R/2019-08-14T13:01:00.000Z/P3W/2019-08-22T13:01:00.000Z';
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
       .its('xml')
@@ -53,10 +56,10 @@ describe('Start Timer Event', () => {
     cy.get('[data-test=day-4]').click();
 
     const timerExpression2 = [
-      '2019-08-14T05:30:00.000Z',
-      'R/2019-08-20T05:30:00.000Z/P3W/2019-08-22T05:30:00.000Z',
-      'R/2019-08-14T05:30:00.000Z/P3W/2019-08-22T05:30:00.000Z',
-      'R/2019-08-15T05:30:00.000Z/P3W/2019-08-22T05:30:00.000Z',
+      '2019-08-14T13:01:00.000Z',
+      'R/2019-08-20T13:01:00.000Z/P3W/2019-08-22T13:01:00.000Z',
+      'R/2019-08-14T13:01:00.000Z/P3W/2019-08-22T13:01:00.000Z',
+      'R/2019-08-15T13:01:00.000Z/P3W/2019-08-22T13:01:00.000Z',
     ].join('|');
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
@@ -64,6 +67,8 @@ describe('Start Timer Event', () => {
       .then(xml => xml.trim())
       .should('contain', timerExpression2);
   });
+
+  
 
   it('Updates properties for periodicity other than "week"', function() {
     const year = 2019;
@@ -86,7 +91,8 @@ describe('Start Timer Event', () => {
     cy.get('[data-test=end-date-picker]').click();
     cy.wait(modalAnimationTime);
     const endDay = 22;
-    cy.get('.vdatetime-popup').contains(endDay).click();
+    cy.get('.bootstrap-datetimepicker-widget').contains(endDay).click();
+    cy.get('[data-action="close"]').click();
 
     const periods = [
       { selector: 'day', letter: 'D' },

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -226,7 +226,7 @@ describe('Undo/redo', () => {
 
     waitToRenderAllShapes();
     getElementAtPosition(startEventPosition).click();
-    cy.get('#accordion-button-advanced').click();
+    cy.get('.button-label').contains('Advance').click();
 
     const newId = '1234';
     const newName = 'foobar';


### PR DESCRIPTION
**Changes:**
- Allows the new Date Picker using `vue-bootstrap-datetimepicker` to work with both the `Start Timer Event` & `Intermediate Timer Event`. 
- Removes `vuejs-datepicker`
- Fixes failing ci tests

**This branch is dependent on:**
[vue-form-elements/2296](https://github.com/ProcessMaker/vue-form-elements/pull/83)

closes [2296](https://github.com/ProcessMaker/processmaker/issues/2296)