### PR TITLE
Updated z-index for crown config

### DIFF
--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -82,7 +82,7 @@
         :moddle="moddle"
         :processNode="processNode"
         @save-state="pushToUndoStack"
-        class="h-100"
+        class="inspector h-100"
       />
     </b-col>
     <component
@@ -936,7 +936,7 @@ $vertex-error-color: #ED4757;
     top: 0;
   }
 
-  .controls {
+  .controls, .inspector {
     z-index: 1;
   }
 

--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -283,7 +283,7 @@ export default {
   .crown-config {
     background-color: $primary-color;
     position: absolute;
-    z-index: 5;
+    z-index: 0;
     display: flex;
     justify-content: center;
     width: auto;


### PR DESCRIPTION
Closes #841

Minor fix.
No longer shows the crown when dragging underneath controls or inspector panel.

Guess it showed above the toolbar and mini-map as well, when dragged nearby.