### PR TITLE
Collapse control panel

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -7,10 +7,10 @@
       :title="tooltipTitle"
     />
 
-    <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : !panelsOpen }]" data-test="controls-column">
+    <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : panelsCompressed }]" data-test="controls-column">
       <controls
         :controls="controls"
-        :panelsOpen="panelsOpen"
+        :panelsCompressed="panelsCompressed"
         :style="{ height: parentHeight }"
         :invalidDrop="validateDropTarget"
         :allowDrop="allowDrop"
@@ -44,8 +44,8 @@
         </div>
 
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Third group">
-          <button class="btn btn-sm btn-secondary ml-auto" data-test="panels-btn" @click="panelsOpen = !panelsOpen">
-            <font-awesome-icon v-if="panelsOpen" :icon="expandIcon" />
+          <button class="btn btn-sm btn-secondary ml-auto" data-test="panels-btn" @click="panelsCompressed = !panelsCompressed">
+            <font-awesome-icon v-if="panelsCompressed" :icon="expandIcon" />
             <font-awesome-icon v-else :icon="compressIcon" />
           </button>
 
@@ -190,7 +190,7 @@ export default {
       minimumScale: 0.2,
       scaleStep: 0.1,
       miniMapOpen: false,
-      panelsOpen: true,
+      panelsCompressed: false,
       isGrabbing: false,
       isRendering: false,
       allWarnings: [],

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -10,6 +10,7 @@
     <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : !panelsOpen }]">
       <controls
         :controls="controls"
+        :panelsOpen="panelsOpen"
         :style="{ height: parentHeight }"
         :invalidDrop="validateDropTarget"
         :allowDrop="allowDrop"

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -939,6 +939,7 @@ $controls-column-max-width: 265px;
 $controls-column-compressed-max-width: 95px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
+$controls-transition: 0.3s;
 
 .ignore-pointer {
   pointer-events: none;
@@ -951,10 +952,12 @@ $vertex-error-color: #ED4757;
 
   .controls-column {
     max-width: $controls-column-max-width;
+    transition: $controls-transition;
   }
 
   .controls-column-compressed {
     max-width: $controls-column-compressed-max-width;
+    transition: $controls-transition;  
   }
 
   .main-paper {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -952,11 +952,13 @@ $controls-transition: 0.3s;
 
   .controls-column {
     max-width: $controls-column-max-width;
+    transition-timing-function: ease-out;
     transition: $controls-transition;
   }
 
   .controls-column-compressed {
     max-width: $controls-column-compressed-max-width;
+    transition-timing-function: ease-in;
     transition: $controls-transition;  
   }
 

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -7,7 +7,7 @@
       :title="tooltipTitle"
     />
 
-    <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : !panelsOpen }]">
+    <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : !panelsOpen }]" data-test="controls-column">
       <controls
         :controls="controls"
         :panelsOpen="panelsOpen"

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -7,7 +7,7 @@
       :title="tooltipTitle"
     />
 
-    <b-col class="h-100 overflow-hidden controls-column" :class="{ 'ignore-pointer': canvasDragPosition }">
+    <b-col class="h-100 overflow-hidden controls-column" :class="[{ 'ignore-pointer': canvasDragPosition, 'controls-column-compressed' : !panelsOpen }]">
       <controls
         :controls="controls"
         :style="{ height: parentHeight }"
@@ -935,6 +935,7 @@ export default {
 $cursors: default, not-allowed, wait;
 $inspector-column-max-width: 265px;
 $controls-column-max-width: 265px;
+$controls-column-compressed-max-width: 95px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
 
@@ -949,6 +950,10 @@ $vertex-error-color: #ED4757;
 
   .controls-column {
     max-width: $controls-column-max-width;
+  }
+
+  .controls-column-compressed {
+    max-width: $controls-column-compressed-max-width;
   }
 
   .main-paper {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -939,7 +939,6 @@ $controls-column-max-width: 265px;
 $controls-column-compressed-max-width: 95px;
 $toolbar-height: 2rem;
 $vertex-error-color: #ED4757;
-$controls-transition: 0.3s;
 
 .ignore-pointer {
   pointer-events: none;
@@ -952,14 +951,10 @@ $controls-transition: 0.3s;
 
   .controls-column {
     max-width: $controls-column-max-width;
-    transition-timing-function: ease-out;
-    transition: $controls-transition;
   }
 
   .controls-column-compressed {
     max-width: $controls-column-compressed-max-width;
-    transition-timing-function: ease-in;
-    transition: $controls-transition;  
   }
 
   .main-paper {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -42,10 +42,18 @@
           <span class="btn btn-sm btn-secondary scale-value">{{ Math.round(scale*100) }}%</span>
         </div>
 
-        <button class="btn btn-sm btn-secondary mini-map-btn ml-auto" data-test="mini-map-btn" @click="miniMapOpen = !miniMapOpen">
-          <font-awesome-icon v-if="miniMapOpen" :icon="minusIcon" />
-          <font-awesome-icon v-else :icon="mapIcon" />
-        </button>
+        <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Third group">
+          <button class="btn btn-sm btn-secondary ml-auto" data-test="panels-btn" @click="panelsOpen = !panelsOpen">
+            <font-awesome-icon v-if="panelsOpen" :icon="expandIcon" />
+            <font-awesome-icon v-else :icon="compressIcon" />
+          </button>
+
+          <button class="btn btn-sm btn-secondary mini-map-btn ml-auto" data-test="mini-map-btn" @click="miniMapOpen = !miniMapOpen">
+            <font-awesome-icon v-if="miniMapOpen" :icon="minusIcon" />
+            <font-awesome-icon v-else :icon="mapIcon" />
+          </button>
+        </div>
+
       </div>
 
       <div ref="paper" data-test="paper" class="main-paper" />
@@ -117,7 +125,7 @@ import runningInCypressTest from '@/runningInCypressTest';
 import getValidationProperties from '@/targetValidationUtils';
 import MiniPaper from '@/components/MiniPaper';
 
-import { faMapMarked, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faMapMarked, faMinus, faPlus, faExpand, faCompress } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { id as poolId } from './nodes/pool';
@@ -181,6 +189,7 @@ export default {
       minimumScale: 0.2,
       scaleStep: 0.1,
       miniMapOpen: false,
+      panelsOpen: true,
       isGrabbing: false,
       isRendering: false,
       allWarnings: [],
@@ -242,6 +251,12 @@ export default {
     },
     minusIcon() {
       return faMinus;
+    },
+    expandIcon() {
+      return faExpand;
+    },
+    compressIcon() {
+      return faCompress;
     },
   },
   methods: {

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -22,7 +22,7 @@
         @dragstart="$event.preventDefault()"
         @mousedown="startDrag($event, control)"
       >
-        <div class="tool text-truncate ml-1" v-b-tooltip.hover.d50 :title="$t(control.label)">
+        <div class="tool text-truncate ml-1" v-b-tooltip.hover.viewport.d50 :title="$t(control.label)">
           <img :src="control.icon" class="tool-icon mr-1">
           {{ $t(control.label) }}
         </div>

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -142,5 +142,4 @@ export default {
   width: 1.5rem;
   pointer-events: none;
 }
-
 </style>

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -17,14 +17,15 @@
       <b-list-group-item v-for="(control, index) in controlItems"
         v-if="control.label.toLowerCase().includes(filterQuery.toLowerCase())"
         :key="index"
-        class="control-item p-2 border-right-0 flex-grow-1"
+        class="control-item border-right-0 flex-grow-1"
+        :class="{ 'p-2': !panelsCompressed }"
         :data-test="control.type"
         @dragstart="$event.preventDefault()"
         @mousedown="startDrag($event, control)"
       >
-        <div class="tool text-truncate ml-1" v-b-tooltip.hover.viewport.d50 :title="$t(control.label)">
+        <div class="tool" :class="{ 'text-truncate ml-1': !panelsCompressed }" v-b-tooltip.hover.viewport.d50 :title="$t(control.label)">
           <img :src="control.icon" class="tool-icon mr-1">
-          {{ $t(control.label) }}
+          {{ !panelsCompressed ? $t(control.label) : '' }}
         </div>
       </b-list-group-item>
     </b-list-group>

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card no-body class="controls">
-    <b-input-group size="sm">
+    <b-input-group size="sm" v-if="panelsOpen">
       <b-input-group-prepend>
         <span class="input-group-text border-left-0 border-top-0 rounded-0"><i class="fas fa-filter"/></span>
       </b-input-group-prepend>
@@ -36,7 +36,7 @@
 import flatten from 'lodash/flatten';
 
 export default {
-  props: ['controls', 'allowDrop'],
+  props: ['controls', 'allowDrop', 'panelsOpen'],
   watch: {
     allowDrop(allowDrop) {
       if (this.draggingElement) {

--- a/src/components/controls.vue
+++ b/src/components/controls.vue
@@ -1,6 +1,6 @@
 <template>
   <b-card no-body class="controls">
-    <b-input-group size="sm" v-if="panelsOpen">
+    <b-input-group size="sm" v-show="!panelsCompressed">
       <b-input-group-prepend>
         <span class="input-group-text border-left-0 border-top-0 rounded-0"><i class="fas fa-filter"/></span>
       </b-input-group-prepend>
@@ -36,7 +36,7 @@
 import flatten from 'lodash/flatten';
 
 export default {
-  props: ['controls', 'allowDrop', 'panelsOpen'],
+  props: ['controls', 'allowDrop', 'panelsCompressed'],
   watch: {
     allowDrop(allowDrop) {
       if (this.draggingElement) {

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -405,4 +405,16 @@ describe('Modeler', () => {
       .find('>text')
       .should('have.css', 'display', 'block');
   });
+
+  it('Collapse and expand controls panel', () => {
+    cy.get('[data-test=controls-column]').should('not.have.class', 'controls-column-compressed');
+    
+    cy.get('[data-test="panels-btn"]').click();
+    
+    cy.get('[data-test=controls-column]').should('have.class', 'controls-column-compressed');
+    
+    cy.get('[data-test="panels-btn"]').click();
+    
+    cy.get('[data-test=controls-column]').should('not.have.class', 'controls-column-compressed');
+  });
 });

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -406,15 +406,17 @@ describe('Modeler', () => {
       .should('have.css', 'display', 'block');
   });
 
-  it('Collapse and expand controls panel', () => {
+  it('can collapse the controls panel', () => {
     cy.get('[data-test=controls-column]').should('not.have.class', 'controls-column-compressed');
-    
+
     cy.get('[data-test="panels-btn"]').click();
-    
     cy.get('[data-test=controls-column]').should('have.class', 'controls-column-compressed');
-    
+  });
+
+  it('can expand the controls panel', () => {
     cy.get('[data-test="panels-btn"]').click();
-    
+    cy.get('[data-test="panels-btn"]').click();
+
     cy.get('[data-test=controls-column]').should('not.have.class', 'controls-column-compressed');
   });
 });


### PR DESCRIPTION
The purpose of this PR is to give users the feature to collapse the controls panel to display the icons only.

Note: The filter is hidden when the user selects to display icons only.

<img width="1145" alt="Screen Shot 2019-11-05 at 2 56 43 PM" src="https://user-images.githubusercontent.com/26545455/68241368-86257300-ffdc-11e9-8f0c-c9a9fe2a10bc.png">

Todo: ~Fix layout issue with tooltip in processmaker~, remove `...` when collapsed.

Fixes #781 