### PR TITLE
Merge warning and error panels

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -320,9 +320,8 @@ export default {
       });
     },
     async validateBpmnDiagram() {
-      const validationErrors = await this.linter.lint(this.definitions);
-      this.validationErrors = validationErrors;
-      this.$emit('validate', validationErrors);
+      this.validationErrors = await this.linter.lint(this.definitions);
+      this.$emit('validate', this.validationErrors);
     },
     undo() {
       if (this.isRendering) {
@@ -683,7 +682,7 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
-      const node = {type: control.type, definition, diagram};
+      const node = { type: control.type, definition, diagram };
       this.highlightNode(node);
       this.addNode(node);
     },

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -11,9 +11,13 @@
 
     <span class="divider" />
 
-    <div v-if="toggleValidationPanel && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
+    <div v-if="isProblemsPanelDisplayed && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
       <div class="validation-container-list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
-        <font-awesome-icon class="status-bar-container-status-icon ml-1 mr-2 mt-1" :style="{ color: iconColor }" :icon="validationIcon" />
+        <font-awesome-icon
+          class="status-bar-container-status-icon ml-1 mr-2 mt-1"
+          :style="{ color: isErrorCategory(error) ? errorColor : warningColor }"
+          :icon="isErrorCategory(error) ? faTimesCircle: faExclamationTriangle"
+        />
         <div class="validation-container-list-message">
           <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
           <p class="mb-0"><em>{{ error.message }}.</em></p>
@@ -30,24 +34,24 @@
       </div>
     </div>
 
-    <button v-if="hasNoIssues" type="button" class="btn btn-light" :disabled="hasNoIssues" @click="toggleValidationPanel = !toggleValidationPanel">
+    <button v-if="numberOfProblems === 0" type="button" class="btn btn-light" :disabled="numberOfProblems === 0" @click="isProblemsPanelDisplayed = !isProblemsPanelDisplayed">
       BPMN Valid
       <span class="badge badge-success badge-pill">
-        <font-awesome-icon :icon="checkMarkIcon" />
+        <font-awesome-icon :icon="faCheck" />
       </span>
     </button>
-    <button v-else type="button" data-test="validation-list-toggle" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+    <button v-else type="button" data-test="validation-list-toggle" class="btn btn-light" @click="isProblemsPanelDisplayed = !isProblemsPanelDisplayed">
       BPMN Issues
       <span class="badge badge-primary badge-pill">
         {{ numberOfProblems }}
       </span>
-      <font-awesome-icon class="ml-3" :icon="toggleValidationPanel? chevronUpIcon : chevronDownIcon" />
+      <font-awesome-icon class="ml-3" :icon="isProblemsPanelDisplayed? faChevronUp : faChevronDown" />
     </button>
   </div>
 </template>
 
 <script>
-import { faCheck, faCheckCircle, faChevronDown, faChevronUp, faExclamationTriangle, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCheck, faChevronDown, faChevronUp, faExclamationTriangle, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import store from '@/store';
 
@@ -58,26 +62,15 @@ export default {
   props: ['validationErrors', 'warnings'],
   data() {
     return {
-      toggleValidationPanel: false,
+      isProblemsPanelDisplayed: false,
       errorColor: '#D9534F',
       warningColor: '#F0AD4E',
-      toggleWarningsPanel: false,
       faExclamationTriangle,
-      faCheckCircle,
-      chevronUpIcon: faChevronUp,
-      chevronDownIcon: faChevronDown,
-      checkMarkIcon: faCheck,
+      faTimesCircle,
+      faChevronUp,
+      faChevronDown,
+      faCheck,
     };
-  },
-  watch: {
-    warnings() {
-      this.toggleWarningsPanel = this.warnings.length > 0;
-    },
-    hasIssues(value) {
-      if (value) {
-        this.toggleValidationPanel = false;
-      }
-    },
   },
   computed: {
     autoValidate: {
@@ -88,9 +81,6 @@ export default {
         store.commit('setAutoValidate', autoValidate);
       },
     },
-    hasNoIssues() {
-      return this.numberOfProblems === 0;
-    },
     errorList() {
       return Object.entries(this.validationErrors)
         .flatMap(([errorKey, errors]) => {
@@ -99,26 +89,13 @@ export default {
           });
         });
     },
-    getCategory() {
-      return this.errorList.find((category) => {
-        return category;
-      });
-    },
-    validationIcon() {
-      return this.isError
-        ? faTimesCircle
-        : faExclamationTriangle;
-    },
-    isError() {
-      return this.getCategory.category === 'error';
-    },
-    iconColor() {
-      return this.isError
-        ? `${this.errorColor}`
-        : `${this.warningColor}`;
-    },
     numberOfProblems() {
       return this.errorList.length + this.warnings.length;
+    },
+  },
+  methods: {
+    isErrorCategory(error) {
+      return error.category === 'error';
     },
   },
 };

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -13,17 +13,13 @@
       <div class="divider"/>
 
       <div v-if="toggleValidationPanel" class="validation-container position-absolute text-left" data-test="validation-list">
-        <div class="validation-container__list d-flex justify-content-between" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`" >
-          <span class="validation-container__list--errorCategory d-flex justify-content-center">
-            <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="validationIcon" />
-          </span>
-          <span class="validation-container__list--id">
-            {{ error.id }}
-          </span>
-          <span class="validation-container__list--message">
-            <span class="validation-container__list--key">{{ error.errorKey }}</span>
-            <div>{{ $t(error.message) }}</div>
-          </span>
+        <div class="validation-container__list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`" >
+          <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-2 mt-1" :style="{ color: iconColor }" :icon="validationIcon" />
+          <div>
+            <div class="font-weight-bold text-capitalize">{{ error.errorKey }}</div>
+            <div><span class="font-weight-bold mr-1">Element:</span>{{ error.id }}</div>
+            <div>{{ error.message }}</div>
+          </div>
         </div>
 
         <div
@@ -178,10 +174,6 @@ $warning-color: #F0AD4E;
   &__status {
     cursor: pointer;
   }
-
-  &__status-icon {
-    margin: 0 0.75rem;
-  }
 }
 
 .divider {
@@ -204,7 +196,7 @@ $warning-color: #F0AD4E;
   border-right: none;
 
   &__list {
-    padding: 1rem;
+    padding: 0.5rem;
     word-wrap: break-word;
 
     &--id {
@@ -215,11 +207,6 @@ $warning-color: #F0AD4E;
 
     &--message {
       width: $message-container-width;
-    }
-
-    &--errorCategory {
-      padding: 0.25rem 1rem 0 0.5rem;
-      width: $error-category-width;
     }
 
     &--key {

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -21,7 +21,7 @@
         <div class="validation-container-list-message">
           <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
           <p class="mb-0"><em>{{ error.message }}.</em></p>
-          <p class="mb-0" v-if="error.id"><strong>Node ID:</strong> {{ error.id }}</p>
+          <p class="mb-0" v-if="error.id"><strong>{{ $t('Node ID') }}:</strong> {{ error.id }}</p>
         </div>
       </div>
 
@@ -35,13 +35,13 @@
     </div>
 
     <button v-if="numberOfProblems === 0" type="button" class="btn btn-light" :disabled="numberOfProblems === 0" @click="isProblemsPanelDisplayed = !isProblemsPanelDisplayed">
-      BPMN Valid
+      {{ $t('BPMN Valid') }}
       <span class="badge badge-success badge-pill">
         <font-awesome-icon :icon="faCheck" />
       </span>
     </button>
     <button v-else type="button" data-test="validation-list-toggle" class="btn btn-light" @click="isProblemsPanelDisplayed = !isProblemsPanelDisplayed">
-      BPMN Issues
+      {{ $t('BPMN Issues') }}
       <span class="badge badge-primary badge-pill">
         {{ numberOfProblems }}
       </span>

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -15,7 +15,7 @@
       <div v-if="toggleValidationPanel" class="validation-container position-absolute text-left">
         <div class="validation-container__list d-flex justify-content-between" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`" >
           <span class="validation-container__list--errorCategory d-flex justify-content-center">
-            <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="valditionIcon" />
+            <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="validationIcon" />
           </span>
           <span class="validation-container__list--id">
             {{ error.id }}
@@ -42,7 +42,7 @@
       </div>
 
       <div v-if="warnings.length === 0 && !numberOfValidationErrors">
-        <button type="button" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+        <button type="button" class="btn btn-light" :disabled="warnings.length === 0 && !numberOfValidationErrors" @click="toggleValidationPanel = !toggleValidationPanel">
           BPMN Valid
           <span class="badge badge-success badge-pill">
             <font-awesome-icon :icon="checkMarkIcon" />
@@ -128,7 +128,7 @@ export default {
         ? this.chevronUpIcon
         : this.chevronDownIcon;
     },
-    valditionIcon() {
+    validationIcon() {
       return this.isErrorOrWarning
         ? faTimesCircle
         : faExclamationTriangle;

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -78,12 +78,19 @@
           <font-awesome-icon class="status-bar-container__status-ellipsis" :icon="ellipsisIcon" />
         </div>
       </div>
+
+      <button type="button" class="btn btn-light">
+        BPMN Issues
+        <span class="badge badge-primary badge-pill">{{ warnings.length + numberOfValidationErrors }}</span>
+        <font-awesome-icon class="ml-3"   :icon="chevronDownIcon" />
+      </button>
+
     </div>
   </div>
 </template>
 
 <script>
-import { faCheckCircle, faTimesCircle, faEllipsisV, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faTimesCircle, faEllipsisV, faExclamationTriangle, faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import store from '@/store';
 
@@ -101,6 +108,8 @@ export default {
       toggleWarningsPanel: this.warnings.length > 0,
       faExclamationTriangle,
       faCheckCircle,
+      chevronUpIcon: faChevronUp,
+      chevronDownIcon: faChevronDown,
     };
   },
   watch: {

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -34,7 +34,7 @@
       </div>
     </div>
 
-    <button v-if="numberOfProblems === 0" type="button" class="btn btn-light" :disabled="numberOfProblems === 0" @click="isProblemsPanelDisplayed = !isProblemsPanelDisplayed">
+    <button v-if="numberOfProblems === 0" type="button" class="btn btn-light" :disabled="true">
       {{ $t('BPMN Valid') }}
       <span class="badge badge-success badge-pill">
         <font-awesome-icon :icon="faCheck" />

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -1,50 +1,5 @@
 <template>
   <div>
-    <div data-test="validation-list" class="validation-container position-absolute text-left" v-if="toggleValidationPanel">
-      <span
-        class="validation-container__defaultMessage d-flex justify-content-center align-items-center h-100"
-        v-if="!numberOfValidationErrors"
-      >{{ $t('no problems to report') }}</span>
-
-      <div class="validation-container__list d-flex justify-content-between" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
-        <span class="validation-container__list--errorCategory d-flex justify-content-center">
-          <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="valditionIcon" />
-        </span>
-        <span class="validation-container__list--id">
-          {{ error.id }}
-        </span>
-        <span class="validation-container__list--message">
-          <span class="validation-container__list--key">{{ error.errorKey }}</span>
-          <div>{{ $t(error.message) }}</div>
-        </span>
-      </div>
-    </div>
-
-    <div
-      data-test="validation-list"
-      class="validation-container position-absolute text-left"
-      v-if="toggleWarningsPanel"
-    >
-      <span
-        class="validation-container__defaultMessage d-flex justify-content-center align-items-center h-100"
-        v-if="warnings.length === 0"
-      >{{ $t('no warnings to report') }}</span>
-
-      <div
-        class="validation-container__list d-flex"
-        v-for="(error, index) in warnings" :key="index"
-      >
-        <span class="validation-container__list--errorCategory d-flex justify-content-center mr-2">
-          <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
-        </span>
-
-        <span class="validation-container__list--message">
-          <span class="validation-container__list--key">{{ error.title }}</span>
-          <div>{{ $t(error.text) }}</div>
-        </span>
-      </div>
-    </div>
-
     <div class="status-bar-container d-flex align-items-center justify-content-end">
       <b-form-checkbox
         data-test="validation-toggle"
@@ -57,40 +12,60 @@
 
       <div class="divider"/>
 
-      <div data-test="validation-list-toggle" class="status-bar-container__status" @click="toggleValidationPanel = !toggleValidationPanel; toggleWarningsPanel = false">
-        <div class="d-flex align-items-center">
-          <span class="status-bar-container__status-text">{{ $t('Problems') }} {{ numberOfValidationErrors }}</span>
-          <font-awesome-icon class="status-bar-container__status-icon h-100" :style="{ color: statusColor }" :icon="statusIcon" />
-          <font-awesome-icon class="status-bar-container__status-ellipsis" :icon="ellipsisIcon" />
+      <div v-if="toggleValidationPanel" class="validation-container position-absolute text-left">
+        <div class="validation-container__list d-flex justify-content-between" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`" >
+          <span class="validation-container__list--errorCategory d-flex justify-content-center">
+            <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="valditionIcon" />
+          </span>
+          <span class="validation-container__list--id">
+            {{ error.id }}
+          </span>
+          <span class="validation-container__list--message">
+            <span class="validation-container__list--key">{{ error.errorKey }}</span>
+            <div>{{ $t(error.message) }}</div>
+          </span>
+        </div>
+
+        <div
+          class="validation-container__list d-flex"
+          v-for="(error, index) in warnings" :key="index"
+        >
+          <span class="validation-container__list--errorCategory d-flex justify-content-center mr-2">
+            <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
+          </span>
+
+          <span class="validation-container__list--message">
+            <span class="validation-container__list--key">{{ error.title }}</span>
+            <div>{{ $t(error.text) }}</div>
+          </span>
         </div>
       </div>
 
-      <div class="divider"/>
-
-      <div class="status-bar-container__status" @click="toggleWarningsPanel = !toggleWarningsPanel; toggleValidationPanel = false">
-        <div class="d-flex align-items-center">
-          <span class="status-bar-container__status-text">{{ $t('Warnings') }} {{ warnings.length }}</span>
-          <font-awesome-icon
-            class="status-bar-container__status-icon h-100"
-            :style="{ color: warnings.length > 0 ? warningColor : validColor }"
-            :icon="warnings.length > 0 ? faExclamationTriangle : faCheckCircle"
-          />
-          <font-awesome-icon class="status-bar-container__status-ellipsis" :icon="ellipsisIcon" />
-        </div>
+      <div v-if="warnings.length === 0 && !numberOfValidationErrors">
+        <button type="button" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+          BPMN Valid
+          <span class="badge badge-success badge-pill">
+            <font-awesome-icon :icon="checkMarkIcon" />
+          </span>
+        </button>
       </div>
 
-      <button type="button" class="btn btn-light">
-        BPMN Issues
-        <span class="badge badge-primary badge-pill">{{ warnings.length + numberOfValidationErrors }}</span>
-        <font-awesome-icon class="ml-3"   :icon="chevronDownIcon" />
-      </button>
+      <div v-else>
+        <button type="button" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+          BPMN Issues
+          <span class="badge badge-primary badge-pill">
+            {{ warnings.length + numberOfValidationErrors }}
+          </span>
+          <font-awesome-icon class="ml-3" :icon="chevronToggle" />
+        </button>
+      </div>
 
     </div>
   </div>
 </template>
 
 <script>
-import { faCheckCircle, faTimesCircle, faEllipsisV, faExclamationTriangle, faChevronUp, faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faTimesCircle, faExclamationTriangle, faChevronUp, faChevronDown, faCheck } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import store from '@/store';
 
@@ -110,6 +85,7 @@ export default {
       faCheckCircle,
       chevronUpIcon: faChevronUp,
       chevronDownIcon: faChevronDown,
+      checkMarkIcon: faCheck,
     };
   },
   watch: {
@@ -147,13 +123,10 @@ export default {
       });
       return errorCategory;
     },
-    ellipsisIcon() {
-      return faEllipsisV;
-    },
-    statusIcon() {
-      return this.hasValidationErrors
-        ? faTimesCircle
-        : faCheckCircle;
+    chevronToggle() {
+      return this.toggleValidationPanel
+        ? this.chevronUpIcon
+        : this.chevronDownIcon;
     },
     valditionIcon() {
       return this.isErrorOrWarning

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -37,8 +37,8 @@
         </div>
       </div>
 
-      <div v-if="warnings.length === 0 && !numberOfValidationErrors">
-        <button type="button" class="btn btn-light" :disabled="warnings.length === 0 && !numberOfValidationErrors" @click="toggleValidationPanel = !toggleValidationPanel">
+      <div v-if="hasIssues">
+        <button type="button" class="btn btn-light" :disabled="hasIssues" @click="toggleValidationPanel = !toggleValidationPanel">
           BPMN Valid
           <span class="badge badge-success badge-pill">
             <font-awesome-icon :icon="checkMarkIcon" />
@@ -88,6 +88,11 @@ export default {
     warnings() {
       this.toggleWarningsPanel = this.warnings.length > 0;
     },
+    hasIssues(value) {
+      if (value) {
+        this.toggleValidationPanel = false;
+      }
+    },
   },
   computed: {
     autoValidate: {
@@ -97,6 +102,9 @@ export default {
       set(autoValidate) {
         store.commit('setAutoValidate', autoValidate);
       },
+    },
+    hasIssues() {
+      return this.warnings.length === 0 && !this.numberOfValidationErrors;
     },
     errorList() {
       return Object.entries(this.validationErrors).reduce((errorList, [ errorKey, errors ]) => {

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -176,7 +176,7 @@ export default {
 
 <style scoped lang="scss">
 $primary-white: #f7f7f7;
-$seconadry-grey: #555555;
+$secondary-grey: #555555;
 $secondary-blue: #3397e1;
 $border-color: rgba(0, 0, 0, 0.125);
 $id-container-width: 6.5rem;
@@ -190,7 +190,7 @@ $warning-color: #F0AD4E;
 $button-color: #3BD7FF;
 
 .status-bar-container {
-  color: $seconadry-grey;
+  color: $secondary-grey;
   height: $status-bar-container-height;
   cursor: pointer;
 
@@ -236,7 +236,7 @@ $button-color: #3BD7FF;
 
     &--id {
       width: $id-container-width;
-      color: $seconadry-grey;
+      color: $secondary-grey;
       text-transform: none;
     }
 

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -12,26 +12,29 @@
     <span class="divider" />
 
     <div v-if="isProblemsPanelDisplayed && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
-      <div class="validation-container__list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
-        <font-awesome-icon
-          class="status-bar-container__status-icon ml-1 mr-2 mt-1"
-          :style="{ color: isErrorCategory(error) ? errorColor : warningColor }"
-          :icon="isErrorCategory(error) ? faTimesCircle: faExclamationTriangle"
-        />
-        <div class="validation-container__list--message">
-          <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
-          <p class="mb-0"><em>{{ error.message }}.</em></p>
-          <p class="mb-0" v-if="error.id"><strong>{{ $t('Node ID') }}:</strong> {{ error.id }}</p>
-        </div>
-      </div>
-
-      <div class="validation-container__list d-flex align-items-baseline" v-for="(warning, index) in warnings" :key="index">
-        <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-2 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
-        <div class="validation-container__list--message">
-          <h6 class="text-capitalize mb-0">{{ warning.title }}</h6>
-          <p class="mb-0"><em>{{ warning.text }}.</em></p>
-        </div>
-      </div>
+      <dl class="validation-container__list align-items-baseline">
+        <template v-for="error in errorList">
+          <dt class="text-capitalize" :key="`${error.id}_${error.errorKey}`">
+            <font-awesome-icon
+              class="status-bar-container__status-icon ml-1 mr-1 mt-1"
+              :style="{ color: isErrorCategory(error) ? errorColor : warningColor }"
+              :icon="isErrorCategory(error) ? faTimesCircle: faExclamationTriangle"
+            />
+            {{ error.errorKey }}
+          </dt>
+          <dd :key="`${error.id}_${error.errorKey}`">
+            <p class="pl-4 mb-0 font-italic">{{ error.message }}.</p>
+            <p class="pl-4 mb-0" v-if="error.id"><span class="font-weight-bold">{{ $t('Node ID') }}:</span> {{ error.id }}</p>
+          </dd>
+        </template>
+        <template v-for="(warning, index) in warnings">
+          <dt class="text-capitalize" :key="index">
+            <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-1 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
+            {{ warning.title }}
+          </dt>
+          <dd :key="index" class="font-italic pl-4">{{ warning.text }}</dd>
+        </template>
+      </dl>
     </div>
 
     <button v-if="numberOfProblems === 0" type="button" class="btn btn-light" :disabled="true">

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -169,7 +169,6 @@ $validation-container-width: 25rem;
 $status-bar-container-height: 3rem;
 $error-color: #D9534F;
 $warning-color: #F0AD4E;
-$button-color: #3BD7FF;
 
 .status-bar-container {
   color: $secondary-grey;
@@ -178,10 +177,6 @@ $button-color: #3BD7FF;
 
   &__status {
     cursor: pointer;
-  }
-
-  &__status-ellipsis:hover {
-    color: $secondary-blue;
   }
 
   &__status-icon {
@@ -208,10 +203,6 @@ $button-color: #3BD7FF;
   border-radius: 0.25rem;
   border-right: none;
 
-  &__defaultMessage {
-    text-transform: capitalize;
-  }
-
   &__list {
     padding: 1rem;
     word-wrap: break-word;
@@ -235,14 +226,6 @@ $button-color: #3BD7FF;
       font-weight: 700;
       text-transform: capitalize;
     }
-  }
-
-  .label-background-warning {
-    background-color: $warning-color;
-  }
-
-  .label-background-error {
-    background-color: $error-color;
   }
 }
 </style>

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -11,8 +11,8 @@
 
     <span class="divider" />
 
-    <div v-if="isProblemsPanelDisplayed && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
-      <dl class="validation-container__list align-items-baseline">
+    <div v-if="isProblemsPanelDisplayed && numberOfProblems" class="validation-container position-absolute text-left">
+      <dl class="validation-container__list align-items-baseline" data-test="validation-list">
         <template v-for="error in errorList">
           <dt class="text-capitalize" :key="`${error.id}_${error.errorKey}`">
             <font-awesome-icon

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -12,22 +12,22 @@
     <span class="divider" />
 
     <div v-if="isProblemsPanelDisplayed && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
-      <div class="validation-container-list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
+      <div class="validation-container__list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
         <font-awesome-icon
-          class="status-bar-container-status-icon ml-1 mr-2 mt-1"
+          class="status-bar-container__status-icon ml-1 mr-2 mt-1"
           :style="{ color: isErrorCategory(error) ? errorColor : warningColor }"
           :icon="isErrorCategory(error) ? faTimesCircle: faExclamationTriangle"
         />
-        <div class="validation-container-list-message">
+        <div class="validation-container__list--message">
           <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
           <p class="mb-0"><em>{{ error.message }}.</em></p>
           <p class="mb-0" v-if="error.id"><strong>{{ $t('Node ID') }}:</strong> {{ error.id }}</p>
         </div>
       </div>
 
-      <div class="validation-container-list d-flex align-items-baseline" v-for="(warning, index) in warnings" :key="index">
-        <font-awesome-icon class="status-bar-container-status-icon ml-1 mr-2 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
-        <div class="validation-container-list-message">
+      <div class="validation-container__list d-flex align-items-baseline" v-for="(warning, index) in warnings" :key="index">
+        <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-2 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
+        <div class="validation-container__list--message">
           <h6 class="text-capitalize mb-0">{{ warning.title }}</h6>
           <p class="mb-0"><em>{{ warning.text }}.</em></p>
         </div>
@@ -114,7 +114,7 @@ $status-bar-container-height: 3rem;
   color: $secondary-grey;
   height: $status-bar-container-height;
 
-  &-status {
+  &__status {
     cursor: pointer;
   }
 }
@@ -139,11 +139,11 @@ $status-bar-container-height: 3rem;
   border-radius: 0.25rem;
   border-right: none;
 
-  &-list {
+  &__list {
     padding: 0.5rem;
     word-wrap: break-word;
 
-    &-message {
+    &--message {
       width: $message-container-width;
     }
   }

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -1,50 +1,48 @@
 <template>
-  <div>
-    <div class="status-bar-container d-flex align-items-center justify-content-end">
-      <b-form-checkbox
-        data-test="validation-toggle"
-        class="h-100 d-flex align-items-center"
-        v-model="autoValidate"
-        switch
-      >
-        {{ $t('Auto validate') }}
-      </b-form-checkbox>
+  <div class="status-bar-container d-flex align-items-center justify-content-end">
+    <b-form-checkbox
+      data-test="validation-toggle"
+      class="h-100 d-flex align-items-center"
+      v-model="autoValidate"
+      switch
+    >
+      {{ $t('Auto validate') }}
+    </b-form-checkbox>
 
-      <div class="divider" />
+    <span class="divider" />
 
-      <div v-if="toggleValidationPanel && !hasNoIssues" class="validation-container position-absolute text-left" data-test="validation-list">
-        <div class="validation-container__list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
-          <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-2 mt-1" :style="{ color: iconColor }" :icon="validationIcon" />
-          <div class="validation-container__list--message">
-            <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
-            <p class="mb-0"><em>{{ $t(error.message) }}.</em></p>
-            <p class="mb-0" v-if="error.id"><strong>Node ID:</strong> {{ error.id }}</p>
-          </div>
-        </div>
-
-        <div class="validation-container__list d-flex align-items-baseline" v-for="(warning, index) in warnings" :key="index">
-          <font-awesome-icon class="status-bar-container__status-icon ml-1 mr-2 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
-          <div class="validation-container__list--message">
-            <h6 class="text-capitalize mb-0">{{ warning.title }}</h6>
-            <p class="mb-0"><em>{{ $t(warning.text) }}.</em></p>
-          </div>
+    <div v-if="toggleValidationPanel && numberOfProblems" class="validation-container position-absolute text-left" data-test="validation-list">
+      <div class="validation-container-list d-flex align-items-baseline" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`">
+        <font-awesome-icon class="status-bar-container-status-icon ml-1 mr-2 mt-1" :style="{ color: iconColor }" :icon="validationIcon" />
+        <div class="validation-container-list-message">
+          <h6 class="text-capitalize mb-0">{{ error.errorKey }}</h6>
+          <p class="mb-0"><em>{{ error.message }}.</em></p>
+          <p class="mb-0" v-if="error.id"><strong>Node ID:</strong> {{ error.id }}</p>
         </div>
       </div>
 
-      <button v-if="hasNoIssues" type="button" class="btn btn-light" :disabled="hasNoIssues" @click="toggleValidationPanel = !toggleValidationPanel">
-        BPMN Valid
-        <span class="badge badge-success badge-pill">
-          <font-awesome-icon :icon="checkMarkIcon" />
-        </span>
-      </button>
-      <button v-else type="button" data-test="validation-list-toggle" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
-        BPMN Issues
-        <span class="badge badge-primary badge-pill">
-          {{ warnings.length + numberOfValidationErrors }}
-        </span>
-        <font-awesome-icon class="ml-3" :icon="toggleValidationPanel? chevronUpIcon : chevronDownIcon" />
-      </button>
+      <div class="validation-container-list d-flex align-items-baseline" v-for="(warning, index) in warnings" :key="index">
+        <font-awesome-icon class="status-bar-container-status-icon ml-1 mr-2 mt-1" :style="{ color: warningColor }" :icon="faExclamationTriangle" />
+        <div class="validation-container-list-message">
+          <h6 class="text-capitalize mb-0">{{ warning.title }}</h6>
+          <p class="mb-0"><em>{{ warning.text }}.</em></p>
+        </div>
+      </div>
     </div>
+
+    <button v-if="hasNoIssues" type="button" class="btn btn-light" :disabled="hasNoIssues" @click="toggleValidationPanel = !toggleValidationPanel">
+      BPMN Valid
+      <span class="badge badge-success badge-pill">
+        <font-awesome-icon :icon="checkMarkIcon" />
+      </span>
+    </button>
+    <button v-else type="button" data-test="validation-list-toggle" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+      BPMN Issues
+      <span class="badge badge-primary badge-pill">
+        {{ numberOfProblems }}
+      </span>
+      <font-awesome-icon class="ml-3" :icon="toggleValidationPanel? chevronUpIcon : chevronDownIcon" />
+    </button>
   </div>
 </template>
 
@@ -91,7 +89,7 @@ export default {
       },
     },
     hasNoIssues() {
-      return this.warnings.length === 0 && this.numberOfValidationErrors === 0;
+      return this.numberOfProblems === 0;
     },
     errorList() {
       return Object.entries(this.validationErrors)
@@ -119,8 +117,8 @@ export default {
         ? `${this.errorColor}`
         : `${this.warningColor}`;
     },
-    numberOfValidationErrors() {
-      return this.errorList.length;
+    numberOfProblems() {
+      return this.errorList.length + this.warnings.length;
     },
   },
 };
@@ -129,23 +127,17 @@ export default {
 <style scoped lang="scss">
 $primary-white: #f7f7f7;
 $secondary-grey: #555555;
-$secondary-blue: #3397e1;
 $border-color: rgba(0, 0, 0, 0.125);
-$id-container-width: 6.5rem;
 $message-container-width: 18rem;
-$error-category-width: 1rem;
 $validation-container-height: 14rem;
 $validation-container-width: 25rem;
 $status-bar-container-height: 3rem;
-$error-color: #D9534F;
-$warning-color: #F0AD4E;
 
 .status-bar-container {
   color: $secondary-grey;
   height: $status-bar-container-height;
-  cursor: pointer;
 
-  &__status {
+  &-status {
     cursor: pointer;
   }
 }
@@ -158,6 +150,7 @@ $warning-color: #F0AD4E;
 }
 
 .validation-container {
+  cursor: default;
   bottom: 0;
   right: 0;
   height: $validation-container-height;
@@ -169,23 +162,12 @@ $warning-color: #F0AD4E;
   border-radius: 0.25rem;
   border-right: none;
 
-  &__list {
+  &-list {
     padding: 0.5rem;
     word-wrap: break-word;
 
-    &--id {
-      width: $id-container-width;
-      color: $secondary-grey;
-      text-transform: none;
-    }
-
-    &--message {
+    &-message {
       width: $message-container-width;
-    }
-
-    &--key {
-      font-weight: 700;
-      text-transform: capitalize;
     }
   }
 }

--- a/src/components/ValidationStatus.vue
+++ b/src/components/ValidationStatus.vue
@@ -12,7 +12,7 @@
 
       <div class="divider"/>
 
-      <div v-if="toggleValidationPanel" class="validation-container position-absolute text-left">
+      <div v-if="toggleValidationPanel" class="validation-container position-absolute text-left" data-test="validation-list">
         <div class="validation-container__list d-flex justify-content-between" v-for="error in errorList" :key="`${error.id}_${error.errorKey}`" >
           <span class="validation-container__list--errorCategory d-flex justify-content-center">
             <font-awesome-icon class="status-bar-container__status-icon" :style="{ color: iconColor }" :icon="validationIcon" />
@@ -51,7 +51,7 @@
       </div>
 
       <div v-else>
-        <button type="button" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
+        <button type="button" data-test="validation-list-toggle" class="btn btn-light" @click="toggleValidationPanel = !toggleValidationPanel">
           BPMN Issues
           <span class="badge badge-primary badge-pill">
             {{ warnings.length + numberOfValidationErrors }}

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -241,8 +241,8 @@ describe('Modeler', () => {
     cy.get('[data-test=validation-toggle]').click({ force: true });
     cy.get('[data-test=validation-list-toggle]').click();
 
-    const initialNumberOfValidationErrors = 2;
-    cy.get('[data-test=validation-list]').children().should('have.length', initialNumberOfValidationErrors);
+    const initialNumberOfDefinitionListElements = 4;
+    cy.get('[data-test=validation-list]').children().should('have.length', initialNumberOfDefinitionListElements);
 
     const startEventPosition = { x: 150, y: 150 };
 
@@ -253,9 +253,10 @@ describe('Modeler', () => {
     const taskPosition = { x: 150, y: 300 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
-    const numberOfNewValidationErrors = 1;
+    const numberOfNewDefinitionListElements = 2;
     cy.get('[data-test=validation-list]').children()
-      .should('have.length', initialNumberOfValidationErrors + numberOfNewValidationErrors).should('contain', 'node_2');
+      .should('have.length', initialNumberOfDefinitionListElements + numberOfNewDefinitionListElements)
+      .should('contain', 'node_2');
 
     cy.get('[data-test=undo]').click();
     waitToRenderAllShapes();
@@ -265,14 +266,14 @@ describe('Modeler', () => {
     });
 
     cy.get('[data-test=validation-list]').children()
-      .should('have.length', initialNumberOfValidationErrors)
+      .should('have.length', initialNumberOfDefinitionListElements)
       .should('not.contain', 'node_2');
 
     cy.get('[data-test=redo]').click();
     waitToRenderAllShapes();
 
     cy.get('[data-test=validation-list]').children()
-      .should('have.length', initialNumberOfValidationErrors + numberOfNewValidationErrors)
+      .should('have.length', initialNumberOfDefinitionListElements + numberOfNewDefinitionListElements)
       .should('contain', 'node_2');
 
     getElementAtPosition(startEventPosition).then($startEvent => {

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -137,8 +137,8 @@ describe('Modeler', () => {
     const gatewayPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.inclusiveGateway, gatewayPosition);
 
-    cy.get('[data-test=validation-list-toggle]').click();
-    cy.get('[type=checkbox]').check({ force: true });
+    cy.get('[data-test="validation-toggle"]').click({ force: true });
+    cy.get('[data-test="validation-list-toggle"]').click();
 
     cy.get('[data-test=validation-list]').should($lsit => {
       expect($lsit).to.contain('Gateway must have multiple outgoing Sequence Flows');
@@ -288,7 +288,8 @@ describe('Modeler', () => {
     uploadXml('unknownElement.xml');
     const warning = 'DataStoreReference is an unsupported element type in parse';
 
-    cy.get('.status-bar-container__status').click({ multiple: true });
+    cy.get('[data-test="validation-toggle"]').click({ force: true });
+    cy.get('[data-test="validation-list-toggle"]').click({ force: true });
     cy.get('[data-test="validation-list"]').should('contain', warning);
   });
 
@@ -440,10 +441,8 @@ describe('Modeler', () => {
     cy.get('[data-test=panels-btn]').click();
     cy.wait(700);
     dragFromSourceToDest(nodeTypes.task, taskPosition);
-    getElementAtPosition({ x: taskPosition.x + 5, y: taskPosition.y }).
-      click().
-      getType().
-      should('equal', nodeTypes.task);
+    getElementAtPosition({ x: taskPosition.x + 5, y: taskPosition.y }).click().getType()
+      .should('equal', nodeTypes.task);
   });
 
   it('should not generate duplicate diagram IDs', function() {


### PR DESCRIPTION
**Acceptance Criteria**
- Warnings and Error panels merge into one.
- Button shows a green checkmark and `BPMN Valid` if there are no issues
![image](https://user-images.githubusercontent.com/26545455/69188066-cced8f80-0ae9-11ea-9700-92ed91762c60.png)

- Button shows a number of issues if diagram contains issues
![image](https://user-images.githubusercontent.com/26545455/69188072-d119ad00-0ae9-11ea-8c76-827f6f6b74ac.png)

![image](https://user-images.githubusercontent.com/26545455/69187963-9f084b00-0ae9-11ea-9dd0-4883b75f23d5.png)

**Todo**

- [x] Modify `warnings` object

- [x] Merge warnings + validation error props

- [x] Add element type to `Element:` heading

- [x] Fix Two Failing test 
      ` Validates gateway direction - Modeler.spec.js`
      ` shows warning for unknown element during parsing - Modeler.spec.js`

Fixes #792 