### PR TITLE
Disable duplicate sequence flow check

### DIFF
--- a/.bpmnlintrc
+++ b/.bpmnlintrc
@@ -5,6 +5,7 @@
   ],
   "rules": {
     "no-inclusive-gateway": "off",
-    "fake-join": "off"
+    "fake-join": "off",
+    "no-duplicate-sequence-flows": "off"
   }
 }


### PR DESCRIPTION
Fixes #780.

It seems the "_no duplicate sequence flows_" error is cause by a bug in the `bpmnlint` source, at https://github.com/bpmn-io/bpmnlint/blob/d48d64f6a7cd8ef4a685a958848fe4776dcdd0a9/rules/no-duplicate-sequence-flows.js.

This file also contains a `console.log` call; it seems a long term solution will require submitting a bug report on that repo and getting a PR up there. In the interim, this PR will disable that rule in modeler to prevent the erroneous warning.