### PR TITLE
Replace text with icons

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -27,12 +27,19 @@
     >
       <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Undo/redo controls">
-          <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo" v-b-tooltip.hover  :title="`${$t('Undo')}`">
-            <font-awesome-icon :icon="undoIcon" />
-          </button>
-          <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo" v-b-tooltip.hover :title="`${$t('Redo')}`">
-            <font-awesome-icon :icon="redoIcon" />
-          </button>
+          <span id="undo-wrapper" class="d-inline-block cursor-pointer" tabindex="0" @click="undo">
+            <button type="button" class="btn btn-sm btn-secondary"  :disabled="!canUndo" data-test="undo">
+              <font-awesome-icon :icon="undoIcon" />
+            </button>
+          </span>
+          <b-tooltip target="undo-wrapper">{{ $t('Undo') }}</b-tooltip>
+
+          <span id="redo-wrapper" class="d-inline-block cursor-pointer" tabindex="0" @click="redo">
+            <button type="button" class="btn btn-sm btn-secondary" :disabled="!canRedo" data-test="redo">
+              <font-awesome-icon :icon="redoIcon" />
+            </button>
+          </span>
+          <b-tooltip target="redo-wrapper">{{ $t('Redo') }}</b-tooltip>
         </div>
 
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Zoom controls">
@@ -953,6 +960,10 @@ $vertex-error-color: #ED4757;
     }
   }
 
+  .cursor-pointer {
+    cursor: pointer;
+  }
+
   @each $cursor in $cursors {
     .paper-container.#{$cursor} {
       .joint-paper,
@@ -965,10 +976,6 @@ $vertex-error-color: #ED4757;
   .joint-marker-vertex:hover {
     fill: $vertex-error-color;
     cursor: url('../assets/delete-icon-vertex.png') 0 0, pointer;
-  }
-
-  .foo {
-    pointer-events: all !important;
   }
 }
 </style>

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -27,14 +27,14 @@
     >
       <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Undo/redo controls">
-          <span id="undo-wrapper" class="d-inline-block cursor-pointer" tabindex="0" @click="undo">
+          <span id="undo-wrapper" role="button" class="d-inline-block" tabindex="0" @click="undo">
             <button type="button" class="btn btn-sm btn-secondary"  :disabled="!canUndo" data-test="undo">
               <font-awesome-icon :icon="undoIcon" />
             </button>
           </span>
           <b-tooltip target="undo-wrapper">{{ $t('Undo') }}</b-tooltip>
 
-          <span id="redo-wrapper" class="d-inline-block cursor-pointer" tabindex="0" @click="redo">
+          <span id="redo-wrapper" role="button" class="d-inline-block" tabindex="0" @click="redo">
             <button type="button" class="btn btn-sm btn-secondary" :disabled="!canRedo" data-test="redo">
               <font-awesome-icon :icon="redoIcon" />
             </button>
@@ -958,10 +958,6 @@ $vertex-error-color: #ED4757;
         cursor: pointer;
       }
     }
-  }
-
-  .cursor-pointer {
-    cursor: pointer;
   }
 
   @each $cursor in $cursors {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -28,14 +28,14 @@
       <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Undo/redo controls">
           <span id="undo-wrapper" role="button" class="d-inline-block" tabindex="0" @click="undo">
-            <button type="button" class="btn btn-sm btn-secondary"  :disabled="!canUndo" data-test="undo">
+            <button type="button" class="btn btn-sm btn-secondary btn-undo" :disabled="!canUndo" data-test="undo">
               <font-awesome-icon :icon="undoIcon" />
             </button>
           </span>
           <b-tooltip target="undo-wrapper">{{ $t('Undo') }}</b-tooltip>
 
           <span id="redo-wrapper" role="button" class="d-inline-block" tabindex="0" @click="redo">
-            <button type="button" class="btn btn-sm btn-secondary" :disabled="!canRedo" data-test="redo">
+            <button type="button" class="btn btn-sm btn-secondary btn-redo" :disabled="!canRedo" data-test="redo">
               <font-awesome-icon :icon="redoIcon" />
             </button>
           </span>
@@ -972,6 +972,16 @@ $vertex-error-color: #ED4757;
   .joint-marker-vertex:hover {
     fill: $vertex-error-color;
     cursor: url('../assets/delete-icon-vertex.png') 0 0, pointer;
+  }
+
+  .btn-undo {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  .btn-redo {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
   }
 }
 </style>

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -27,8 +27,12 @@
     >
       <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Undo/redo controls">
-          <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo">{{ $t('Undo') }}</button>
-          <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo">{{ $t('Redo') }}</button>
+          <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo" v-b-tooltip.hover  :title="`${$t('Undo')}`">
+            <font-awesome-icon class="" :icon="undoIcon" />
+          </button>
+          <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo" v-b-tooltip.hover :title="`${$t('Redo')}`">
+            <font-awesome-icon class="" :icon="redoIcon" />
+          </button>
         </div>
 
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Zoom controls">
@@ -126,7 +130,7 @@ import runningInCypressTest from '@/runningInCypressTest';
 import getValidationProperties from '@/targetValidationUtils';
 import MiniPaper from '@/components/MiniPaper';
 
-import { faCompress, faExpand, faMapMarked, faMinus, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { faCompress, faExpand, faMapMarked, faMinus, faPlus, faStepBackward, faStepForward } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 import { id as poolId } from './nodes/pool';
@@ -200,6 +204,8 @@ export default {
       minusIcon: faMinus,
       expandIcon: faExpand,
       compressIcon: faCompress,
+      undoIcon: faStepBackward,
+      redoIcon: faStepForward,
     };
   },
   watch: {

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -28,19 +28,19 @@
       <div class="toolbar d-inline-block mt-3 position-relative" role="toolbar" aria-label="Toolbar" :class="{ 'ignore-pointer': canvasDragPosition }">
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Undo/redo controls">
           <button type="button" class="btn btn-sm btn-secondary" @click="undo" :disabled="!canUndo" data-test="undo" v-b-tooltip.hover  :title="`${$t('Undo')}`">
-            <font-awesome-icon class="" :icon="undoIcon" />
+            <font-awesome-icon :icon="undoIcon" />
           </button>
           <button type="button" class="btn btn-sm btn-secondary" @click="redo" :disabled="!canRedo" data-test="redo" v-b-tooltip.hover :title="`${$t('Redo')}`">
-            <font-awesome-icon class="" :icon="redoIcon" />
+            <font-awesome-icon :icon="redoIcon" />
           </button>
         </div>
 
         <div class="btn-group btn-group-sm mr-2" role="group" aria-label="Zoom controls">
           <button type="button" class="btn btn-sm btn-secondary" @click="scale += scaleStep" data-test="zoom-in">
-            <font-awesome-icon class="" :icon="plusIcon" />
+            <font-awesome-icon :icon="plusIcon" />
           </button>
           <button type="button" class="btn btn-sm btn-secondary" @click="scale = Math.max(minimumScale, scale -= scaleStep)" data-test="zoom-out">
-            <font-awesome-icon class="" :icon="minusIcon" />
+            <font-awesome-icon :icon="minusIcon" />
           </button>
           <button type="button" class="btn btn-sm btn-secondary" @click="scale = initialScale" :disabled="scale === initialScale" data-test="zoom-reset">{{ $t('Reset') }}</button>
           <span class="btn btn-sm btn-secondary scale-value">{{ Math.round(scale*100) }}%</span>
@@ -965,6 +965,10 @@ $vertex-error-color: #ED4757;
   .joint-marker-vertex:hover {
     fill: $vertex-error-color;
     cursor: url('../assets/delete-icon-vertex.png') 0 0, pointer;
+  }
+
+  .foo {
+    pointer-events: all !important;
   }
 }
 </style>


### PR DESCRIPTION
The purpose of this PR is to replace the undo/redo text with icons and have tooltips with undo/redo text.

Fixes #797 