### PR TITLE
Fix 'isGeneric' problem

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -545,6 +545,14 @@ export default {
         return;
       }
 
+      if (definition.get('documentation')) {
+        definition.set('documentation', null);
+      }
+
+      if (definition.get('extensionElements')) {
+        definition.set('extensionElements', null);
+      }
+
       const customParser = parsers.custom.find(parser => parser(definition, this.moddle));
       const implementationParser = parsers.implementation.find(parser => parser(definition, this.moddle));
       const defaultParser = parsers.default.find(parser => parser(definition, this.moddle));

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -513,6 +513,11 @@ export default {
 
       store.commit('highlightNode', this.processNode);
     },
+    removeUnsupportedElementAttributes(definition) {
+      const unsupportedElements = ['documentation', 'extensionElements'];
+      unsupportedElements.filter(name => definition.get(name))
+        .forEach(name => definition.set(name, null));
+    },
     setNode(definition, flowElements, artifacts) {
       /* Get the diagram element for the corresponding flow element node. */
       const diagram = this.planeElements.find(diagram => diagram.bpmnElement.id === definition.id);
@@ -545,13 +550,7 @@ export default {
         return;
       }
 
-      if (definition.get('documentation')) {
-        definition.set('documentation', null);
-      }
-
-      if (definition.get('extensionElements')) {
-        definition.set('extensionElements', null);
-      }
+      this.removeUnsupportedElementAttributes(definition);
 
       const customParser = parsers.custom.find(parser => parser(definition, this.moddle));
       const implementationParser = parsers.implementation.find(parser => parser(definition, this.moddle));

--- a/src/runningInCypressTest.js
+++ b/src/runningInCypressTest.js
@@ -1,4 +1,3 @@
 export default function runningInCypressTest() {
-  // return !!window.Cypress;
-  return true;
+  return !!window.Cypress;
 }

--- a/src/runningInCypressTest.js
+++ b/src/runningInCypressTest.js
@@ -1,3 +1,4 @@
 export default function runningInCypressTest() {
-  return !!window.Cypress;
+  // return !!window.Cypress;
+  return true;
 }


### PR DESCRIPTION
Resolves #757 

It seems that the library we're using to parse and generate BPMN XML doesn't support extension elements or documentation elements when they are children of diagram elements. This PR temporarily addresses this problem by removing them from the node definition when it is parsed. 

We will further refactor this code to extract things and make it more maintainable. We want to release this as quickly as possible however to resolve the blocking issue.

We are planning on spending more time in the future looking into why the library doesn't support this properly and seeing if we can apply a fix there.