### PR TITLE
Remove unused dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20882,11 +20882,6 @@
       "resolved": "https://registry.npmjs.org/vue-upload-component/-/vue-upload-component-2.8.20.tgz",
       "integrity": "sha512-zrnJvULu4rnZe36Ib2/AZrI/h/mmNbUJZ+acZD652PyumzbvjCOQeYHe00sGifTdYjzzS66CwhTT+ubZ2D0Aow=="
     },
-    "vuejs-datepicker": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/vuejs-datepicker/-/vuejs-datepicker-1.5.4.tgz",
-      "integrity": "sha512-AVzgu3pb/fF/Sj3qu8YPnp7KhtsXkm8TSnBEcyYsWb1bMJr5FdPCxuIzISgw5kq0It7HkVJUGXQ4CiCwq9hhww=="
-    },
     "vuex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "vue": "^2.5.17",
     "vue-deepset": "^0.6.3",
     "vue-upload-component": "^2.8.14",
-    "vuejs-datepicker": "^1.5.4",
     "vuex": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The `vuejs-datepicker` component (added in https://github.com/ProcessMaker/modeler/commit/a6b0127c7482454aa67a11275e104bbd5ce61041) has been replaced with `vue-form-element`'s `form-date-picker` component, but the unused dependency was not removed. This PR removes the unused dependency. 