### PR TITLE
Reposition mini-map and button placement

### DIFF
--- a/src/components/MiniPaper.vue
+++ b/src/components/MiniPaper.vue
@@ -64,8 +64,8 @@ export default {
 </script>
 
 <style lang="scss">
-$mini-paper-container-top-position: 2.5rem;
-$mini-paper-container-right-position: 0;
+$mini-paper-container-top-position: 1rem;
+$mini-paper-container-right-position: 17.5rem;
 
 .mini-paper-container {
   position: absolute;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -20,12 +20,12 @@
     </b-col>
 
     <b-col
-      class="paper-container h-100 pr-4 d-flex"
+      class="paper-container h-100 pr-4"
       ref="paper-container"
       :class="[cursor, { 'grabbing-cursor' : isGrabbing }]"
       :style="{ width: parentWidth, height: parentHeight }"
     >
-      <div class="toolbar d-flex mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
+      <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>
@@ -46,12 +46,12 @@
           <font-awesome-icon  v-if="miniMapOpen" :icon="minusIcon" />
           <font-awesome-icon v-else :icon="mapIcon" />
         </button>
-
-        <mini-paper :isOpen="miniMapOpen" :paper="paper" :graph="graph" />
       </div>
 
       <div ref="paper" data-test="paper" class="main-paper" />
     </b-col>
+    
+    <mini-paper :isOpen="miniMapOpen" :paper="paper" :graph="graph" />
 
     <b-col class="pl-0 h-100 overflow-hidden inspector-column" :class="{ 'ignore-pointer': canvasDragPosition }">
       <InspectorPanel

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -996,8 +996,6 @@ $vertex-error-color: #ED4757;
 
     .toolbar {
       z-index: 1;
-      flex: 1;
-      align-content: flex-start;
       height: $toolbar-height;
 
       > button {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -959,12 +959,6 @@ $controls-column-max-width: 185px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
 
-$tool-bar-spacer-width: 0.5rem;
-$tool-bar-spacer-height: 2rem;
-$tool-bar-spacer-left-position: 6.4rem;
-$tool-bar-spacer-right-position: 2.1rem;
-
-
 .ignore-pointer {
   pointer-events: none;
 }
@@ -1003,36 +997,11 @@ $tool-bar-spacer-right-position: 2.1rem;
     .toolbar {
       z-index: 1;
       height: $toolbar-height;
-
-      &::before {
-        content: '';
-        background: transparent;
-        position: absolute;
-        width: $tool-bar-spacer-width;
-        height: $tool-bar-spacer-height;
-        cursor: auto;
-        z-index: 2;
-        left: $tool-bar-spacer-left-position;
-      }
-
-      &::after {
-        content: '';
-        background: transparent;
-        position: absolute;
-        width: $tool-bar-spacer-width;
-        height: $tool-bar-spacer-height;
-        cursor: auto;
-        z-index: 2;
-        right: $tool-bar-spacer-right-position;
-      }
+      cursor: auto;
 
       > button {
         cursor: pointer;
       }
-    }
-
-    .scale-value {
-      cursor: auto;
     }
   }
 

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -959,6 +959,12 @@ $controls-column-max-width: 185px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
 
+$tool-bar-spacer-width: 0.5rem;
+$tool-bar-spacer-height: 2rem;
+$tool-bar-spacer-left-position: 6.4rem;
+$tool-bar-spacer-right-position: 2.1rem;
+
+
 .ignore-pointer {
   pointer-events: none;
 }
@@ -998,9 +1004,35 @@ $vertex-error-color: #ED4757;
       z-index: 1;
       height: $toolbar-height;
 
+      &::before {
+        content: '';
+        background: transparent;
+        position: absolute;
+        width: $tool-bar-spacer-width;
+        height: $tool-bar-spacer-height;
+        cursor: auto;
+        z-index: 2;
+        left: $tool-bar-spacer-left-position;
+      }
+
+      &::after {
+        content: '';
+        background: transparent;
+        position: absolute;
+        width: $tool-bar-spacer-width;
+        height: $tool-bar-spacer-height;
+        cursor: auto;
+        z-index: 2;
+        right: $tool-bar-spacer-right-position;
+      }
+
       > button {
         cursor: pointer;
       }
+    }
+
+    .scale-value {
+      cursor: auto;
     }
   }
 


### PR DESCRIPTION
Fixes #487.

The purpose of this PR is to reposition the mini-button beside the other controls. Having the mini-map button justified to the right of the paper cause the `tool-bar` div to span to whole width of the paper. This cause a bug where in some cases users were not able to drag the graph.

**Video of the fix**
https://drive.google.com/open?id=1HJKsy3F_sQQCYOPM9pOvNN0P5ru7yM7D