### PR TITLE
Add new crown to End Events

### DIFF
--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="crown-config" :style="style" v-if="showCrown">
     <sequence-flow-button
+      v-if="isValidSequenceFlowSource"
       @click="addSequence"
       class="crown-config__icon"
       :title="$t('Sequence Flow')"
@@ -67,6 +68,11 @@ export default {
         'processmaker-modeler-pool',
         'processmaker-modeler-intermediate-message-catch-event',
       ],
+      invalidSequenceFlowSources: [
+        'processmaker-modeler-end-event',
+        'processmaker-modeler-error-end-event',
+        'processmaker-modeler-message-end-event',
+      ],
     };
   },
   created() {
@@ -95,6 +101,9 @@ export default {
     },
     isValidMessageFlowSource() {
       return this.validMessageFlowSources.includes(this.node.type);
+    },
+    isValidSequenceFlowSource() {
+      return !this.invalidSequenceFlowSources.includes(this.node.type);
     },
   },
   methods: {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -19,7 +19,6 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/boundaryEvent/shape';
 import isValidBoundaryEventTarget from './validBoundaryEventTargets';
 import resetShapeColor from '@/components/resetShapeColor';
@@ -52,14 +51,6 @@ export default {
       shape: null,
       definition: null,
       previousPosition: null,
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
       validPosition: null,
       invalidTargetElement: null,
     };

--- a/src/components/nodes/callActivity/callActivity.vue
+++ b/src/components/nodes/callActivity/callActivity.vue
@@ -19,7 +19,6 @@
 
 <script>
 import { util } from 'jointjs';
-import connectIcon from '@/assets/connect-elements.svg';
 import portsConfig from '@/mixins/portsConfig';
 import TaskShape from '@/components/nodes/task/shape';
 import { taskHeight } from '@/components/nodes/task/taskConfig';
@@ -52,18 +51,6 @@ export default {
     'isRendering',
   ],
   mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag],
-  data() {
-    return {
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
-    };
-  },
   watch: {
     'node.definition.name'(name) {
       const { width } = this.node.diagram.bounds;

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -1,17 +1,48 @@
 <template>
-  <div/>
+  <crown-config
+    :highlighted="highlighted"
+    :paper="paper"
+    :graph="graph"
+    :shape="shape"
+    :node="node"
+    :nodeRegistry="nodeRegistry"
+    :moddle="moddle"
+    :collaboration="collaboration"
+    :process-node="processNode"
+    :plane-elements="planeElements"
+    :is-rendering="isRendering"
+    @remove-node="$emit('remove-node', $event)"
+    @add-node="$emit('add-node', $event)"
+    @save-state="$emit('save-state', $event)"
+  />
 </template>
 
 <script>
-import crownConfig from '@/mixins/crownConfig';
 import portsConfig from '@/mixins/portsConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import EventShape from '../startEvent/eventShape';
 import { endColor } from '@/components/nodeColors';
+import CrownConfig from '@/components/crownConfig';
+import highlightConfig from '@/mixins/highlightConfig';
 
 export default {
-  props: ['graph', 'node', 'id'],
-  mixins: [crownConfig, portsConfig, hideLabelOnDrag],
+  components: {
+    CrownConfig,
+  },
+  props: [
+    'graph',
+    'node',
+    'id',
+    'highlighted',
+    'nodeRegistry',
+    'moddle',
+    'paper',
+    'collaboration',
+    'processNode',
+    'planeElements',
+    'isRendering',
+  ],
+  mixins: [highlightConfig, portsConfig, hideLabelOnDrag],
   data() {
     return {
       shape: null,
@@ -25,6 +56,7 @@ export default {
   },
   mounted() {
     this.shape = new EventShape();
+    this.shape.set('type', 'processmaker.components.nodes.endEvent.Shape');
     const bounds = this.node.diagram.bounds;
     this.shape.position(bounds.get('x'), bounds.get('y'));
     this.shape.resize(bounds.get('width'), bounds.get('height'));

--- a/src/components/nodes/errorEndEvent/errorEndEvent.vue
+++ b/src/components/nodes/errorEndEvent/errorEndEvent.vue
@@ -1,7 +1,3 @@
-<template>
-  <div/>
-</template>
-
 <script>
 import EndEvent from '@/components/nodes/endEvent/endEvent';
 import errorIcon from '@/assets/error.svg';

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -19,7 +19,6 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import connectIcon from '@/assets/connect-elements.svg';
 import GatewayShape from '@/components/nodes/gateway/shape';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crownConfig';
@@ -48,14 +47,6 @@ export default {
       shape: null,
       definition: null,
       labelWidth: 175,
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
     };
   },
   watch: {

--- a/src/components/nodes/intermediateEvent/intermediateEvent.vue
+++ b/src/components/nodes/intermediateEvent/intermediateEvent.vue
@@ -19,7 +19,6 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from '@/components/nodes/intermediateEvent/shape';
 import hasMarkers from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
@@ -48,14 +47,6 @@ export default {
     return {
       shape: null,
       definition: null,
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
     };
   },
   watch: {

--- a/src/components/nodes/messageEndEvent/messageEndEvent.vue
+++ b/src/components/nodes/messageEndEvent/messageEndEvent.vue
@@ -1,7 +1,3 @@
-<template>
-  <div/>
-</template>
-
 <script>
 import EndEvent from '@/components/nodes/endEvent/endEvent';
 import messageEndEventSymbol from '@/assets/message-end-event.svg';

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -19,7 +19,6 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import connectIcon from '@/assets/connect-elements.svg';
 import EventShape from './eventShape';
 import hasMarkers from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
@@ -49,14 +48,6 @@ export default {
     return {
       shape: null,
       definition: null,
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
     };
   },
   watch: {

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -19,7 +19,6 @@
 
 <script>
 import { util } from 'jointjs';
-import connectIcon from '@/assets/connect-elements.svg';
 import highlightConfig from '@/mixins/highlightConfig';
 import portsConfig from '@/mixins/portsConfig';
 import hasMarkers from '@/mixins/hasMarkers';
@@ -54,14 +53,6 @@ export default {
     return {
       shape: null,
       definition: null,
-      crownConfig: [
-        {
-          id: 'sequence-flow-button',
-          title: this.$t('Sequence Flow'),
-          icon: connectIcon,
-          clickHandler: this.addSequence,
-        },
-      ],
     };
   },
   computed: {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -107,6 +107,7 @@ function hasNewCrownConfig($element) {
     'processmaker.components.nodes.boundaryEvent.Shape',
     'processmaker.components.nodes.intermediateEvent.Shape',
     'processmaker.components.nodes.startEvent.Shape',
+    'processmaker.components.nodes.endEvent.Shape',
     'processmaker.components.nodes.gateway.Shape',
   ];
   return newCrown.includes($element.data('type'));


### PR DESCRIPTION
Closes #806 

Has some extra height on start, end and intermediate events. This shows up when moving the element after dropping it onto the diagram. Ignoring for now.
![Screen Shot 2019-11-13 at 4 44 32 PM](https://user-images.githubusercontent.com/6653340/68807950-cddc7800-0636-11ea-91b8-b906a8172ef3.png)