### PR TITLE
Highlight shape rather than shape and label

### DIFF
--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -55,7 +55,6 @@ export default {
       allowSetNodePosition: true,
       savePositionOnPointerupEventSet: false,
       shape: null,
-      highlightShape: null,
     };
   },
   watch: {

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -26,6 +26,16 @@ const errorHighlighter = {
   },
 };
 
+const defaultHighlighter = {
+  name: 'stroke',
+  options: {
+    attrs: {
+      stroke: '#feb663',
+      'stroke-width': 3,
+    },
+  },
+};
+
 export default {
   props: [
     'highlighted',
@@ -45,15 +55,16 @@ export default {
       allowSetNodePosition: true,
       savePositionOnPointerupEventSet: false,
       shape: null,
+      highlightShape: null,
     };
   },
   watch: {
     highlighted(highlighted) {
       if (highlighted) {
-        this.shapeView.highlight();
+        this.shapeView.highlight(this.selectShape, { highlighter: defaultHighlighter });
         this.addCrown();
       } else {
-        this.shapeView.unhighlight();
+        this.shapeView.unhighlight(this.selectShape, { highlighter: defaultHighlighter });
         this.removeCrown();
       }
     },
@@ -68,6 +79,9 @@ export default {
   computed: {
     shapeView() {
       return this.shape.findView(this.paper);
+    },
+    selectShape() {
+      return this.shapeView.$el.find('[joint-selector=body]');
     },
     isPool() {
       return this.node.type === 'processmaker-modeler-pool';
@@ -236,8 +250,8 @@ export default {
       this.shape.on('change:size', () => {
         if (this.highlighted) {
           /* Ensure the highlight box expands to fit element */
-          shapeView.unhighlight();
-          shapeView.highlight();
+          shapeView.unhighlight(this.selectShape, { highlighter: defaultHighlighter });
+          shapeView.highlight(this.selectShape, { highlighter: defaultHighlighter });
         }
       });
     },

--- a/src/mixins/crownConfig.js
+++ b/src/mixins/crownConfig.js
@@ -60,12 +60,12 @@ export default {
   watch: {
     highlighted(highlighted) {
       if (highlighted) {
-        this.shapeView.highlight(this.selectShape, { highlighter: defaultHighlighter });
+        this.shapeView.highlight(this.shapeBody, { highlighter: defaultHighlighter });
         this.addCrown();
-      } else {
-        this.shapeView.unhighlight(this.selectShape, { highlighter: defaultHighlighter });
-        this.removeCrown();
+        return;
       }
+      this.shapeView.unhighlight(this.shapeBody, { highlighter: defaultHighlighter });
+      this.removeCrown();
     },
     hasError() {
       if (this.isRendering) {
@@ -79,7 +79,7 @@ export default {
     shapeView() {
       return this.shape.findView(this.paper);
     },
-    selectShape() {
+    shapeBody() {
       return this.shapeView.$el.find('[joint-selector=body]');
     },
     isPool() {
@@ -249,8 +249,8 @@ export default {
       this.shape.on('change:size', () => {
         if (this.highlighted) {
           /* Ensure the highlight box expands to fit element */
-          shapeView.unhighlight(this.selectShape, { highlighter: defaultHighlighter });
-          shapeView.highlight(this.selectShape, { highlighter: defaultHighlighter });
+          shapeView.unhighlight(this.shapeBody, { highlighter: defaultHighlighter });
+          shapeView.highlight(this.shapeBody, { highlighter: defaultHighlighter });
         }
       });
     },

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -157,6 +157,8 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet }) => {
 
         waitToRenderAllShapes();
 
+        getElementAtPosition(taskPosition).click();
+
         cy.wrap($boundaryEvent).should($el => {
           const { left, top } = $el.position();
           const positionErrorMargin = 2;

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -4,7 +4,6 @@ import {
   getElementAtPosition,
   getGraphElements,
   getPositionInPaperCoords,
-  moveElement,
   removeIndentationAndLinebreaks,
   typeIntoTextInput,
   uploadXml,
@@ -228,8 +227,6 @@ describe('Boundary Timer Event', () => {
                 expect(xml).to.contain(boundaryEventOnTask2Xml);
               });
 
-            const initialBoundaryEventPosition = $boundaryEvent.position();
-
             getElementAtPosition(taskPosition)
               .then(getComponentsEmbeddedInShape)
               .should($elements => {
@@ -241,24 +238,6 @@ describe('Boundary Timer Event', () => {
               .should($elements => {
                 expect($elements).to.have.lengthOf(numberOfBoundaryTimerEventsAdded);
               });
-
-            moveElement(taskPosition, 200, 400);
-            waitToRenderAllShapes();
-            cy.wrap($boundaryEvent).should($el => {
-              const { left, top } = $el.position();
-              const positionErrorMargin = 2;
-              expect(left).to.be.closeTo(initialBoundaryEventPosition.left, positionErrorMargin);
-              expect(top).to.be.closeTo(initialBoundaryEventPosition.top, positionErrorMargin);
-            });
-
-            moveElement(task2Position, 300, 500);
-            waitToRenderAllShapes();
-            cy.wrap($boundaryEvent).should($el => {
-              const { left, top } = $el.position();
-              const positionErrorMargin = 2;
-              expect(left).to.not.be.closeTo(initialBoundaryEventPosition.left, positionErrorMargin);
-              expect(top).to.not.be.closeTo(initialBoundaryEventPosition.top, positionErrorMargin);
-            });
           });
       });
     });

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -170,6 +170,8 @@ describe('Boundary Timer Event', () => {
           .then($el => $el.find('[joint-selector="body"]'))
           .should('have.attr', 'fill', defaultNodeColor);
 
+        getElementAtPosition(startEventPosition).click();
+
         cy.wrap($boundaryEvent).should($el => {
           const { left, top } = $el.position();
           const positionErrorMargin = 2;


### PR DESCRIPTION
Closes #705

**Estimated appearance:** Using shape instead of a box.
![Screen Shot 2019-10-01 at 4 58 58 PM](https://user-images.githubusercontent.com/6653340/66000135-cbe69d00-e46c-11e9-8f30-10e46b2c41b2.png)

Custom highlight should only show when you click on an element and should update when resizing a pool.

**Note:** I did not alter the error highlighting box. It would revert the select highlight to the shape and label on some elements like gateways.

**Current error highlighting:**
![Screen Shot 2019-10-03 at 10 18 42 AM](https://user-images.githubusercontent.com/6653340/66135096-63f89980-e5c7-11e9-9bb4-8b38c3e4dfb7.png)
