### PR TITLE
forEach error on validation

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -132,7 +132,6 @@ import registerInspectorExtension from '@/components/InspectorExtensionManager';
 import initAnchor from '@/mixins/linkManager.js';
 
 const version = '1.0';
-const unsupportedElements = ['documentation', 'extensionElements'];
 
 export default {
   components: {
@@ -514,11 +513,13 @@ export default {
       store.commit('highlightNode', this.processNode);
     },
     removeUnsupportedElementAttributes(definition) {
+      const unsupportedElements = ['documentation', 'extensionElements'];
+
       unsupportedElements.filter(name => definition.get(name))
         .forEach(name => definition.set(name, null));
 
       definition.$descriptor.properties = definition.$descriptor.properties.filter(
-        p => unsupportedElements.indexOf(p.name) === -1);
+        p => !unsupportedElements.includes(p.name));
     },
     setNode(definition, flowElements, artifacts) {
       /* Get the diagram element for the corresponding flow element node. */

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -464,6 +464,7 @@ export default {
         }
 
         /* Add all other elements */
+
         const flowElements = process.get('flowElements');
         const artifacts = process.get('artifacts');
 

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -132,6 +132,7 @@ import registerInspectorExtension from '@/components/InspectorExtensionManager';
 import initAnchor from '@/mixins/linkManager.js';
 
 const version = '1.0';
+const unsupportedElements = ['documentation', 'extensionElements'];
 
 export default {
   components: {
@@ -464,7 +465,6 @@ export default {
         }
 
         /* Add all other elements */
-
         const flowElements = process.get('flowElements');
         const artifacts = process.get('artifacts');
 
@@ -514,9 +514,11 @@ export default {
       store.commit('highlightNode', this.processNode);
     },
     removeUnsupportedElementAttributes(definition) {
-      const unsupportedElements = ['documentation', 'extensionElements'];
       unsupportedElements.filter(name => definition.get(name))
         .forEach(name => definition.set(name, null));
+
+      definition.$descriptor.properties = definition.$descriptor.properties.filter(
+        p => unsupportedElements.indexOf(p.name) === -1);
     },
     setNode(definition, flowElements, artifacts) {
       /* Get the diagram element for the corresponding flow element node. */

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -517,10 +517,7 @@ export default {
       const unsupportedElements = ['documentation', 'extensionElements'];
 
       unsupportedElements.filter(name => definition.get(name))
-        .forEach(name => definition.set(name, null));
-
-      definition.$descriptor.properties = definition.$descriptor.properties.filter(
-        p => !unsupportedElements.includes(p.name));
+        .forEach(name => definition.set(name, undefined));
     },
     setNode(definition, flowElements, artifacts) {
       /* Get the diagram element for the corresponding flow element node. */


### PR DESCRIPTION
Closes #777 

When validating, it was looking through a list on the $descriptor.properties. Since we removed documentation and extensionElements from definitions it was able to pass some of the if conditions (`p.name in element` and `p.isMany`), but not find the propertyValue (`element[p.name]`).
![Screen Shot 2019-10-31 at 4 38 17 PM](https://user-images.githubusercontent.com/6653340/68042778-1cd6f480-fcaa-11e9-8225-73d497de35f4.png)
