### PR TITLE
Fix issues with error highlighting after resizing

### DIFF
--- a/src/components/paperManager.js
+++ b/src/components/paperManager.js
@@ -94,7 +94,11 @@ export default class PaperManager {
     this.paper.drawBackground({ color: defaultNodeColor });
   }
 
-  hasScheduledUpdates() {
-    return this.#paper._updates.priorities.some(updates => !util.isEmpty(updates));
+  executeAfterScheduledUpdates(callback) {
+    if (this.#paper._updates.priorities.some(updates => !util.isEmpty(updates))) {
+      this.addOnceHandler('render:done', callback);
+      return;
+    }
+    callback();
   }
 }

--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -87,6 +87,10 @@ export default {
       });
     },
     reHighlightExpandedElement() {
+      if (this.hasError) {
+        this.shapeView.unhighlight(this.shapeBody, { highlighter: errorHighlighter });
+        this.shapeView.highlight(this.shapeBody, { highlighter: errorHighlighter });
+      }
       if (this.highlighted) {
         this.shapeView.unhighlight(this.shapeBody, { highlighter: defaultHighlighter });
         this.shapeView.highlight(this.shapeBody, { highlighter: defaultHighlighter });


### PR DESCRIPTION
Closes #470.

Resolves an issue where error highlights were not changing after an element is resized. After this I decided to refactor the code to simplify things.