### PR TITLE
Show label after dropping boundary event on another task

### DIFF
--- a/src/mixins/hideLabelOnDrag.js
+++ b/src/mixins/hideLabelOnDrag.js
@@ -8,8 +8,9 @@ export default {
 
       this.shape.attr('label/display', 'none');
     },
-    showLabel() {
+    async showLabel() {
       this.shape.attr('label/display', 'initial');
+      await this.$nextTick();
       this.shape.once('change:position', this.hideLabel);
     },
   },
@@ -18,5 +19,6 @@ export default {
 
     this.shape.once('change:position', this.hideLabel);
     this.shape.listenTo(this.paper, 'cell:pointerup blank:pointerup', this.showLabel);
+    this.shape.on('change:parent', this.showLabel);
   },
 };

--- a/src/mixins/hideLabelOnDrag.js
+++ b/src/mixins/hideLabelOnDrag.js
@@ -19,6 +19,6 @@ export default {
 
     this.shape.once('change:position', this.hideLabel);
     this.shape.listenTo(this.paper, 'cell:pointerup blank:pointerup', this.showLabel);
-    this.shape.on('change:parent', this.showLabel);
+    this.shape.once('change:parent', this.showLabel);
   },
 };


### PR DESCRIPTION
Closes #723 
Closes #724

Added a listener for when the shape is embedded in another parent.

Added a test back that was failing. Due to the label being missing after dragging & dropping a Boundary Event from one task to another.