### PR TITLE
Keep all boundary events in position when moving pools

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -19,6 +19,8 @@ import { invalidNodeColor, defaultNodeColor, poolColor } from '@/components/node
 import pull from 'lodash/pull';
 import store from '@/store';
 
+const boundaryEventsPattern = /^processmaker-modeler-boundary-\D*-event$/;
+
 const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
   markup: [
     ...shapes.standard.Rectangle.prototype.markup,
@@ -378,7 +380,7 @@ export default {
         .getElements()
         .filter(({ component }) => component && component !== this)
         .forEach(({ component }) => {
-          if (component.node.type === 'processmaker-modeler-boundary-timer-event'){
+          if (component.node.type.match(boundaryEventsPattern)){
             return;
           }
           this.shape.embed(component.shape);

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -19,8 +19,6 @@ import { invalidNodeColor, defaultNodeColor, poolColor } from '@/components/node
 import pull from 'lodash/pull';
 import store from '@/store';
 
-const boundaryEventsPattern = /^processmaker-modeler-boundary-\D*-event$/;
-
 const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
   markup: [
     ...shapes.standard.Rectangle.prototype.markup,
@@ -380,7 +378,7 @@ export default {
         .getElements()
         .filter(({ component }) => component && component !== this)
         .forEach(({ component }) => {
-          if (component.node.type.match(boundaryEventsPattern)){
+          if (component.node.definition.$type === 'bpmn:BoundaryEvent'){
             return;
           }
           this.shape.embed(component.shape);

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -84,7 +84,9 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet }) => {
         .its('xml')
         .then(removeIndentationAndLinebreaks)
         .then(xml => {
+          const boundaryEventPositionXml = 'bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3"><dc:Bounds x="232" y="251"';
           expect(xml).to.contain(eventXMLSnippet);
+          expect(xml).to.contain(boundaryEventPositionXml);
         });
 
       moveElementRelativeTo({ x: 400, y: 400 }, 150, 150);
@@ -94,7 +96,9 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet }) => {
         .its('xml')
         .then(removeIndentationAndLinebreaks)
         .then(xml => {
+          const boundaryEventPositionXml = 'bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3"><dc:Bounds x="662" y="481"';
           expect(xml).to.contain(eventXMLSnippet);
+          expect(xml).to.contain(boundaryEventPositionXml);
         });
     });
 


### PR DESCRIPTION
Closes #731

Test confirmed that the boundary events were still embedded, but did not confirm that the boundary event was not moving as the pool moved.