### PR TITLE
Shapes with background color can lose that color on valid or invalid states

### DIFF
--- a/src/components/nodeColors.js
+++ b/src/components/nodeColors.js
@@ -1,4 +1,6 @@
 export const validNodeColor = '#dffdd0';
 export const invalidNodeColor = '#fae0e6';
 export const defaultNodeColor = '#fff';
+export const startColor = '#edfffc';
+export const endColor = '#fff1f2';
 export const poolColor = '#f7f7f7';

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -150,9 +150,6 @@ export default {
         this.allowSetNodePosition = true;
       });
     },
-    isPoolShape(model) {
-      return model.component.node.type === 'processmaker-modeler-pool';
-    },
     turnInvalidTargetRed() {
       if (!this.highlighted) {
         return;
@@ -179,8 +176,7 @@ export default {
       this.invalidTargetElement = targetElement;
     },
     resetShapeColor(shape) {
-      const defaultColor = this.isPoolShape(shape) ? poolColor : defaultNodeColor;
-      shape.attr('body/fill', shape.attr('body/originalFill') || defaultColor);
+      shape.attr('body/fill', shape.attr('body/originalFill') || defaultNodeColor);
     },
   },
   async mounted() {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -180,7 +180,7 @@ export default {
     },
     resetShapeColor(shape) {
       const defaultColor = this.isPoolShape(shape) ? poolColor : defaultNodeColor;
-      shape.attr('body/fill', defaultColor);
+      shape.attr('body/fill', shape.attr('body/originalFill') || defaultColor);
     },
   },
   async mounted() {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -9,7 +9,7 @@ import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
 import isValidBoundaryEventTarget from './validBoundaryEventTargets';
 import { getBoundaryAnchorPoint } from '@/portsUtils';
-import { defaultNodeColor, invalidNodeColor, poolColor } from '@/components/nodeColors';
+import { defaultNodeColor, invalidNodeColor } from '@/components/nodeColors';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 
 export default {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -8,8 +8,9 @@ import portsConfig from '@/mixins/portsConfig';
 import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
 import isValidBoundaryEventTarget from './validBoundaryEventTargets';
+import resetShapeColor from '@/components/resetShapeColor';
 import { getBoundaryAnchorPoint } from '@/portsUtils';
-import { defaultNodeColor, invalidNodeColor } from '@/components/nodeColors';
+import { invalidNodeColor } from '@/components/nodeColors';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 
 export default {
@@ -170,13 +171,10 @@ export default {
       }
 
       if (this.invalidTargetElement) {
-        this.resetShapeColor(this.invalidTargetElement);
+        resetShapeColor(this.invalidTargetElement);
       }
 
       this.invalidTargetElement = targetElement;
-    },
-    resetShapeColor(shape) {
-      shape.attr('body/fill', shape.attr('body/originalFill') || defaultNodeColor);
     },
   },
   async mounted() {

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -7,6 +7,7 @@ import crownConfig from '@/mixins/crownConfig';
 import portsConfig from '@/mixins/portsConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import EventShape from '../startEvent/eventShape';
+import { endColor } from '@/components/nodeColors';
 
 export default {
   props: ['graph', 'node', 'id'],
@@ -29,7 +30,8 @@ export default {
     this.shape.resize(bounds.get('width'), bounds.get('height'));
     this.shape.attr({
       body: {
-        fill: '#FFF1F2',
+        fill: endColor,
+        originalFill: endColor,
         stroke: '#ED4757',
       },
       label: {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -485,6 +485,7 @@ export default {
     }));
     this.shape.attr('body', {
       fill: poolColor,
+      originalFill: poolColor,
     });
 
     this.shape.addTo(this.graph);

--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -69,6 +69,7 @@ export default {
     this.shape.attr('body/cursor', 'default');
     this.shape.attr('body', {
       fill: poolColor,
+      originalFill: poolColor,
     });
     this.shape.attr('label', {
       text: util.breakText(this.node.definition.get('name'), { width: bounds.height }),

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -9,6 +9,7 @@ import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from './eventShape';
 import hasMarkers from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
+import { startColor } from '@/components/nodeColors';
 
 export default {
   props: ['graph', 'node', 'id'],
@@ -40,7 +41,8 @@ export default {
     this.shape.attr({
       body: {
         stroke: '#00bf9c',
-        fill: '#EDFFFC',
+        fill: startColor,
+        originalFill: startColor,
       },
       label: {
         text: this.node.definition.get('name'),

--- a/src/components/resetShapeColor.js
+++ b/src/components/resetShapeColor.js
@@ -1,0 +1,6 @@
+import { defaultNodeColor } from './nodeColors';
+
+export default function resetShapeColor(shape)
+{
+  shape.attr('body/fill', shape.attr('body/originalFill') || defaultNodeColor);
+}

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -220,15 +220,8 @@ export default {
         this.listeningToMouseup = false;
       }
     },
-    isPoolOrLane(model) {
-      if (!model.component) {
-        return false;
-      }
-      return ['processmaker-modeler-lane', 'processmaker-modeler-pool'].includes(model.component.node.type);
-    },
     resetBodyColor(shape) {
-      const defaultColor = this.isPoolOrLane(shape) ? poolColor : defaultNodeColor;
-      this.setBodyColor(shape.attr('body/originalFill') || defaultColor, shape);
+      this.setBodyColor(shape.attr('body/originalFill') || defaultNodeColor, shape);
     },
   },
   created() {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -2,8 +2,9 @@ import { dia, linkTools } from 'jointjs';
 import pull from 'lodash/pull';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import { defaultNodeColor, invalidNodeColor, validNodeColor } from '@/components/nodeColors';
+import { invalidNodeColor, validNodeColor } from '@/components/nodeColors';
 import { getDefaultAnchorPoint } from '@/portsUtils';
+import resetShapeColor from '@/components/resetShapeColor';
 
 const endpoints = {
   source: 'source',
@@ -27,7 +28,7 @@ export default {
   watch: {
     target(target, previousTarget) {
       if (previousTarget && previousTarget !== target) {
-        this.resetBodyColor(previousTarget);
+        resetShapeColor(previousTarget);
       }
     },
     isValidConnection(isValid) {
@@ -116,7 +117,7 @@ export default {
       this.resetPaper();
 
       const targetShape = this.shape.getTargetElement();
-      this.resetBodyColor(targetShape);
+      resetShapeColor(targetShape);
 
       this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
@@ -183,7 +184,7 @@ export default {
       this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
         this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
         this.shape.stopListening(this.paper, 'cell:pointerclick');
-        this.resetBodyColor(this.target);
+        resetShapeColor(this.target);
         this.$emit('set-cursor', 'not-allowed');
       });
     },
@@ -196,7 +197,7 @@ export default {
       this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
       this.paper.setInteractivity(this.graph.get('interactiveFunc'));
       if (this.target) {
-        this.resetBodyColor(this.target);
+        resetShapeColor(this.target);
       }
     },
     setupLinkTools() {
@@ -219,9 +220,6 @@ export default {
         document.removeEventListener('mouseup', this.emitSave);
         this.listeningToMouseup = false;
       }
-    },
-    resetBodyColor(shape) {
-      this.setBodyColor(shape.attr('body/originalFill') || defaultNodeColor, shape);
     },
   },
   created() {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -70,12 +70,6 @@ export default {
     elementPadding() {
       return this.shape && this.shape.source().id === this.shape.target().id ? 20 : 1;
     },
-    isPoolOrLane() {
-      if (!this.target) {
-        return;
-      }
-      return ['processmaker-modeler-lane', 'processmaker-modeler-pool'].includes(this.target.component.node.type);
-    },
   },
   methods: {
     setEndpoint(shape, endpoint, connectionOffset) {
@@ -122,12 +116,7 @@ export default {
       this.resetPaper();
 
       const targetShape = this.shape.getTargetElement();
-
       this.resetBodyColor(targetShape);
-
-      if (this.isPoolOrLane) {
-        this.setBodyColor(poolColor);
-      }
 
       this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
@@ -209,10 +198,6 @@ export default {
       if (this.target) {
         this.resetBodyColor(this.target);
       }
-
-      if (this.isPoolOrLane) {
-        this.setBodyColor(poolColor);
-      }
     },
     setupLinkTools() {
       const verticesTool = new linkTools.Vertices();
@@ -235,11 +220,14 @@ export default {
         this.listeningToMouseup = false;
       }
     },
-    isPoolShape(model) {
-      return model.component.node.type === 'processmaker-modeler-pool';
+    isPoolOrLane(model) {
+      if (!model.component) {
+        return false;
+      }
+      return ['processmaker-modeler-lane', 'processmaker-modeler-pool'].includes(model.component.node.type);
     },
     resetBodyColor(shape) {
-      const defaultColor = this.isPoolShape(shape) ? poolColor : defaultNodeColor;
+      const defaultColor = this.isPoolOrLane(shape) ? poolColor : defaultNodeColor;
       this.setBodyColor(shape.attr('body/originalFill') || defaultColor, shape);
     },
   },

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -2,7 +2,7 @@ import { dia, linkTools } from 'jointjs';
 import pull from 'lodash/pull';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import { defaultNodeColor, invalidNodeColor, poolColor, validNodeColor } from '@/components/nodeColors';
+import { defaultNodeColor, invalidNodeColor, validNodeColor } from '@/components/nodeColors';
 import { getDefaultAnchorPoint } from '@/portsUtils';
 
 const endpoints = {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -27,7 +27,8 @@ export default {
   watch: {
     target(target, previousTarget) {
       if (previousTarget && previousTarget !== target) {
-        this.setBodyColor(poolColor, previousTarget);
+        const defaultColor = this.isPoolShape(previousTarget) ? poolColor : defaultNodeColor;
+        this.setBodyColor(previousTarget.attr('body/originalFill') || defaultColor, previousTarget);
       }
     },
     isValidConnection(isValid) {
@@ -234,6 +235,9 @@ export default {
         document.removeEventListener('mouseup', this.emitSave);
         this.listeningToMouseup = false;
       }
+    },
+    isPoolShape(model) {
+      return model.component.node.type === 'processmaker-modeler-pool';
     },
   },
   created() {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -27,8 +27,7 @@ export default {
   watch: {
     target(target, previousTarget) {
       if (previousTarget && previousTarget !== target) {
-        const defaultColor = this.isPoolShape(previousTarget) ? poolColor : defaultNodeColor;
-        this.setBodyColor(previousTarget.attr('body/originalFill') || defaultColor, previousTarget);
+        this.resetBodyColor(previousTarget);
       }
     },
     isValidConnection(isValid) {
@@ -124,7 +123,7 @@ export default {
 
       const targetShape = this.shape.getTargetElement();
 
-      this.setBodyColor(defaultNodeColor, targetShape);
+      this.resetBodyColor(targetShape);
 
       if (this.isPoolOrLane) {
         this.setBodyColor(poolColor);
@@ -195,7 +194,7 @@ export default {
       this.shape.listenToOnce(this.paper, 'cell:mouseleave', () => {
         this.paper.el.addEventListener('mousemove', this.updateLinkTarget);
         this.shape.stopListening(this.paper, 'cell:pointerclick');
-        this.setBodyColor(defaultNodeColor);
+        this.resetBodyColor(this.target);
         this.$emit('set-cursor', 'not-allowed');
       });
     },
@@ -208,7 +207,7 @@ export default {
       this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
       this.paper.setInteractivity(this.graph.get('interactiveFunc'));
       if (this.target) {
-        this.setBodyColor(defaultNodeColor);
+        this.resetBodyColor(this.target);
       }
 
       if (this.isPoolOrLane) {
@@ -238,6 +237,10 @@ export default {
     },
     isPoolShape(model) {
       return model.component.node.type === 'processmaker-modeler-pool';
+    },
+    resetBodyColor(shape) {
+      const defaultColor = this.isPoolShape(shape) ? poolColor : defaultNodeColor;
+      this.setBodyColor(shape.attr('body/originalFill') || defaultColor, shape);
     },
   },
   created() {

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -10,7 +10,7 @@ import {
   waitToRenderAllShapes,
 } from '../support/utils';
 import { boundaryEventSelector, nodeTypes } from '../support/constants';
-import { defaultNodeColor, invalidNodeColor } from '../../../src/components/nodeColors';
+import { startColor, invalidNodeColor } from '../../../src/components/nodeColors';
 
 const boundaryEventPosition = { x: 250, y: 250 };
 const taskPosition = { x: 250, y: 200 };
@@ -327,7 +327,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
             getElementAtPosition(invalidNodeTargetPosition, invalidTargetNodeType)
               .then($el => $el.find('[joint-selector="body"]'))
-              .should('have.attr', 'fill', defaultNodeColor);
+              .should('have.attr', 'fill', startColor);
 
             getElementAtPosition(invalidNodeTargetPosition).click();
 

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -10,7 +10,7 @@ import {
   waitToRenderAllShapes,
 } from '../support/utils';
 import { boundaryEventSelector, nodeTypes } from '../support/constants';
-import { startColor, invalidNodeColor } from '../../../src/components/nodeColors';
+import { startColor, defaultNodeColor, invalidNodeColor } from '../../../src/components/nodeColors';
 
 const boundaryEventPosition = { x: 250, y: 250 };
 const taskPosition = { x: 250, y: 200 };
@@ -20,25 +20,25 @@ const boundaryEventData = [{
   nodeType: nodeTypes.boundaryTimerEvent,
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Timer Event" attachedToRef="node_2"><bpmn:timerEventDefinition><bpmn:timeDuration>PT1H</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
-  invalidTargets: [nodeTypes.startEvent],
+  invalidTargets: [{ type: nodeTypes.startEvent }],
 }, {
   type: 'Boundary Error Event',
   nodeType: nodeTypes.boundaryErrorEvent,
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Error Event" attachedToRef="node_2"><bpmn:errorEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
-  invalidTargets: [nodeTypes.startEvent],
+  invalidTargets: [{ type: nodeTypes.startEvent }],
 }, {
   type: 'Boundary Escalation Event',
   nodeType: nodeTypes.boundaryEscalationEvent,
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Escalation Event" attachedToRef="node_2"><bpmn:escalationEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.callActivity,
-  invalidTargets: [nodeTypes.startEvent, nodeTypes.task],
+  invalidTargets: [{ type: nodeTypes.startEvent }, { type: nodeTypes.task, color: defaultNodeColor }],
 }, {
   type: 'Boundary Message Event',
   nodeType: nodeTypes.boundaryMessageEvent,
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Message Event" attachedToRef="node_2"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.callActivity,
-  invalidTargets: [nodeTypes.startEvent],
+  invalidTargets: [{ type: nodeTypes.startEvent }],
 }];
 
 function testThatBoundaryEventIsCloseToTask(boundaryEvent, task) {
@@ -298,8 +298,8 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       dragFromSourceToDest(nodeType, taskPosition);
       const invalidNodeTargetPosition = { x: 450, y: 150 };
 
-      invalidTargets.forEach(invalidTargetNodeType => {
-        dragFromSourceToDest(invalidTargetNodeType, invalidNodeTargetPosition);
+      invalidTargets.forEach(invalidTargetNode => {
+        dragFromSourceToDest(invalidTargetNode.type, invalidNodeTargetPosition);
 
         cy.window().its('store.state.paper').then(paper => {
           const newPosition = paper.localToPagePoint(invalidNodeTargetPosition.x, invalidNodeTargetPosition.y);
@@ -317,7 +317,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
             waitToRenderAllShapes();
 
-            getElementAtPosition(invalidNodeTargetPosition, invalidTargetNodeType)
+            getElementAtPosition(invalidNodeTargetPosition, invalidTargetNode.type)
               .then($el => $el.find('[joint-selector="body"]'))
               .should('have.attr', 'fill', invalidNodeColor);
 
@@ -325,9 +325,9 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
             waitToRenderAllShapes();
 
-            getElementAtPosition(invalidNodeTargetPosition, invalidTargetNodeType)
+            getElementAtPosition(invalidNodeTargetPosition, invalidTargetNode.type)
               .then($el => $el.find('[joint-selector="body"]'))
-              .should('have.attr', 'fill', startColor);
+              .should('have.attr', 'fill', invalidTargetNode.color || startColor);
 
             getElementAtPosition(invalidNodeTargetPosition).click();
 

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -10,6 +10,7 @@ import {
 import { nodeTypes } from '../support/constants';
 import { taskWidth } from '../../../src/components/nodes/task/taskConfig';
 import { startEventDiameter } from '../../../src/components/nodes/startEvent/startEventConfig';
+import { startColor, endColor } from '../../../src/components/nodeColors';
 
 describe('Sequence Flows', () => {
   it('Can connect two elements', () => {
@@ -232,5 +233,24 @@ describe('Sequence Flows', () => {
     connectNodesWithFlow('sequence-flow-button', taskPosition, endEventPosition);
 
     cy.get('.main-paper [data-type="standard.Link"] [joint-selector="line"]').should('have.attr', 'd', 'M 308 326 L 308 450');
+  });
+
+  it('retains original background color when it can and cannot connect to an element', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    const endEventPosition = { x: 350, y: 350 };
+    const taskPosition = { x: 250, y: 250 };
+
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+
+    connectNodesWithFlow('sequence-flow-button', taskPosition, startEventPosition);
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).
+      then($el => $el.find('[joint-selector="body"]')).
+      should('have.attr', 'fill', startColor);
+
+    connectNodesWithFlow('sequence-flow-button', taskPosition, endEventPosition);
+    getElementAtPosition(endEventPosition, nodeTypes.endEvent).
+      then($el => $el.find('[joint-selector="body"]')).
+      should('have.attr', 'fill', endColor);
   });
 });

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -235,18 +235,24 @@ describe('Sequence Flows', () => {
     cy.get('.main-paper [data-type="standard.Link"] [joint-selector="line"]').should('have.attr', 'd', 'M 308 326 L 308 450');
   });
 
-  it('retains original background color when it can and cannot connect to an element', () => {
+  it('retains original background color when it cannot connect to an element', () => {
     const startEventPosition = { x: 150, y: 150 };
-    const endEventPosition = { x: 350, y: 350 };
     const taskPosition = { x: 250, y: 250 };
 
     dragFromSourceToDest(nodeTypes.task, taskPosition);
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
 
     connectNodesWithFlow('sequence-flow-button', taskPosition, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).
       then($el => $el.find('[joint-selector="body"]')).
       should('have.attr', 'fill', startColor);
+  });
+
+  it('retains original background color when it can connect to an element', () => {
+    const endEventPosition = { x: 350, y: 350 };
+    const taskPosition = { x: 250, y: 250 };
+
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
 
     connectNodesWithFlow('sequence-flow-button', taskPosition, endEventPosition);
     getElementAtPosition(endEventPosition, nodeTypes.endEvent).


### PR DESCRIPTION
Closes #763

**Additionally solved:**

When you drag a boundary event onto a start or end event, the start or end event would lose their background color.

Drag a boundary event onto a start and end event. They should retain their background colors.
<img width="368" alt="Screen Shot 2019-11-01 at 2 38 52 PM" src="https://user-images.githubusercontent.com/6653340/68047731-6bd65700-fcb5-11e9-97ae-2609cab145ee.png">
