### PR TITLE
Only show dropdown on initial render

### DIFF
--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -58,6 +58,19 @@ export default {
       this.shape.attr('label/text', name);
     },
   },
+  methods: {
+    removeDropdownOnUnhighlight() {
+      const unwatch = this.$watch('highlighted', highlighted => {
+        if (!highlighted) {
+          this.showDropdown = false;
+          unwatch();
+        }
+      });
+    },
+  },
+  created() {
+    this.removeDropdownOnUnhighlight();
+  },
   mounted() {
     this.shape = new EventShape();
     this.shape.set('type', 'processmaker.components.nodes.startEvent.Shape');

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -50,12 +50,12 @@ export default {
     return {
       shape: null,
       definition: null,
-      showDropdown: this.node.type === 'processmaker-modeler-start-event',
+      showDropdown: false,
     };
   },
-  watch: {
-    'node.definition.name'(name) {
-      this.shape.attr('label/text', name);
+  computed: {
+    isBaseStartEvent() {
+      return this.node.type === 'processmaker-modeler-start-event';
     },
   },
   methods: {
@@ -68,8 +68,16 @@ export default {
       });
     },
   },
+  watch: {
+    'node.definition.name'(name) {
+      this.shape.attr('label/text', name);
+    },
+  },
   created() {
-    this.removeDropdownOnUnhighlight();
+    if (this.isBaseStartEvent && this.highlighted) {
+      this.showDropdown = true;
+      this.removeDropdownOnUnhighlight();
+    }
   },
   mounted() {
     this.shape = new EventShape();

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -456,7 +456,8 @@ describe('Modeler', () => {
   });
 
   it('should only show dropdown for the start event', function() {
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = { x: 400, y: 400 };
+    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
 
     cy.get('[data-test=switch-to-start-timer-event]').should('exist');
@@ -469,7 +470,8 @@ describe('Modeler', () => {
   });
 
   it('should hide start event dropdown on unhighlight', function() {
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = { x: 400, y: 400 };
+    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
     cy.get('.paper-container').click();
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
@@ -479,10 +481,19 @@ describe('Modeler', () => {
   });
 
   it('should hide start event dropdown when switching component type', function() {
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = { x: 400, y: 400 };
+    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
 
     cy.get('[data-test=switch-to-start-timer-event]').click();
+
+    cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
+    cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
+  });
+
+  it('should not show dropdown for start event already rendered on load', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
 
     cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
     cy.get('[data-test=switch-to-message-start-event]').should('not.exist');

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -454,4 +454,37 @@ describe('Modeler', () => {
       expect(xml.match(/node_2_di/g)).to.have.length(1);
     });
   });
+
+  it('should only show dropdown for the start event', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
+
+    cy.get('[data-test=switch-to-start-timer-event]').should('exist');
+    cy.get('[data-test=switch-to-message-start-event]').should('exist');
+
+    dragFromSourceToDest(nodeTypes.task, { x: 300, y: 300 });
+
+    cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
+    cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
+  });
+
+  it('should hide start event dropdown on unhighlight', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
+    cy.get('.paper-container').click();
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
+
+    cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
+    cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
+  });
+
+  it('should hide start event dropdown when switching component type', function() {
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
+
+    cy.get('[data-test=switch-to-start-timer-event]').click();
+
+    cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
+    cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
+  });
 });


### PR DESCRIPTION
Fixes #871.

Todo:
- [x] Only show the dropdown for the start event.
- [x] Remove the dropdown when the element is unhighlighted.
- [x] Do not show the dropdown when the element is swapped (only show it for the base start event).
- [x] Add tests.