### PR TITLE
Position Message Flow crown

### DIFF
--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -107,6 +107,12 @@ export default {
     isValidMessageFlowSource() {
       return this.validMessageFlowSources.includes(this.node.type);
     },
+    isFlow() {
+      return [
+        'processmaker-modeler-sequence-flow',
+        'processmaker-modeler-message-flow',
+      ].includes(this.node.type);
+    },
     isTextAnnotation() {
       return this.node.type === 'processmaker-modeler-text-annotation';
     },
@@ -195,6 +201,12 @@ export default {
 
       this.$emit('save-state');
     },
+    getShapeBounds(shapeView) {
+      if (this.isFlow) {
+        return shapeView.getBBox();
+      }
+      return shapeView.getBBox({ useModelGeometry: !this.isTextAnnotation });
+    },
     repositionCrown() {
       const shapeView = this.shape.findView(this.paper);
 
@@ -202,7 +214,7 @@ export default {
         return;
       }
 
-      const { x, y, width } = shapeView.getBBox({ useModelGeometry: !this.isTextAnnotation });
+      const { x, y, width } = this.getShapeBounds(shapeView);
 
       this.style = {
         top: `${y - 45}px`,

--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -201,12 +201,6 @@ export default {
 
       this.$emit('save-state');
     },
-    getShapeBounds(shapeView) {
-      if (this.isFlow) {
-        return shapeView.getBBox();
-      }
-      return shapeView.getBBox({ useModelGeometry: !this.isTextAnnotation });
-    },
     repositionCrown() {
       const shapeView = this.shape.findView(this.paper);
 
@@ -214,7 +208,7 @@ export default {
         return;
       }
 
-      const { x, y, width } = this.getShapeBounds(shapeView);
+      const { x, y, width } = shapeView.getBBox({ useModelGeometry: !this.isTextAnnotation && !this.isFlow });
 
       this.style = {
         top: `${y - 45}px`,


### PR DESCRIPTION
Closes #835 

Examples of what changed.

## Sequence Flows (bonus):
Now:
![Screen Shot 2019-11-20 at 9 23 27 AM](https://user-images.githubusercontent.com/6653340/69247330-3ddb8880-0b78-11ea-9eb2-a87f3d5b20f9.png)
Previous:
![Screen Shot 2019-11-19 at 5 03 51 PM](https://user-images.githubusercontent.com/6653340/69247391-551a7600-0b78-11ea-955e-3b2772cacd65.png)
Original:
![Screen Shot 2019-11-19 at 5 08 27 PM](https://user-images.githubusercontent.com/6653340/69247350-4764f080-0b78-11ea-9bd1-047d8e9f3040.png)

## Message Flows
### Example 1
Now:
![Screen Shot 2019-11-20 at 9 22 47 AM](https://user-images.githubusercontent.com/6653340/69248082-995a4600-0b79-11ea-8983-17f79c7b56b4.png)
Previous:
![Screen Shot 2019-11-19 at 4 42 23 PM](https://user-images.githubusercontent.com/6653340/69248378-31f0c600-0b7a-11ea-9c20-b66db1511c77.png)
Original:
![Screen Shot 2019-11-19 at 5 10 27 PM](https://user-images.githubusercontent.com/6653340/69248142-b2fb8d80-0b79-11ea-9287-5d8e2499af5f.png)
### Example 1
Now:
![Screen Shot 2019-11-20 at 9 46 25 AM](https://user-images.githubusercontent.com/6653340/69248683-b3485880-0b7a-11ea-9fc3-07c55e01128d.png)
Previous:
![Screen Shot 2019-11-19 at 1 24 53 PM](https://user-images.githubusercontent.com/6653340/69248714-c0fdde00-0b7a-11ea-8e4b-487db5595ffc.png)
Original:
![Screen Shot 2019-11-19 at 1 25 06 PM](https://user-images.githubusercontent.com/6653340/69248737-cbb87300-0b7a-11ea-90d3-070a2bd538d0.png)

