### PR TITLE
Boundary event test revision

### DIFF
--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -110,8 +110,6 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
           const taskPosition2 = $task.position();
           expect(boundaryPosition2.top).to.be.closeTo(taskPosition2.top, 1);
           expect(boundaryPosition2.left).to.be.closeTo(taskPosition2.left, 88);
-          console.log($anchor.position());
-          console.log($task.position());
         });
       });
 

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -81,26 +81,46 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
 
     it('can stay anchored to task when moving pool', function() {
       configurePool({ x: 300, y: 300 });
+
+      const taskSelector = '.main-paper ' +
+        '[data-type="processmaker.components.nodes.task.Shape"]';
+
+      cy.get(boundaryEventSelector).then($anchor => {
+        cy.get(taskSelector).then($task => {
+          const boundaryPosition1 = $anchor.position();
+          const taskPosition1 = $task.position();
+          expect(boundaryPosition1.top).to.be.closeTo(taskPosition1.top, 1);
+          expect(boundaryPosition1.left).to.be.closeTo(taskPosition1.left, 88);
+        });
+      });
+
       cy.get('[data-test=downloadXMLBtn]').click();
       cy.window()
         .its('xml')
         .then(removeIndentationAndLinebreaks)
         .then(xml => {
-          const boundaryEventPositionXml = 'bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3"><dc:Bounds x="232" y="251"';
           expect(xml).to.contain(eventXMLSnippetWithoutNullAttributes);
-          expect(xml).to.contain(boundaryEventPositionXml);
         });
 
-      moveElementRelativeTo({ x: 400, y: 400 }, 150, 150);
+      moveElementRelativeTo({ x: 400, y: 400 }, 50, 50);
+      waitToRenderAllShapes();
+      cy.get(boundaryEventSelector).then($anchor => {
+        cy.get(taskSelector).then($task => {
+          const boundaryPosition2 = $anchor.position();
+          const taskPosition2 = $task.position();
+          expect(boundaryPosition2.top).to.be.closeTo(taskPosition2.top, 1);
+          expect(boundaryPosition2.left).to.be.closeTo(taskPosition2.left, 88);
+          console.log($anchor.position());
+          console.log($task.position());
+        });
+      });
 
       cy.get('[data-test=downloadXMLBtn]').click();
       cy.window()
         .its('xml')
         .then(removeIndentationAndLinebreaks)
         .then(xml => {
-          const boundaryEventPositionXml = 'bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3"><dc:Bounds x="662" y="481"';
           expect(xml).to.contain(eventXMLSnippetWithoutNullAttributes);
-          expect(xml).to.contain(boundaryEventPositionXml);
         });
     });
 

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -85,12 +85,12 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
       const taskSelector = '.main-paper ' +
         '[data-type="processmaker.components.nodes.task.Shape"]';
 
-      cy.get(boundaryEventSelector).then($anchor => {
+      cy.get(boundaryEventSelector).then($boundaryEvent => {
         cy.get(taskSelector).then($task => {
-          const boundaryPosition1 = $anchor.position();
-          const taskPosition1 = $task.position();
-          expect(boundaryPosition1.top).to.be.closeTo(taskPosition1.top, 1);
-          expect(boundaryPosition1.left).to.be.closeTo(taskPosition1.left, 88);
+          const boundaryPosition = $boundaryEvent.position();
+          const taskPosition = $task.position();
+          expect(boundaryPosition.top).to.be.closeTo(taskPosition.top, 1);
+          expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 88);
         });
       });
 
@@ -104,12 +104,12 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
 
       moveElementRelativeTo({ x: 400, y: 400 }, 50, 50);
       waitToRenderAllShapes();
-      cy.get(boundaryEventSelector).then($anchor => {
+      cy.get(boundaryEventSelector).then($boundaryEvent => {
         cy.get(taskSelector).then($task => {
-          const boundaryPosition2 = $anchor.position();
-          const taskPosition2 = $task.position();
-          expect(boundaryPosition2.top).to.be.closeTo(taskPosition2.top, 1);
-          expect(boundaryPosition2.left).to.be.closeTo(taskPosition2.left, 88);
+          const boundaryPosition = $boundaryEvent.position();
+          const taskPosition = $task.position();
+          expect(boundaryPosition.top).to.be.closeTo(taskPosition.top, 1);
+          expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 88);
         });
       });
 

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -42,6 +42,14 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
   }
 
+  function testThatBoundaryEventIsCloseToTask(boundaryEvent, task) {
+    const boundaryPosition = boundaryEvent.position();
+    const taskPosition = task.position();
+
+    expect(boundaryPosition.top).to.be.closeTo(taskPosition.top, 1);
+    expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 88);
+  }
+
   describe(`Common behaviour test for boundary event type ${type}`, () => {
     it('can render a boundary event of this type', function() {
       dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -87,10 +95,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
 
       cy.get(boundaryEventSelector).then($boundaryEvent => {
         cy.get(taskSelector).then($task => {
-          const boundaryPosition = $boundaryEvent.position();
-          const taskPosition = $task.position();
-          expect(boundaryPosition.top).to.be.closeTo(taskPosition.top, 1);
-          expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 88);
+          testThatBoundaryEventIsCloseToTask($boundaryEvent, $task);
         });
       });
 
@@ -106,10 +111,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, eventXMLSnippetWit
       waitToRenderAllShapes();
       cy.get(boundaryEventSelector).then($boundaryEvent => {
         cy.get(taskSelector).then($task => {
-          const boundaryPosition = $boundaryEvent.position();
-          const taskPosition = $task.position();
-          expect(boundaryPosition.top).to.be.closeTo(taskPosition.top, 1);
-          expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 88);
+          testThatBoundaryEventIsCloseToTask($boundaryEvent, $task);
         });
       });
 

--- a/tests/e2e/support/constants.js
+++ b/tests/e2e/support/constants.js
@@ -33,5 +33,4 @@ export const nodeTypes = {
 };
 
 export const boundaryEventSelector = '.main-paper ' +
-  '[data-type="processmaker.components.nodes.task.Shape"] + ' +
   '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';


### PR DESCRIPTION
Take out the hard coded values in the test. Might be more reliable, unless the allowance is off.

**Note:** You can confirm the test fails by commenting out line 381 in pool.vue (there is another line like this one, but it won't fail the test).
```php
if (component.node.definition.$type === 'bpmn:BoundaryEvent'){
  return;
}
```