### PR TITLE
Fix failing test: Updates properties for periodicity other than "week"

### DIFF
--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -82,11 +82,15 @@ describe('Start Timer Event', () => {
     const repeat = 3;
     typeIntoTextInput('[data-test=repeat-input]', repeat);
 
-    cy.get('[data-test=ends-on]').click('left');
-    cy.get('[data-test=end-date-picker]').click();
-    cy.wait(modalAnimationTime);
     const endDay = 22;
-    cy.get('.vdatetime-popup').contains(endDay).click();
+    cy.get('[data-test=ends-on]').click('left');
+    cy.get('[data-test=end-date-picker]')
+      .click();
+    cy.get('.form-date-picker')
+      .contains(endDay)
+      .click();
+    cy.get('[data-action="close"]')
+      .click();
 
     const periods = [
       { selector: 'day', letter: 'D' },


### PR DESCRIPTION
Fixes #640.

This PR reduces the number of test failures from 3 to 2. The following two tests should be the only two failing tests on this PR:
* Intermediate Catch Event: Sets default values when switching between types
* Start Timer Event: Update properties on Start Timer Event for "week" periodicity