### PR TITLE
Add crown to text annotation

### DIFF
--- a/src/assets/connect-artifacts.svg
+++ b/src/assets/connect-artifacts.svg
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg">
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="connect-artifacts" transform="translate(9.000000, 9.000000) scale(-1, 1) translate(-9.000000, -9.000000) ">
-            <path d="M1,1 L1,4 L4,4 L4,1 L1,1 Z M0,-2.22044605e-16 L5,-2.22044605e-16 L5,5 L0,5 L0,-2.22044605e-16 Z" id="connect-elements" fill="#788793" fill-rule="nonzero"></path>
-            <path d="M14,14 L14,17 L17,17 L17,14 L14,14 Z M13,13 L18,13 L18,18 L13,18 L13,13 Z" id="connect-elements" fill="#788793" fill-rule="nonzero"></path>
-            <path d="M4.5,4.5 L13.5,13.5" id="Line" stroke="#788793" stroke-linecap="square" stroke-dasharray="2"></path>
+            <path d="M1,1 L1,4 L4,4 L4,1 L1,1 Z M0,-2.22044605e-16 L5,-2.22044605e-16 L5,5 L0,5 L0,-2.22044605e-16 Z"
+                  id="connect-elements" fill="#fff" fill-rule="nonzero"></path>
+            <path d="M14,14 L14,17 L17,17 L17,14 L14,14 Z M13,13 L18,13 L18,18 L13,18 L13,13 Z" id="connect-elements"
+                  fill="#fff" fill-rule="nonzero"></path>
+            <path d="M4.5,4.5 L13.5,13.5" id="Line" stroke="#fff" stroke-linecap="square" stroke-dasharray="2"></path>
         </g>
     </g>
 </svg>

--- a/src/components/associationFlowButton.vue
+++ b/src/components/associationFlowButton.vue
@@ -1,0 +1,20 @@
+<template>
+  <img
+    v-on="$listeners"
+    :src="connectIcon"
+    data-test="message-flow-button"
+    id="association-flow-button"
+  >
+</template>
+
+<script>
+import connectIcon from '@/assets/connect-artifacts.svg';
+
+export default {
+  data() {
+    return {
+      connectIcon,
+    };
+  },
+};
+</script>

--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -1,6 +1,14 @@
 <template>
   <div class="crown-config" :style="style" v-if="showCrown">
+    <association-flow-button
+      v-b-tooltip.hover.viewport.d50
+      v-if="isTextAnnotation"
+      @click="addAssociation"
+      class="crown-config__icon"
+      :title="$t('Association Flow')"
+    />
     <sequence-flow-button
+      v-if="!isTextAnnotation"
       @click="addSequence"
       class="crown-config__icon"
       :title="$t('Sequence Flow')"
@@ -23,13 +31,16 @@
 import DeleteButton from '@/components/deleteButton';
 import MessageFlowButton from '@/components/messageFlowButton';
 import SequenceFlowButton from '@/components/sequenceFlowButton';
+import AssociationFlowButton from '@/components/associationFlowButton';
 import pull from 'lodash/pull';
+import { direction } from '@/components/nodes/association/associationConfig';
 
 export default {
   components: {
     DeleteButton,
     MessageFlowButton,
     SequenceFlowButton,
+    AssociationFlowButton,
   },
   props: [
     'highlighted',
@@ -101,6 +112,9 @@ export default {
     isValidMessageFlowSource() {
       return this.validMessageFlowSources.includes(this.node.type);
     },
+    isTextAnnotation() {
+      return this.node.type === 'processmaker-modeler-text-annotation';
+    },
   },
   methods: {
     addSequence(cellView, evt, x, y) {
@@ -136,6 +150,20 @@ export default {
       this.$emit('add-node', {
         type: 'processmaker-modeler-message-flow',
         definition: messageFlowDefinition,
+        diagram: this.moddle.create('bpmndi:BPMNEdge'),
+      });
+    },
+    addAssociation(cellView, evt, x, y) {
+      this.removeCrown();
+      const associationLink = this.moddle.create('bpmn:Association', {
+        sourceRef: this.shape.component.node.definition,
+        targetRef: { x, y },
+        associationDirection: direction.none,
+      });
+
+      this.$emit('add-node', {
+        type: 'processmaker-modeler-association',
+        definition: associationLink,
         diagram: this.moddle.create('bpmndi:BPMNEdge'),
       });
     },

--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -91,7 +91,12 @@ export default {
       const { x, y, width: shapeWidth } = this.shape.findView(this.paper).getBBox();
       const width = (this.node.diagram.bounds.width * this.paper.scale().sx);
       const widthOffsetFromLabel = shapeWidth - width > 3 ? (shapeWidth / 2) - 15 : 0;
-      return 'top:' + (y - 45) + 'px;left:' + ((x + width - 20) + widthOffsetFromLabel) + 'px;cursor:pointer';
+
+      return {
+        top: `${y - 45}px`,
+        left: `${x + width - 20 + widthOffsetFromLabel}px`,
+        cursor: 'pointer',
+      };
     },
     isValidMessageFlowSource() {
       return this.validMessageFlowSources.includes(this.node.type);

--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -1,18 +1,49 @@
 <template>
-  <div/>
+  <crown-config
+    :highlighted="highlighted"
+    :paper="paper"
+    :graph="graph"
+    :shape="shape"
+    :node="node"
+    :nodeRegistry="nodeRegistry"
+    :moddle="moddle"
+    :collaboration="collaboration"
+    :process-node="processNode"
+    :plane-elements="planeElements"
+    :is-rendering="isRendering"
+    @remove-node="$emit('remove-node', $event)"
+    @add-node="$emit('add-node', $event)"
+    @save-state="$emit('save-state', $event)"
+  />
 </template>
 
 <script>
 import { shapes, util } from 'jointjs';
 import connectIcon from '@/assets/connect-artifacts.svg';
-import crownConfig from '@/mixins/crownConfig';
 import portsConfig from '@/mixins/portsConfig';
 import { highlightPadding } from '@/mixins/crownConfig';
+import CrownConfig from '@/components/crownConfig';
+import highlightConfig from '@/mixins/highlightConfig';
 
 export const maxTextAnnotationWidth = 160;
 export default {
-  props: ['graph', 'node', 'id'],
-  mixins: [crownConfig, portsConfig],
+  components: {
+    CrownConfig,
+  },
+  props: [
+    'graph',
+    'node',
+    'id',
+    'highlighted',
+    'nodeRegistry',
+    'moddle',
+    'paper',
+    'collaboration',
+    'processNode',
+    'planeElements',
+    'isRendering',
+  ],
+  mixins: [highlightConfig, portsConfig],
   data() {
     return {
       shape: null,
@@ -49,9 +80,10 @@ export default {
       this.shape.resize(this.nodeWidth, newHeight - highlightPadding);
     },
     updateNodeText(text) {
-      let { height } = this.shape.findView(this.paper).getBBox();
+      const { height } = this.shape.findView(this.paper).getBBox();
       const refPoints = `25 ${height} 3 ${height} 3 3 25 3`;
       const bounds = this.node.diagram.bounds;
+
       this.shape.position(bounds.x, bounds.y);
       this.shape.attr({
         body: { refPoints },
@@ -63,9 +95,9 @@ export default {
           textAnchor: 'left',
         },
       });
+
       this.paper.once('render:done', () => {
         this.setElementHeight(height, bounds.height, text);
-        this.updateCrownPosition();
       });
     },
   },
@@ -86,10 +118,6 @@ export default {
         refX: '5',
         refY: '5',
       },
-    });
-
-    this.shape.on('change:size', () => {
-      this.updateCrownPosition();
     });
 
     this.shape.addTo(this.graph);

--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -19,7 +19,6 @@
 
 <script>
 import { shapes, util } from 'jointjs';
-import connectIcon from '@/assets/connect-artifacts.svg';
 import portsConfig from '@/mixins/portsConfig';
 import { highlightPadding } from '@/mixins/crownConfig';
 import CrownConfig from '@/components/crownConfig';
@@ -49,14 +48,6 @@ export default {
       shape: null,
       definition: null,
       nodeWidth: 10,
-      crownConfig: [
-        {
-          id: 'association-flow-button',
-          title: this.$t('Association Flow'),
-          icon: connectIcon,
-          clickHandler: this.addAssociation,
-        },
-      ],
     };
   },
   watch: {

--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -105,6 +105,7 @@ export default {
     const bounds = this.node.diagram.bounds;
 
     this.shape = new shapes.standard.Polyline();
+    this.shape.set('type', 'textAnnotation');
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(this.nodeWidth, bounds.height);
     this.shape.attr({

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -108,6 +108,7 @@ function hasNewCrownConfig($element) {
     'processmaker.components.nodes.intermediateEvent.Shape',
     'processmaker.components.nodes.startEvent.Shape',
     'processmaker.components.nodes.gateway.Shape',
+    'textAnnotation',
   ];
   return newCrown.includes($element.data('type'));
 }


### PR DESCRIPTION
Fixes #805.

This PR adds the new crown config to the text annotation component.

Before:
<img width="213" alt="Screen Shot 2019-11-14 at 11 40 01 AM" src="https://user-images.githubusercontent.com/7561061/68877120-8952ea00-06d3-11ea-8594-ab3c80d35445.png">

After:
<img width="264" alt="Screen Shot 2019-11-14 at 11 39 38 AM" src="https://user-images.githubusercontent.com/7561061/68877131-8c4dda80-06d3-11ea-95ce-6586c779c14a.png">

**Note:** The position of the crown config currently doesn't change when the text inside of it is modified. 