### PR TITLE
Made controls column the same width as the inspector.

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-container id="modeler-app" class="h-100 container position-relative">
+  <b-container id="modeler-app" class="h-100 container position-relative p-0">
 
     <b-card no-body class="h-100">
       <b-card-header class="d-flex align-items-center header">

--- a/src/components/MiniPaper.vue
+++ b/src/components/MiniPaper.vue
@@ -57,8 +57,8 @@ export default {
 </script>
 
 <style lang="scss">
-$mini-paper-container-top-position: 2.5rem;
-$mini-paper-container-right-position: 0;
+$mini-paper-container-top-position: 1rem;
+$mini-paper-container-right-position: 17.5rem;
 
 .mini-paper-container {
   position: absolute;

--- a/src/components/MiniPaper.vue
+++ b/src/components/MiniPaper.vue
@@ -57,8 +57,8 @@ export default {
 </script>
 
 <style lang="scss">
-$mini-paper-container-top-position: 1rem;
-$mini-paper-container-right-position: 17.5rem;
+$mini-paper-container-top-position: 2.5rem;
+$mini-paper-container-right-position: 0;
 
 .mini-paper-container {
   position: absolute;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -20,12 +20,12 @@
     </b-col>
 
     <b-col
-      class="paper-container h-100 pr-4"
+      class="paper-container h-100 pr-4 d-flex"
       ref="paper-container"
       :class="[cursor, { 'grabbing-cursor' : isGrabbing }]"
       :style="{ width: parentWidth, height: parentHeight }"
     >
-      <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
+      <div class="toolbar d-flex mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>
@@ -48,7 +48,6 @@
         </button>
       </div>
 
-      <div ref="paper" data-test="paper" class="main-paper" />
     </b-col>
 
     <mini-paper :isOpen="miniMapOpen" :paperManager="paperManager" :graph="graph" />
@@ -952,7 +951,7 @@ export default {
 
 $cursors: default, not-allowed, wait;
 $inspector-column-max-width: 265px;
-$controls-column-max-width: 185px;
+$controls-column-max-width: 265px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
 
@@ -993,8 +992,11 @@ $vertex-error-color: #ED4757;
 
     .toolbar {
       z-index: 1;
+      flex: 1;
+      align-content: flex-start;
       height: $toolbar-height;
       cursor: auto;
+      background-color: #fff;
 
       > button {
         cursor: pointer;

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -20,12 +20,12 @@
     </b-col>
 
     <b-col
-      class="paper-container h-100 pr-4 d-flex"
+      class="paper-container h-100 pr-4"
       ref="paper-container"
       :class="[cursor, { 'grabbing-cursor' : isGrabbing }]"
       :style="{ width: parentWidth, height: parentHeight }"
     >
-      <div class="toolbar d-flex mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
+      <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="First group">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>
@@ -48,6 +48,7 @@
         </button>
       </div>
 
+      <div ref="paper" data-test="paper" class="main-paper" />
     </b-col>
 
     <mini-paper :isOpen="miniMapOpen" :paperManager="paperManager" :graph="graph" />
@@ -992,11 +993,8 @@ $vertex-error-color: #ED4757;
 
     .toolbar {
       z-index: 1;
-      flex: 1;
-      align-content: flex-start;
       height: $toolbar-height;
       cursor: auto;
-      background-color: #fff;
 
       > button {
         cursor: pointer;

--- a/src/components/miniMapManager.js
+++ b/src/components/miniMapManager.js
@@ -11,7 +11,7 @@ export default class {
     const miniMap = new dia.Paper({
       el: element,
       model: graph,
-      width: 300,
+      width: 250,
       height: 200,
       interactive: false,
     });

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -125,7 +125,7 @@ describe('Undo/redo', () => {
     getElementAtPosition(startEventPosition).should('exist');
     getElementAtPosition(startEventMoveToPosition).should('not.exist');
 
-    const taskPosition1 = { x: 50, y: 400 };
+    const taskPosition1 = { x: 150, y: 400 };
     const taskPosition2 = { x: taskPosition1.x + 200, y: taskPosition1.y };
     const taskPosition3 = { x: taskPosition2.x + 200, y: taskPosition2.y };
     dragFromSourceToDest(nodeTypes.task, taskPosition1);


### PR DESCRIPTION
#693 
With less space, had to revert mini-map placement.

Making the columns the same width, gives less room to work with the diagram. This will be solved later.

**Before:**
![Screen Shot 2019-09-30 at 11 19 55 AM](https://user-images.githubusercontent.com/6653340/65892496-6911da80-e374-11e9-8c8a-1f6fe4efbfa7.png)
**After:**
![Screen Shot 2019-09-30 at 4 11 40 PM](https://user-images.githubusercontent.com/6653340/65912929-041eaa80-e39d-11e9-9a72-57be68d8176a.png)
![Screen Shot 2019-09-30 at 2 25 32 PM](https://user-images.githubusercontent.com/6653340/65912826-d6d1fc80-e39c-11e9-9238-528ad765b4ca.png)
