### PR TITLE
Restored method that was accidentally removed from escalation event

### DIFF
--- a/src/components/nodes/boundaryEscalationEvent/boundaryEscalationEvent.vue
+++ b/src/components/nodes/boundaryEscalationEvent/boundaryEscalationEvent.vue
@@ -1,11 +1,17 @@
 <script>
 import BoundaryEvent from '@/components/nodes/boundaryEvent/boundaryEvent';
 import escalationIcon from '@/assets/boundary-escalation-icon.svg';
+import { isValidBoundaryEscalationEvent } from '@/targetValidationUtils';
 
 export default {
   extends: BoundaryEvent,
   mounted() {
     this.shape.attr('image/xlink:href', escalationIcon);
+  },
+  methods: {
+    isValidBoundaryEventTarget(model) {
+      return isValidBoundaryEscalationEvent(model.component);
+    },
   },
 };
 </script>

--- a/src/targetValidationUtils.js
+++ b/src/targetValidationUtils.js
@@ -109,7 +109,7 @@ function isOverValidBoundaryEscalationEventTarget(clientX, clientY, paper, graph
     find(({ component }) => isValidBoundaryEscalationEvent(component));
 }
 
-function isValidBoundaryEscalationEvent(component) {
+export function isValidBoundaryEscalationEvent(component) {
   return component && component.node.definition.$type === validBoundaryEscalationEventTarget;
 }
 


### PR DESCRIPTION
Prevents attaching to other tasks when dragging from a call activity.