### PR TITLE
Create ModelerNode class

### DIFF
--- a/src/ModelerNode.js
+++ b/src/ModelerNode.js
@@ -1,0 +1,60 @@
+import { g } from 'jointjs';
+
+export default class ModelerNode {
+  constructor(type, nodeRegistry, moddle, $t) {
+    this.type = type;
+    this.definition = nodeRegistry[type].definition(moddle, $t);
+    this.diagram = nodeRegistry[type].diagram(moddle);
+  }
+
+  isType(bpmnType) {
+    return this.bpmnType === bpmnType;
+  }
+
+  get bpmnType() {
+    return this.definition.$type;
+  }
+
+  getSize() {
+    return {
+      width: this.diagram.bounds.width,
+      height: this.diagram.bounds.height,
+    };
+  }
+
+  setPosition({ x, y }) {
+    this.diagram.bounds.x = x;
+    this.diagram.bounds.y = y;
+  }
+
+  getPosition() {
+    return {
+      x: this.diagram.bounds.x,
+      y: this.diagram.bounds.y,
+    };
+  }
+
+  getCenterPosition() {
+    const { x, y } = this.getPosition();
+    const { width, height } = this.getSize();
+    const rectangle = new g.Rect(x, y, width, height);
+
+    return rectangle.center();
+  }
+
+  setCenterOnPoint({ x, y }) {
+    const { width, height } = this.getSize();
+
+    this.setPosition({
+      x: x - (width / 2),
+      y: y - (height / 2),
+    });
+  }
+
+  static BpmnTypes = {
+    boundaryEvent: 'bpmn:BoundaryEvent',
+    pool: 'bpmn:Participant',
+    exclusiveGateway: 'bpmn:ExclusiveGateway',
+    inclusiveGateway: 'bpmn:InclusiveGateway',
+  }
+}

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -14,6 +14,9 @@ export default {
       associationDirection: `${ direction.none }`,
     });
   },
+  diagram(moddle) {
+    return moddle.create('bpmndi:BPMNEdge');
+  },
   inspectorConfig: [
     {
       name: 'Association',

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -86,21 +86,12 @@ export default {
 
       return x !== prevX || y !== prevY;
     },
-    getCenterPosition() {
-      const { x, y } = this.shape.position();
-      const { width, height } = this.shape.size();
-
-      return {
-        x: x + (width / 2),
-        y: y + (height / 2),
-      };
-    },
     updateShapePosition(task) {
       if (!this.hasPositionChanged()) {
         return;
       }
 
-      const { x, y } = getBoundaryAnchorPoint(this.getCenterPosition(), task);
+      const { x, y } = getBoundaryAnchorPoint(this.node.getCenterPosition(), task);
       const { width, height } = this.shape.size();
       this.shape.position(x - (width / 2), y - (height / 2));
       this.updateCrownPosition();

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -8,8 +8,11 @@ export default {
   component,
   bpmnType: 'bpmn:MessageFlow',
   control: false,
-  definition(moddle, $t) {
-    return moddle.create('bpmn:MessageFlow', { name: $t('Message Flow') });
+  definition(moddle) {
+    return moddle.create('bpmn:MessageFlow', { name: '' });
+  },
+  diagram(moddle) {
+    return moddle.create('bpmndi:BPMNEdge');
   },
   inspectorConfig: [
     {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -18,6 +18,7 @@ import laneBelowIcon from '@/assets/lane-below.svg';
 import { invalidNodeColor, defaultNodeColor, poolColor } from '@/components/nodeColors';
 import pull from 'lodash/pull';
 import store from '@/store';
+import ModelerNode from '@/ModelerNode';
 
 const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
   markup: [
@@ -137,11 +138,11 @@ export default {
        * Get the current laneSet element or create a new one. */
 
       const lanes = [];
+      const node = new ModelerNode('processmaker-modeler-lane', this.nodeRegistry, this.moddle, this.$t);
+
 
       if (!this.laneSet) {
         this.createLaneSet();
-
-        const definition = Lane.definition(this.moddle, this.$t);
 
         /* If there are currently elements in the pool, add them to the first lane */
         this.shape.getEmbeddedCells().filter(element => {
@@ -149,10 +150,10 @@ export default {
             element.component.node.type !== laneId &&
             element.component.node.type !== textAnnotationId;
         }).forEach(element => {
-          definition.get('flowNodeRef').push(element.component.node.definition);
+          node.definition.get('flowNodeRef').push(element.component.node.definition);
         });
 
-        lanes.push(this.pushNewLane(definition));
+        lanes.push(this.pushNewLane(node.definition));
       }
 
       lanes.push(this.pushNewLane());

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -3,6 +3,7 @@ import trashIcon from '@/assets/trash-alt-solid.svg';
 import messageFlowIcon from '@/assets/message-flow.svg';
 import { direction } from '@/components/nodes/association/associationConfig';
 import pull from 'lodash/pull';
+import ModelerNode from '@/ModelerNode';
 
 export const highlightPadding = 3;
 
@@ -130,54 +131,37 @@ export default {
     },
     addSequence(cellView, evt, x, y) {
       this.removeCrown();
-      const sequenceFlowConfig = this.nodeRegistry['processmaker-modeler-sequence-flow'];
-      const sequenceLink = sequenceFlowConfig.definition(this.moddle, this.$t);
-      sequenceLink.set('sourceRef', this.node.definition);
-      sequenceLink.set('targetRef', { x, y });
+      const node = new ModelerNode('processmaker-modeler-sequence-flow', this.nodeRegistry, this.moddle, this.$t);
+      node.definition.set('sourceRef', this.node.definition);
+      node.definition.set('targetRef', { x, y });
 
       if (
-        sequenceLink.sourceRef.$type === 'bpmn:ExclusiveGateway' ||
-        sequenceLink.sourceRef.$type === 'bpmn:InclusiveGateway')
+        node.definition.sourceRef.$type === ModelerNode.exclusiveGateway ||
+        node.definition.sourceRef.$type === ModelerNode.inclusiveGateway)
       {
-        sequenceLink.conditionExpression = this.moddle.create('bpmn:FormalExpression', {
+        node.definition.conditionExpression = this.moddle.create('bpmn:FormalExpression', {
           body: '',
         });
       }
 
-      this.$emit('add-node', {
-        type: 'processmaker-modeler-sequence-flow',
-        definition: sequenceLink,
-        diagram: sequenceFlowConfig.diagram(this.moddle),
-      });
+      this.$emit('add-node', node);
     },
     addAssociation(cellView, evt, x, y) {
       this.removeCrown();
-      const associationLink = this.moddle.create('bpmn:Association', {
-        sourceRef: this.shape.component.node.definition,
-        targetRef: { x, y },
-        associationDirection: direction.none,
-      });
+      const node = new ModelerNode('processmaker-modeler-association', this.nodeRegistry, this.moddle, this.$t);
+      node.definition.set('sourceRef', this.node.definition);
+      node.definition.set('targetRef', { x, y });
+      node.definition.get('associationDirection', direction.none);
 
-      this.$emit('add-node', {
-        type: 'processmaker-modeler-association',
-        definition: associationLink,
-        diagram: this.moddle.create('bpmndi:BPMNEdge'),
-      });
+      this.$emit('add-node', node);
     },
     addMessageFlow(cellView, evt, x, y) {
       this.removeCrown();
+      const node = new ModelerNode('processmaker-modeler-message-flow', this.nodeRegistry, this.moddle, this.$t);
+      node.definition.set('sourceRef', this.node.definition);
+      node.definition.set('targetRef', { x, y });
 
-      const messageFlowDefinition = this.moddle.create('bpmn:MessageFlow', {
-        name: '',
-        sourceRef: this.shape.component.node.definition,
-        targetRef: { x, y },
-      });
-
-      this.$emit('add-node', {
-        type: 'processmaker-modeler-message-flow',
-        definition: messageFlowDefinition,
-        diagram: this.moddle.create('bpmndi:BPMNEdge'),
-      });
+      this.$emit('add-node', node);
     },
     addMessageFlowButton() {
       this.crownConfig.push({


### PR DESCRIPTION
This PR creates a `ModelerNode` class to abstract all node/definition/diagram related functionality. This refactor is a result of the discussion in https://github.com/ProcessMaker/modeler/pull/636.