### PR TITLE
Add new crown to Boundary Events

### DIFF
--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -88,9 +88,10 @@ export default {
   },
   computed: {
     style() {
-      const { x, y } = this.shape.findView(this.paper).getBBox();
+      const { x, y, width: shapeWidth } = this.shape.findView(this.paper).getBBox();
       const width = (this.node.diagram.bounds.width * this.paper.scale().sx);
-      return 'top:' + (y - 45) + 'px;left:' + (x + width - 20) + 'px;cursor:pointer';
+      const widthOffsetFromLabel = shapeWidth - width > 3 ? (shapeWidth / 2) - 15 : 0;
+      return 'top:' + (y - 45) + 'px;left:' + ((x + width - 20) + widthOffsetFromLabel) + 'px;cursor:pointer';
     },
     isValidMessageFlowSource() {
       return this.validMessageFlowSources.includes(this.node.type);

--- a/src/components/nodes/boundaryErrorEvent/boundaryErrorEvent.vue
+++ b/src/components/nodes/boundaryErrorEvent/boundaryErrorEvent.vue
@@ -1,7 +1,3 @@
-<template>
-  <div />
-</template>
-
 <script>
 import BoundaryEvent from '@/components/nodes/boundaryEvent/boundaryEvent';
 import errorBoltIcon from '@/assets/boundary-error-event-icon.svg';

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -215,7 +215,6 @@ export default {
   },
   async mounted() {
     this.shape = new EventShape();
-    this.shape.set('type', 'newCrown');
     this.setShapeProperties();
     this.shape.addTo(this.graph);
 

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -1,9 +1,23 @@
 <template>
-  <div />
+  <crown-config
+    :highlighted="highlighted"
+    :paper="paper"
+    :graph="graph"
+    :shape="shape"
+    :node="node"
+    :nodeRegistry="nodeRegistry"
+    :moddle="moddle"
+    :collaboration="collaboration"
+    :process-node="processNode"
+    :plane-elements="planeElements"
+    :is-rendering="isRendering"
+    @remove-node="$emit('remove-node', $event)"
+    @add-node="$emit('add-node', $event)"
+    @save-state="$emit('save-state', $event)"
+  />
 </template>
 
 <script>
-import crownConfig from '@/mixins/crownConfig';
 import portsConfig from '@/mixins/portsConfig';
 import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
@@ -12,10 +26,27 @@ import resetShapeColor from '@/components/resetShapeColor';
 import { getBoundaryAnchorPoint } from '@/portsUtils';
 import { invalidNodeColor } from '@/components/nodeColors';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
+import CrownConfig from '@/components/crownConfig';
+import highlightConfig from '@/mixins/highlightConfig';
 
 export default {
-  props: ['graph', 'node', 'paper', 'highlighted'],
-  mixins: [crownConfig, portsConfig, hideLabelOnDrag],
+  components: {
+    CrownConfig,
+  },
+  props: [
+    'graph',
+    'node',
+    'id',
+    'highlighted',
+    'nodeRegistry',
+    'moddle',
+    'paper',
+    'collaboration',
+    'processNode',
+    'planeElements',
+    'isRendering',
+  ],
+  mixins: [highlightConfig, portsConfig, hideLabelOnDrag],
   data() {
     return {
       shape: null,
@@ -104,7 +135,6 @@ export default {
       const { x, y } = getBoundaryAnchorPoint(this.getCenterPosition(), task);
       const { width, height } = this.shape.size();
       this.shape.position(x - (width / 2), y - (height / 2));
-      this.updateCrownPosition();
 
       this.previousPosition = this.shape.position();
     },
@@ -131,7 +161,6 @@ export default {
 
       if (!task) {
         this.resetToInitialPosition();
-        this.updateCrownPosition();
         return;
       }
 
@@ -186,6 +215,7 @@ export default {
   },
   async mounted() {
     this.shape = new EventShape();
+    this.shape.set('type', 'newCrown');
     this.setShapeProperties();
     this.shape.addTo(this.graph);
 

--- a/src/components/nodes/callActivity/callActivity.vue
+++ b/src/components/nodes/callActivity/callActivity.vue
@@ -109,7 +109,6 @@ export default {
   },
   mounted() {
     this.shape = new TaskShape();
-    this.shape.set('type', 'newCrown');
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -96,7 +96,6 @@ export default {
   },
   mounted() {
     this.shape = new TaskShape();
-    this.shape.set('type', 'newCrown');
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -102,7 +102,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     it('can stay anchored to task when moving pool', function() {
       configurePool({ x: 300, y: 300 }, nodeType, taskType);
       const taskSelector = '.main-paper ' +
-        '[data-type="newCrown"]';
+        '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
 
       cy.get(boundaryEventSelector).then($boundaryEvent => {
         cy.get(taskSelector).then($task => {

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -156,7 +156,7 @@ describe('Boundary Timer Event', () => {
     dragFromSourceToDest(nodeTypes.task, task2Position);
 
     const boundaryTimerEventSelector = '.main-paper ' +
-      '[data-type="newCrown"] ~ ' +
+      '[data-type="processmaker.components.nodes.task.Shape"] ~ ' +
       '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
 
     getPositionInPaperCoords(task2Position).then(newPosition => {
@@ -205,7 +205,7 @@ describe('Boundary Timer Event', () => {
     dragFromSourceToDest(nodeTypes.task, task2Position);
 
     const boundaryTimerEventSelector = '.main-paper ' +
-      '[data-type="newCrown"] ~ ' +
+      '[data-type="processmaker.components.nodes.task.Shape"] ~ ' +
       '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
 
     getPositionInPaperCoords(task2Position).then(newPosition => {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -3,11 +3,6 @@ import path from 'path';
 
 const renderTime = 300;
 
-const newCrown = [
-  'processmaker.components.nodes.task.Shape',
-  'processmaker.components.nodes.boundaryEvent.Shape',
-];
-
 export function getGraphElements() {
   return cy.window()
     .its('store.state.graph')
@@ -97,13 +92,21 @@ export function getPositionInPaperCoords(position) {
 }
 
 export function getCrownButtonForElement($element, crownButton) {
-  if (newCrown.includes($element.data('type'))) {
+  if (hasNewCrownConfig($element)) {
     return cy.get(`#${ crownButton }`);
   }
   return cy
     .get(`#${$element.attr('id')} ~ [data-test=${crownButton}]`)
     .then(crownButtons => crownButtons.filter((index, button) => Cypress.$(button).is(':visible')))
     .then(crownButtons => crownButtons[0]);
+}
+
+function hasNewCrownConfig($element) {
+  const newCrown = [
+    'processmaker.components.nodes.task.Shape',
+    'processmaker.components.nodes.boundaryEvent.Shape',
+  ];
+  return newCrown.includes($element.data('type'));
 }
 
 export function typeIntoTextInput(selector, value) {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -3,6 +3,11 @@ import path from 'path';
 
 const renderTime = 300;
 
+const newCrown = [
+  'processmaker.components.nodes.task.Shape',
+  'processmaker.components.nodes.boundaryEvent.Shape',
+];
+
 export function getGraphElements() {
   return cy.window()
     .its('store.state.graph')
@@ -92,7 +97,7 @@ export function getPositionInPaperCoords(position) {
 }
 
 export function getCrownButtonForElement($element, crownButton) {
-  if ($element.data('type') === 'newCrown') {
+  if (newCrown.includes($element.data('type'))) {
     return cy.get(`#${ crownButton }`);
   }
   return cy


### PR DESCRIPTION
I ended up removing the altered data-type = newCrown. It was used as a selector in tests and was now the same as tasks.

Can merge into #802 or switch the base to develop.

Closes: #803