### PR TITLE
Restore vertical alignment of text annotations

### DIFF
--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -7,6 +7,7 @@ import { shapes, util } from 'jointjs';
 import connectIcon from '@/assets/connect-artifacts.svg';
 import crownConfig from '@/mixins/crownConfig';
 import portsConfig from '@/mixins/portsConfig';
+import { highlightPadding } from '@/mixins/crownConfig';
 
 export const maxTextAnnotationWidth = 160;
 export default {
@@ -45,7 +46,7 @@ export default {
         newHeight = currentBoundsHeight;
       }
 
-      this.shape.resize(this.nodeWidth, newHeight);
+      this.shape.resize(this.nodeWidth, newHeight - highlightPadding);
     },
     updateNodeText(text) {
       let { height } = this.shape.findView(this.paper).getBBox();


### PR DESCRIPTION
Closes #549 

Text should be in the center again.

Did not yet solve the flicker that occurs after attaching an association flow from the text annotation to a task and then clicking undo/redo.