### PR TITLE
Move boundary event to different pool

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -101,6 +101,15 @@ export default {
 
       return this.graph.findModelsInArea(area);
     },
+    moveEmbeddedElements(currentElement, toPool) {
+      this.getElementsUnderArea(currentElement).forEach((element) => {
+        if (element.isEmbeddedIn(currentElement)) {
+          const elementDefinition = element.component.node.definition;
+          pull(this.containingProcess.get('flowElements'), elementDefinition);
+          toPool.component.containingProcess.get('flowElements').push(elementDefinition);
+        }
+      });
+    },
     moveElement(element, toPool) {
       const elementDefinition = element.component.node.definition;
 
@@ -117,13 +126,7 @@ export default {
       pull(this.containingProcess.get('flowElements'), elementDefinition);
 
       toPool.component.containingProcess.get('flowElements').push(elementDefinition);
-      this.getElementsUnderArea(element).forEach(element => {
-        const elementDefinition = element.component.node.definition;
-        if (elementDefinition.$type === 'bpmn:BoundaryEvent') {
-          pull(this.containingProcess.get('flowElements'), elementDefinition);
-          toPool.component.containingProcess.get('flowElements').push(elementDefinition);
-        }
-      });
+      this.moveEmbeddedElements(element, toPool);
 
       element.component.node.pool = toPool;
       this.shape.unembed(element);

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -117,6 +117,14 @@ export default {
       pull(this.containingProcess.get('flowElements'), elementDefinition);
 
       toPool.component.containingProcess.get('flowElements').push(elementDefinition);
+      this.getElementsUnderArea(element).forEach(element => {
+        const elementDefinition = element.component.node.definition;
+        if (elementDefinition.$type === 'bpmn:BoundaryEvent') {
+          pull(this.containingProcess.get('flowElements'), elementDefinition);
+          toPool.component.containingProcess.get('flowElements').push(elementDefinition);
+        }
+      });
+
       element.component.node.pool = toPool;
       this.shape.unembed(element);
       toPool.component.addToPool(element);

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -102,13 +102,13 @@ export default {
       return this.graph.findModelsInArea(area);
     },
     moveEmbeddedElements(currentElement, toPool) {
-      this.getElementsUnderArea(currentElement).forEach((element) => {
-        if (element.isEmbeddedIn(currentElement)) {
-          const elementDefinition = element.component.node.definition;
+      this.getElementsUnderArea(currentElement)
+        .filter(element => element.isEmbeddedIn(currentElement))
+        .map(element => element.component.node.definition)
+        .forEach((elementDefinition) => {
           pull(this.containingProcess.get('flowElements'), elementDefinition);
           toPool.component.containingProcess.get('flowElements').push(elementDefinition);
-        }
-      });
+        });
     },
     moveElement(element, toPool) {
       const elementDefinition = element.component.node.definition;

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -149,6 +149,7 @@ describe('Pools', () => {
       });
   });
 
+
   it('Removes all references to element from a pool', function() {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
@@ -164,6 +165,34 @@ describe('Pools', () => {
     cy.window().its('xml').then(removeIndentationAndLinebreaks).then(xml => {
       expect(xml).to.contain(emptyPool);
       expect(xml).to.not.contain(startEvent);
+    });
+  });
+
+  it('boundary event changes process when dragged to another pool', function() {
+    const poolPosition = { x: 300, y: 300 };
+    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+
+    const pool2Position = { x: 100, y: 500 };
+    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+
+    const taskPosition = { x: 200, y: 200 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    const boundaryTimerEventPosition = { x: 260, y: 260 };
+    dragFromSourceToDest(nodeTypes.boundaryTimerEvent, boundaryTimerEventPosition);
+
+    const pool1taskXml = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /><bpmn:task id="node_4" name="Task" /><bpmn:boundaryEvent id="node_5" name="New Boundary Timer Event" attachedToRef="node_4">';
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window().its('xml').then(removeIndentationAndLinebreaks).then(xml => {
+      expect(xml).to.contain(pool1taskXml);
+    });
+
+    moveElement(taskPosition, 150, 550);
+
+    const pool2taskXml = '<bpmn:process id="process_2"><bpmn:task id="node_4" name="Task" /><bpmn:boundaryEvent id="node_5" name="New Boundary Timer Event" attachedToRef="node_4">';
+    cy.get('[data-test=downloadXMLBtn]').click();
+    cy.window().its('xml').then(removeIndentationAndLinebreaks).then(xml => {
+      expect(xml).to.contain(pool2taskXml);
     });
   });
 });

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -149,7 +149,6 @@ describe('Pools', () => {
       });
   });
 
-
   it('Removes all references to element from a pool', function() {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
@@ -168,7 +167,7 @@ describe('Pools', () => {
     });
   });
 
-  it('boundary event changes process when dragged to another pool', function() {
+  it('moves boundary event to another process when dragged to that pool', function() {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 


### PR DESCRIPTION
Closes #695

Task was getting moved to the other pool but the boundary event remains in the previous pool.

I moved all embedded elements because checking the type seemed to stop the pool from enveloping an element that was touching a corner of the pool (caused a failing test).