### PR TITLE
Fix element position on parse

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -679,9 +679,20 @@ export default {
       diagram.bounds.x = (clientX - paperOrigin.x) / scale.sx;
       diagram.bounds.y = (clientY - paperOrigin.y) / scale.sy;
 
+      if (this.isBoundaryEvent(definition)) {
+        this.setShapeCenterUnderCursor(diagram);
+      }
+
       // Our BPMN models are updated, now add to our nodes
       // @todo come up with random id
       this.addNode({ type: control.type, definition, diagram });
+    },
+    isBoundaryEvent(definition) {
+      return definition.$type === 'bpmn:BoundaryEvent';
+    },
+    setShapeCenterUnderCursor(diagram) {
+      diagram.bounds.x = diagram.bounds.x - (diagram.bounds.width / 2);
+      diagram.bounds.y = diagram.bounds.y - (diagram.bounds.height / 2);
     },
     addNode({ type, definition, diagram }) {
       /*

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -85,13 +85,23 @@ export default {
 
       return x !== prevX || y !== prevY;
     },
+    getCenterPosition() {
+      const { x, y } = this.shape.position();
+      const { width, height } = this.shape.size();
+
+      return {
+        x: x + (width / 2),
+        y: y + (height / 2),
+      };
+    },
     updateShapePosition(task) {
       if (!this.hasPositionChanged()) {
         return;
       }
-      const { x, y } = getBoundaryAnchorPoint(this.shape.position(), task);
-      const { width } = this.shape.size();
-      this.shape.position(x - (width / 2), y - (width / 2));
+
+      const { x, y } = getBoundaryAnchorPoint(this.getCenterPosition(), task);
+      const { width, height } = this.shape.size();
+      this.shape.position(x - (width / 2), y - (height / 2));
       this.updateCrownPosition();
 
       this.previousPosition = this.shape.position();
@@ -135,6 +145,7 @@ export default {
       this.validPosition = this.shape.position();
       this.shape.listenToOnce(this.paper, 'cell:pointerup blank:pointerup', () => {
         this.moveBoundaryEventIfOverTask();
+        this.$emit('save-state');
         this.allowSetNodePosition = true;
       });
     },

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -530,4 +530,27 @@ describe('Boundary Timer Event', () => {
         expect($elements).to.have.lengthOf(1);
       });
   });
+
+  it('redo positions it in same location as before undo', function() {
+    const taskPosition = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    const boundaryTimerEventPosition = { x: 300, y: 350 };
+    dragFromSourceToDest(nodeTypes.boundaryTimerEvent, boundaryTimerEventPosition);
+
+    cy.get(boundaryEventSelector).as('boundaryEvent').then($boundaryEvent => {
+      const boundaryEventPosition = $boundaryEvent.position();
+
+      cy.get('[data-test=undo]').click();
+      waitToRenderAllShapes();
+      cy.get('[data-test=redo]').click();
+      waitToRenderAllShapes();
+
+      cy.get('@boundaryEvent').should($boundaryEvent => {
+        const { left, top } = $boundaryEvent.position();
+
+        expect(left).to.equal(boundaryEventPosition.left);
+        expect(top).to.equal(boundaryEventPosition.top);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #632.

**Note:**

To fix the issue, I used the centre of the shape as a reference for finding the closest port to snap to. But, when you drag a shape from the controls list, the shape's _top left_ corner will appear under your cursor, which means that the shape's centre will possibly be closer to a different port.

This means that a user might hover directly over a port, but it may snap to the port closer to the right. This fixes the issue of the boundary event re-appearing in a different location, and it's why I added conditional logic to `Modeler.vue` to ensure it's centre is positioned under the cursor.

