### PR TITLE
Removed default start event from standalone modeler.

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -9,11 +9,11 @@
 
         <div class="ml-auto">
           <b-btn variant="secondary" size="sm" v-b-modal="'uploadmodal'" class="mr-2">
-            <i class="fas fa-upload mr-1"/>
+            <i class="fas fa-upload mr-1" />
             {{ $t('Upload XML') }}
           </b-btn>
           <b-btn variant="secondary" size="sm" data-test="downloadXMLBtn" @click="download">
-            <i class="fas fa-download mr-1"/>
+            <i class="fas fa-download mr-1" />
             {{ $t('Download XML') }}
           </b-btn>
         </div>
@@ -95,7 +95,7 @@ export default {
             window.xml = xml;
             return;
           }
-          let file = new File([xml], 'bpmnProcess.xml', {type: 'text/xml'});
+          let file = new File([xml], 'bpmnProcess.xml', { type: 'text/xml' });
           FilerSaver.saveAs(file);
         }
       });
@@ -113,10 +113,6 @@ export default {
   },
   created() {
     reader.onload = this.setUploadedXml;
-  },
-  mounted() {
-    /* Add a start event on initial load */
-    this.$refs.modeler.$once('parsed', () => this.$refs.modeler.addStartEvent());
   },
 };
 </script>

--- a/src/components/Modeler.vue
+++ b/src/components/Modeler.vue
@@ -168,7 +168,6 @@ import BpmnModdle from 'bpmn-moddle';
 import controls from './controls';
 import pull from 'lodash/pull';
 import remove from 'lodash/remove';
-import { startEvent } from '@/components/nodes';
 import store from '@/store';
 import InspectorPanel from '@/components/inspectors/InspectorPanel';
 import undoRedoStore from '@/undoRedoStore';
@@ -788,26 +787,6 @@ export default {
       const { allowDrop, poolTarget } = getValidationProperties(clientX, clientY, control, this.paperManager.paper, this.graph, this.collaboration, this.$refs['paper-container']);
       this.allowDrop = allowDrop;
       this.poolTarget = poolTarget;
-    },
-    addStartEvent() {
-      /* Add an initial startEvent node if the graph is empty */
-      if (this.nodes.length > 0) {
-        return;
-      }
-
-      const definition = startEvent.definition(this.moddle, this.$t);
-      const diagram = startEvent.diagram(this.moddle);
-
-      diagram.bounds.x = 150;
-      diagram.bounds.y = 150;
-
-      this.addNode({
-        definition,
-        diagram,
-        type: startEvent.id,
-      });
-
-      setTimeout(() => undoRedoStore.dispatch('resetHistory'));
     },
     isBpmnNode(shape) {
       return shape.component != null;

--- a/src/undoRedoStore.js
+++ b/src/undoRedoStore.js
@@ -3,7 +3,7 @@ import Vuex from 'vuex';
 
 Vue.use(Vuex);
 
-export default new Vuex.Store( {
+export default new Vuex.Store({
   state: {
     stack: [],
     position: null,
@@ -53,10 +53,6 @@ export default new Vuex.Store( {
       }
 
       commit('setPosition', state.position + 1);
-    },
-    resetHistory({ commit }) {
-      commit('setPosition', 0);
-      commit('clearStack');
     },
   },
 });

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -105,6 +105,13 @@ describe('Undo/redo', () => {
     const startEventMoveToPosition = { x: 300, y: 300 };
 
     cy.get('[data-test=undo]')
+      .click()
+      .should('be.disabled');
+
+    waitToRenderAllShapes();
+
+    cy.get('[data-test=redo]')
+      .click()
       .should('be.disabled');
 
     waitToRenderAllShapes();

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -16,6 +16,8 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import '@cypress/code-coverage/support';
+import { dragFromSourceToDest } from './utils';
+import { nodeTypes } from './constants';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
@@ -29,4 +31,6 @@ Cypress.Cookies.defaults({
 
 beforeEach(() => {
   cy.loadModeler();
+  dragFromSourceToDest(nodeTypes.startEvent, { x: 150, y: 150 });
+  cy.get('.paper-container').click();
 });


### PR DESCRIPTION
Fixes #880 

- Stop standalone modeler rendering a default start event.
- Add a start event to `beforeEach()` for every test to ensure backwards compatibility.
- Edits to make a test keep passing.