### PR TITLE
Fix display of labels in mini-maps

### DIFF
--- a/src/mixins/hideLabelOnDrag.js
+++ b/src/mixins/hideLabelOnDrag.js
@@ -6,10 +6,10 @@ export default {
         return;
       }
 
-      this.shape.attr('label/visibility', 'hidden');
+      this.shape.attr('label/display', 'none');
     },
     showLabel() {
-      this.shape.attr('label/visibility', 'visible');
+      this.shape.attr('label/display', 'initial');
       this.shape.once('change:position', this.hideLabel);
     },
   },

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -375,7 +375,7 @@ describe('Modeler', () => {
     cy.get(startEventSelector).as('startEvent')
       .should('have.text', startEventLabelText)
       .find('>text')
-      .should('have.css', 'visibility', 'visible');
+      .should('have.css', 'display', 'block');
 
     cy.get('@startEvent')
       .trigger('mousedown')
@@ -383,18 +383,18 @@ describe('Modeler', () => {
         waitToRenderAllShapes();
         cy.wrap($startEvent)
           .find('>text')
-          .should('have.css', 'visibility', 'visible');
+          .should('have.css', 'display', 'block');
       });
 
     cy.get('@startEvent')
       .trigger('mousemove', { clientX: 600, clientY: 600 })
       .find('>text')
-      .should('have.css', 'visibility', 'hidden');
+      .should('have.css', 'display', 'none');
 
     cy.get('@startEvent')
       .trigger('mouseup')
       .find('>text')
-      .should('have.css', 'visibility', 'visible');
+      .should('have.css', 'display', 'block');
 
     const poolPosition = { x: 150, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
@@ -406,6 +406,6 @@ describe('Modeler', () => {
       .then(() => waitToRenderAllShapes())
       .get('@startEvent')
       .find('>text')
-      .should('have.css', 'visibility', 'visible');
+      .should('have.css', 'display', 'block');
   });
 });


### PR DESCRIPTION
This PR fixes an issue where element labels were displayed in mini-maps, even when the rest of the mini-map is hidden.