### PR TITLE
Display generic node types in the dropdown list

### DIFF
--- a/src/components/crownConfig.vue
+++ b/src/components/crownConfig.vue
@@ -27,7 +27,7 @@
       :dropdown-data="dropdownData"
       :node="node"
       :show-dropdown="showDropdown"
-      @replace-node="$emit('replace-node', $event)"
+      @replace-node="replaceNode"
     />
 
     <delete-button
@@ -274,6 +274,13 @@ export default {
           this.savePositionOnPointerupEventSet = true;
         }
       });
+    },
+    replaceNode(event) {
+      if (event.node.type === event.typeToReplaceWith) {
+        this.showDropdown = false;
+        return;
+      }
+      this.$emit('replace-node', event);
     },
   },
   async mounted() {

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -48,6 +48,10 @@ export default {
       definition: null,
       dropdownData: [
         {
+          label: 'Generic End Event',
+          nodeType: 'processmaker-modeler-end-event',
+        },
+        {
           label: 'Message End Event',
           nodeType: 'processmaker-modeler-message-end-event',
           dataTest: 'switch-to-message-end-event',

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -48,7 +48,7 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'Generic End Event',
+          label: 'End Event',
           nodeType: 'processmaker-modeler-end-event',
         },
         {

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -49,7 +49,7 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'Generic Start Event',
+          label: 'Start Event',
           nodeType: 'processmaker-modeler-start-event',
         },
         {

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -49,6 +49,10 @@ export default {
       definition: null,
       dropdownData: [
         {
+          label: 'Generic Start Event',
+          nodeType: 'processmaker-modeler-start-event',
+        },
+        {
           label: 'Start Timer Event',
           nodeType: 'processmaker-modeler-start-timer-event',
           dataTest: 'switch-to-start-timer-event',


### PR DESCRIPTION
Closes #886 

Allow 'generic' event types to be added and handled to the dropdown list.