### PR TITLE
Enabled skipped Boundary Timer Events tests

### DIFF
--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -465,7 +465,7 @@ describe('Boundary Timer Event', () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     const boundaryEventPosition = { x: 300, y: 250 };
-    dragFromSourceToDest(nodeTypes.boundaryEvent, boundaryEventPosition);
+    dragFromSourceToDest(nodeTypes.boundaryTimerEvent, boundaryEventPosition);
 
     const boundaryEventConnectedPosition = { x: 282, y: 239 };
     getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);


### PR DESCRIPTION
Resolves https://github.com/ProcessMaker/modeler/issues/623

Removed test that was no longer relevant. Updated skipped tests to boundary timer event types.