### PR TITLE
Add messages dropdown to intermediate message catch event

### DIFF
--- a/src/components/nodes/intermediateMessageCatchEvent/CatchEventMessageSelect.vue
+++ b/src/components/nodes/intermediateMessageCatchEvent/CatchEventMessageSelect.vue
@@ -3,38 +3,21 @@
     v-bind="$attrs"
     v-on="$listeners"
     :disabled="messagesList.length === 0"
-    :options="dropdownList"
+    :options="messagesList"
     class="p-0 mb-2"
   />
 </template>
 
 <script>
 import store from '@/store';
+import { getMessagesList } from './intermediateMessageCatchEventUtils';
 
 export default {
   inheritAttrs: false,
   props: ['value'],
   computed: {
-    dropdownList() {
-      return this.messagesList.length > 0
-        ? this.messagesList
-        : [];
-    },
     messagesList() {
-      return store.getters.rootElements
-        .filter(this.isMessageElement)
-        .map(this.toDropdownFormat);
-    },
-  },
-  methods: {
-    isMessageElement(element) {
-      return element.$type === 'bpmn:Message';
-    },
-    toDropdownFormat(element) {
-      return {
-        value: element.get('id'),
-        content: element.get('name'),
-      };
+      return getMessagesList(store);
     },
   },
 };

--- a/src/components/nodes/intermediateMessageCatchEvent/CatchEventMessageSelect.vue
+++ b/src/components/nodes/intermediateMessageCatchEvent/CatchEventMessageSelect.vue
@@ -1,0 +1,41 @@
+<template>
+  <form-select
+    v-bind="$attrs"
+    v-on="$listeners"
+    :disabled="messagesList.length === 0"
+    :options="dropdownList"
+    class="p-0 mb-2"
+  />
+</template>
+
+<script>
+import store from '@/store';
+
+export default {
+  inheritAttrs: false,
+  props: ['value'],
+  computed: {
+    dropdownList() {
+      return this.messagesList.length > 0
+        ? this.messagesList
+        : [];
+    },
+    messagesList() {
+      return store.getters.rootElements
+        .filter(this.isMessageElement)
+        .map(this.toDropdownFormat);
+    },
+  },
+  methods: {
+    isMessageElement(element) {
+      return element.$type === 'bpmn:Message';
+    },
+    toDropdownFormat(element) {
+      return {
+        value: element.get('id'),
+        content: element.get('name'),
+      };
+    },
+  },
+};
+</script>

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -3,6 +3,7 @@ import omit from 'lodash/omit';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import MessageEventIdGenerator from '../../../MessageEventIdGenerator';
+import CatchEventMessageSelect from './CatchEventMessageSelect';
 
 const messageEventIdGenerator = new MessageEventIdGenerator();
 
@@ -51,7 +52,7 @@ export default {
     }, {});
   },
   inspectorHandler(value, node, setNodeProp, moddle) {
-    for (const key in omit(value, ['$type', 'eventDefinitionId', 'variableName'])) {
+    for (const key in omit(value, ['$type', 'eventDefinitionId', 'variableName', 'messageRef'])) {
       if (node.definition[key] === value[key]) {
         continue;
       }
@@ -139,6 +140,13 @@ export default {
                 label: 'Whitelist',
                 helper: 'IP/Domain whitelist',
                 name: 'whitelist',
+              },
+            },
+            {
+              component: CatchEventMessageSelect,
+              config: {
+                label: 'Listen For Message',
+                name: 'messageRef',
               },
             },
           ],

--- a/src/components/nodes/intermediateMessageCatchEvent/intermediateMessageCatchEventUtils.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/intermediateMessageCatchEventUtils.js
@@ -1,0 +1,16 @@
+function isMessageElement(element) {
+  return element.$type === 'bpmn:Message';
+}
+
+function toDropdownFormat(element) {
+  return {
+    value: element.get('id'),
+    content: element.get('name'),
+  };
+}
+
+export function getMessagesList(store) {
+  return store.getters.rootElements
+    .filter(isMessageElement)
+    .map(toDropdownFormat);
+}

--- a/src/runningInCypressTest.js
+++ b/src/runningInCypressTest.js
@@ -1,4 +1,3 @@
 export default function runningInCypressTest() {
-  // return !!window.Cypress;
-  return true;
+  return !!window.Cypress;
 }

--- a/src/runningInCypressTest.js
+++ b/src/runningInCypressTest.js
@@ -1,3 +1,4 @@
 export default function runningInCypressTest() {
-  return !!window.Cypress;
+  // return !!window.Cypress;
+  return true;
 }

--- a/src/store.js
+++ b/src/store.js
@@ -52,7 +52,6 @@ export default new Vuex.Store({
     updateNodeProp(state, { node, key, value }) {
       node.definition.set(key, value);
 
-
       makeDefinitionPropertyReactive(node.definition, key, value);
     },
     clearNodes(state) {

--- a/tests/unit/intermediateMessageCatchEventUtils.spec.js
+++ b/tests/unit/intermediateMessageCatchEventUtils.spec.js
@@ -1,0 +1,46 @@
+import {
+  getMessagesList,
+} from '@/components/nodes/intermediateMessageCatchEvent/intermediateMessageCatchEventUtils.js';
+
+function MessageFactory(id, name) {
+  return {
+    id,
+    name,
+    $type: 'bpmn:Message',
+    get(key) {
+      return this[key];
+    },
+  };
+}
+
+function NotMessageFactory() {
+  return { $type: 'bpmn:NotMessage' };
+}
+
+function StoreFactory(rootElements) {
+  return {
+    getters: { rootElements },
+  };
+}
+
+describe('intermediateMessageCatchEventUtils', () => {
+  it('getMessagesList returns an options list of messages', () => {
+    const store = StoreFactory([
+      MessageFactory('message_1', 'Message 1'),
+      NotMessageFactory(),
+      MessageFactory('message_2', 'Message 2'),
+      NotMessageFactory(),
+    ]);
+
+    expect(getMessagesList(store)).toEqual([
+      { value: 'message_1', content: 'Message 1' },
+      { value: 'message_2', content: 'Message 2' },
+    ]);
+  });
+
+  it('getMessagesList returns empty list when there are no elements', () => {
+    const store = StoreFactory([]);
+
+    expect(getMessagesList(store)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes #745.

**To test:** Since there's currently no way to add message elements, upload the following BPMN process which contains two messages: https://www.dropbox.com/s/rgqqtmrtrhkmyyi/process_with_messages.bpmn?dl=0. Or, you can create your own process with messages and upload that.

<img width="558" alt="Screen Shot 2019-10-17 at 10 39 33 AM" src="https://user-images.githubusercontent.com/7561061/67019288-6d572b00-f0ca-11e9-8368-59961bbb440b.png">

**Note:** The `messageRef` attribute is currently being ignored. The functionality to actually implement it will have to come after https://github.com/ProcessMaker/modeler/issues/746.
