### PR TITLE
Remove base boundary event type from inspector config

### DIFF
--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -2,6 +2,7 @@ import component from './boundaryTimerEvent.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
+
 export const defaultDurationValue = 'PT1H';
 
 export default {
@@ -74,6 +75,9 @@ export default {
         setNodeProp(node, key, value[key]);
       }
     }
+  },
+  validateIncoming() {
+    return false;
   },
   inspectorConfig: [
     {

--- a/src/setup/defaultNodes.js
+++ b/src/setup/defaultNodes.js
@@ -1,30 +1,28 @@
 /* Expression example */
 import bpmnExtension from '@processmaker/processmaker-bpmn-moddle/resources/processmaker.json';
-
 /* Our initial node types to register with our modeler */
 import {
   association,
-  endEvent,
-  exclusiveGateway,
-  parallelGateway,
-  inclusiveGateway,
-  eventBasedGateway,
-  sequenceFlow,
-  messageFlow,
-  startEvent,
-  startTimerEvent,
-  intermediateTimerEvent,
-  intermediateMessageCatchEvent,
-  task,
+  boundaryTimerEvent,
   callActivity,
-  scriptTask,
-  serviceTask,
+  endEvent,
+  eventBasedGateway,
+  exclusiveGateway,
+  inclusiveGateway,
+  intermediateMessageCatchEvent,
+  intermediateTimerEvent,
   manualTask,
-  textAnnotation,
+  messageFlow,
+  parallelGateway,
   pool,
   poolLane,
-  boundaryEvent,
-  boundaryTimerEvent,
+  scriptTask,
+  sequenceFlow,
+  serviceTask,
+  startEvent,
+  startTimerEvent,
+  task,
+  textAnnotation,
 } from '@/components/nodes';
 
 const nodeTypes = [
@@ -44,11 +42,10 @@ const nodeTypes = [
   association,
   pool,
   poolLane,
-  boundaryEvent,
   boundaryTimerEvent,
 ];
 
-window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode, registerBpmnExtension })  => {
+window.ProcessMaker.EventBus.$on('modeler-init', ({ registerNode, registerBpmnExtension }) => {
   registerNode(startEvent);
   registerNode(startTimerEvent, definition => {
     const eventDefinitions = definition.get('eventDefinitions');


### PR DESCRIPTION
This PR stops users selecting base boundary events as these are purely for programmatic extension in the code. I also refactored/edited the tests to work with boundary timer events.

Resolves #627 