### PR TITLE
Update moddle with interstitial attributes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,9 +2164,9 @@
       }
     },
     "@processmaker/processmaker-bpmn-moddle": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.4.tgz",
-      "integrity": "sha512-CQM5ZaSKMaN/7GHMUdCARjUyuJCzS6KvifRm+Tq5ndZSteVZR5ZzkI2JJgl76Kw4za4oGocoDG4MLXYQYldymQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.4.5.tgz",
+      "integrity": "sha512-IijNvUpsA9BPGLGKHN+grcCaN4QVG06S2aVM8Otz22FmtIuuyDpgKyTvzQ1di70INPs6KWbkjagXyHcwj2Ct9Q==",
       "dev": true,
       "requires": {
         "min-dash": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@cypress/code-coverage": "^1.10.1",
     "@panter/vue-i18next": "^0.15.1",
-    "@processmaker/processmaker-bpmn-moddle": "0.4.4",
+    "@processmaker/processmaker-bpmn-moddle": "0.4.5",
     "@processmaker/screen-builder": "0.20.5",
     "@processmaker/vue-form-elements": "0.12.3",
     "@vue/cli-plugin-babel": "^3.12.0",


### PR DESCRIPTION
This PR updates the version of @processmaker/processmaker-bpmn-moddle was bumped from 0.4.4 to 0.4.5. This update includes:

 - Add property pm: allowInterstitial to Task elements
 - Add property pm: interstitialScreenRef to Task elements

Ref: https://github.com/ProcessMaker/processmaker-bpmn-moddle/issues/28
https://github.com/ProcessMaker/processmaker-bpmn-moddle/pull/29
