### PR TITLE
Remove boundary events from control panel

### DIFF
--- a/src/components/nodes/boundaryErrorEvent/index.js
+++ b/src/components/nodes/boundaryErrorEvent/index.js
@@ -8,6 +8,7 @@ export const id = 'processmaker-modeler-boundary-error-event';
 export default merge(cloneDeep(boundaryEventConfig), {
   id,
   component,
+  control: false,
   label: 'Boundary Error Event',
   icon: require('@/assets/toolpanel/boundary-error-event.svg'),
   definition(moddle, $t) {

--- a/src/components/nodes/boundaryMessageEvent/index.js
+++ b/src/components/nodes/boundaryMessageEvent/index.js
@@ -8,6 +8,7 @@ export const id = 'processmaker-modeler-boundary-message-event';
 export default merge(cloneDeep(boundaryEventConfig), {
   id,
   component,
+  control: false,
   label: 'Boundary Message Event',
   icon: require('@/assets/toolpanel/boundary-message-event.svg'),
   definition(moddle, $t) {

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -11,6 +11,7 @@ export const defaultDurationValue = 'PT1H';
 export default merge(cloneDeep(boundaryEventConfig), {
   id: 'processmaker-modeler-boundary-timer-event',
   component,
+  control: false,
   label: 'Boundary Timer Event',
   icon: require('@/assets/toolpanel/boundary-timer-event.svg'),
   definition(moddle, $t) {

--- a/tests/e2e/specs/BoundaryErrorEvent.spec.js
+++ b/tests/e2e/specs/BoundaryErrorEvent.spec.js
@@ -64,7 +64,7 @@ describe('Boundary Error Event', () => {
       });
     });
 
-    dragFromSourceToDest(nodeTypes.boundaryErrorEvent, boundaryErrorEventPosition);
+    setBoundaryEvent(nodeTypes.boundaryErrorEvent, taskPosition);
 
     const task2Position2 = { x: task2Position.x + 50, y: task2Position.y + 50 };
 

--- a/tests/e2e/specs/BoundaryErrorEvent.spec.js
+++ b/tests/e2e/specs/BoundaryErrorEvent.spec.js
@@ -9,7 +9,6 @@ import {
 import { nodeTypes } from '../support/constants';
 
 describe('Boundary Error Event', () => {
-  const boundaryErrorEvent = 'add-boundary-error-event';
   it('Can only have one boundary error event per task', function() {
     const taskPosition = { x: 250, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -21,7 +20,7 @@ describe('Boundary Error Event', () => {
       });
 
     const boundaryErrorEventPosition = { x: taskPosition.x + 10, y: taskPosition.y + 10 };
-    setBoundaryEvent(boundaryErrorEvent, boundaryErrorEventPosition, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryErrorEvent, taskPosition);
 
     getElementAtPosition(taskPosition, nodeTypes.task)
       .then(getComponentsEmbeddedInShape)
@@ -29,7 +28,7 @@ describe('Boundary Error Event', () => {
         expect($elements).to.have.lengthOf(1);
       });
 
-    setBoundaryEvent(boundaryErrorEvent, boundaryErrorEventPosition, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryErrorEvent, taskPosition);
 
     getElementAtPosition(taskPosition, nodeTypes.task)
       .then(getComponentsEmbeddedInShape)

--- a/tests/e2e/specs/BoundaryErrorEvent.spec.js
+++ b/tests/e2e/specs/BoundaryErrorEvent.spec.js
@@ -4,10 +4,12 @@ import {
   getComponentsEmbeddedInShape,
   getPositionInPaperCoords,
   waitToRenderAllShapes,
+  setBoundaryEvent,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
 describe('Boundary Error Event', () => {
+  const boundaryErrorEvent = 'add-boundary-error-event';
   it('Can only have one boundary error event per task', function() {
     const taskPosition = { x: 250, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -19,7 +21,7 @@ describe('Boundary Error Event', () => {
       });
 
     const boundaryErrorEventPosition = { x: taskPosition.x + 10, y: taskPosition.y + 10 };
-    dragFromSourceToDest(nodeTypes.boundaryErrorEvent, boundaryErrorEventPosition);
+    setBoundaryEvent(boundaryErrorEvent, boundaryErrorEventPosition, taskPosition);
 
     getElementAtPosition(taskPosition, nodeTypes.task)
       .then(getComponentsEmbeddedInShape)
@@ -27,7 +29,7 @@ describe('Boundary Error Event', () => {
         expect($elements).to.have.lengthOf(1);
       });
 
-    dragFromSourceToDest(nodeTypes.boundaryErrorEvent, boundaryErrorEventPosition);
+    setBoundaryEvent(boundaryErrorEvent, boundaryErrorEventPosition, taskPosition);
 
     getElementAtPosition(taskPosition, nodeTypes.task)
       .then(getComponentsEmbeddedInShape)

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -20,14 +20,12 @@ const taskPosition = { x: 250, y: 200 };
 const boundaryEventData = [{
   type: 'Boundary Timer Event',
   nodeType: nodeTypes.boundaryTimerEvent,
-  boundaryEventType: 'add-boundary-timer-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Timer Event" attachedToRef="node_2"><bpmn:timerEventDefinition><bpmn:timeDuration>PT1H</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
   invalidTargets: [{ type: nodeTypes.startEvent }],
 }, {
   type: 'Boundary Error Event',
   nodeType: nodeTypes.boundaryErrorEvent,
-  boundaryEventType: 'add-boundary-error-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Error Event" attachedToRef="node_2"><bpmn:errorEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
   invalidTargets: [{ type: nodeTypes.startEvent }],
@@ -35,14 +33,12 @@ const boundaryEventData = [{
   type: 'Boundary Escalation Event',
   skip: true,
   nodeType: nodeTypes.boundaryEscalationEvent,
-  boundaryEventType: 'add-boundary-escalation-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Escalation Event" attachedToRef="node_2"><bpmn:escalationEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.subProcess,
   invalidTargets: [{ type: nodeTypes.startEvent }, { type: nodeTypes.task, color: defaultNodeColor }],
 }, {
   type: 'Boundary Message Event',
   nodeType: nodeTypes.boundaryMessageEvent,
-  boundaryEventType: 'add-boundary-message-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Message Event" attachedToRef="node_2"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.subProcess,
   invalidTargets: [{ type: nodeTypes.startEvent }],
@@ -56,24 +52,25 @@ function testThatBoundaryEventIsCloseToTask(boundaryEvent, task) {
   expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 118);
 }
 
-function configurePool(poolPosition, boundaryEventType, taskType) {
+function configurePool(poolPosition, nodeType, taskType) {
+  const taskPosition = { x: 250, y: 250 };
   getElementAtPosition({ x: 150, y: 150 })
     .click()
     .then($startEvent => {
       getCrownButtonForElement($startEvent, 'delete-button').click({ force: true });
     });
 
-  dragFromSourceToDest(taskType, { x: 250, y: 250 });
-  setBoundaryEvent(boundaryEventType, { x: 250, y: 250 }, taskType);
+  dragFromSourceToDest(taskType, taskPosition);
+  setBoundaryEvent(nodeType, taskPosition, taskType);
   dragFromSourceToDest(nodeTypes.pool, poolPosition);
 }
 
-boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet, taskType, invalidTargets, skip = false }) => {
+boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidTargets, skip = false }) => {
   (skip ? describe.skip : describe)(`Common behaviour test for boundary event type ${type}`, () => {
     it('can render a boundary event of this type', function() {
       dragFromSourceToDest(taskType, taskPosition);
 
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
       getElementAtPosition(boundaryEventPosition).click();
 
       cy.get('[data-test=downloadXMLBtn]').click();
@@ -88,7 +85,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('removes references of itself when inside of a pool and deleting the pool', function() {
       const poolPosition = { x: 400, y: 300 };
-      configurePool(poolPosition, boundaryEventType, taskType);
+      configurePool(poolPosition, nodeType, taskType);
 
       getElementAtPosition(poolPosition)
         .click()
@@ -106,7 +103,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
     });
 
     it('can stay anchored to task when moving pool', function() {
-      configurePool({ x: 300, y: 300 }, boundaryEventType, taskType);
+      configurePool({ x: 300, y: 300 }, nodeType, taskType);
       const taskSelector = '.main-paper ' +
         '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
 
@@ -147,7 +144,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
       const outgoingTaskPosition = { x: 400, y: 400 };
       dragFromSourceToDest(taskType, outgoingTaskPosition);
 
-      setBoundaryEvent(boundaryEventType, outgoingTaskPosition, taskType);
+      setBoundaryEvent(nodeType, outgoingTaskPosition, taskType);
       moveElement(outgoingTaskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
       connectNodesWithFlow('sequence-flow-button', boundaryEventPosition, outgoingTaskPosition);
 
@@ -172,7 +169,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
       dragFromSourceToDest(taskType, firstTaskPosition);
 
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
 
       connectNodesWithFlow('sequence-flow-button', firstTaskPosition, boundaryEventPosition);
 
@@ -187,7 +184,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('snaps back to original position when dragged over empty area', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -215,7 +212,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
       dragFromSourceToDest(taskType, taskPosition);
 
       const boundaryEventConnectedPosition = { x: 232, y: 220 };
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
       moveElement(taskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
 
       getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);
@@ -225,7 +222,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('correctly re-renders a boundary event on undo and redo', () => {
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
       moveElement(taskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
 
       cy.get('[data-test=undo]').click({ force: true });
@@ -246,7 +243,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('can successfully undo/redo after dragging onto invalid (empty) space ', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).as('boundaryEvent').then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -281,7 +278,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('redo positions it in same location as before undo', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).as('boundaryEvent').then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -302,7 +299,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
 
     it('turns target red when it is an invalid drop target, and snaps back to original position', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
       const invalidNodeTargetPosition = { x: 450, y: 150 };
 
       invalidTargets.forEach(invalidTargetNode => {
@@ -356,7 +353,7 @@ boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet,
     it('should turn pool red when hovered over and then back to default colour when no longer over pool', function() {
       dragFromSourceToDest(nodeTypes.pool, taskPosition);
       dragFromSourceToDest(taskType, taskPosition);
-      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
       getElementAtPosition(taskPosition, nodeType).then($boundaryEvent => {
         const overPoolPosition = { x: 450, y: 450 };
         const overTaskPosition = { x: 550, y: 350 };

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -382,7 +382,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     it('highlight boundary event on creation', function() {
       dragFromSourceToDest(taskType, taskPosition);
 
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
+      setBoundaryEvent(nodeType, taskPosition, taskType);
 
       getElementAtPosition(boundaryEventPosition).click().children().should('have.class', 'joint-highlight-stroke');
     });

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -14,7 +14,7 @@ import {
 import { boundaryEventSelector, nodeTypes } from '../support/constants';
 import { defaultNodeColor, invalidNodeColor, poolColor, startColor } from '../../../src/components/nodeColors';
 
-const boundaryEventPosition = { x: 250, y: 250 };
+const boundaryEventPosition = { x: 280, y: 200 };
 const taskPosition = { x: 250, y: 200 };
 
 const boundaryEventData = [{
@@ -71,7 +71,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       dragFromSourceToDest(taskType, taskPosition);
 
       setBoundaryEvent(nodeType, taskPosition, taskType);
-      getElementAtPosition(boundaryEventPosition).click();
+      getElementAtPosition(boundaryEventPosition, nodeType).click();
 
       cy.get('[data-test=downloadXMLBtn]').click();
 
@@ -150,7 +150,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
       const numberOfSequenceFlowsAdded = 1;
 
-      getElementAtPosition(boundaryEventPosition).then(getLinksConnectedToElement).should($links => {
+      getElementAtPosition(boundaryEventPosition, nodeType).then(getLinksConnectedToElement).should($links => {
         expect($links.length).to.eq(numberOfSequenceFlowsAdded);
       });
 
@@ -159,7 +159,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       cy.get('[data-test=redo]').click({ force: true });
       waitToRenderAllShapes();
 
-      getElementAtPosition(boundaryEventPosition).then(getLinksConnectedToElement).should($links => {
+      getElementAtPosition(boundaryEventPosition, nodeType).then(getLinksConnectedToElement).should($links => {
         expect($links.length).to.eq(numberOfSequenceFlowsAdded);
       });
     });
@@ -177,7 +177,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
         expect($links).to.have.lengthOf(0);
       });
 
-      getElementAtPosition(boundaryEventPosition).click().then($boundaryEvent => {
+      getElementAtPosition(boundaryEventPosition, nodeType).click().then($boundaryEvent => {
         getCrownButtonForElement($boundaryEvent, 'delete-button').click();
       });
     });
@@ -211,13 +211,12 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     it('does not snap boundary event to new position when selecting', function() {
       dragFromSourceToDest(taskType, taskPosition);
 
-      const boundaryEventConnectedPosition = { x: 232, y: 220 };
+      const boundaryEventConnectedPosition = { x: 290, y: 182 };
       setBoundaryEvent(nodeType, taskPosition, taskType);
-      moveElement(taskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
 
-      getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);
-      getElementAtPosition(boundaryEventPosition).click();
-      getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);
+      getElementAtPosition(boundaryEventPosition, nodeType).getPosition().should('contain', boundaryEventConnectedPosition);
+      getElementAtPosition(boundaryEventPosition, nodeType).click();
+      getElementAtPosition(boundaryEventPosition, nodeType).getPosition().should('contain', boundaryEventConnectedPosition);
     });
 
     it('correctly re-renders a boundary event on undo and redo', () => {

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -5,8 +5,10 @@ import {
   getCrownButtonForElement,
   getElementAtPosition,
   getLinksConnectedToElement,
+  moveElement,
   moveElementRelativeTo,
   removeIndentationAndLinebreaks,
+  setBoundaryEvent,
   waitToRenderAllShapes,
 } from '../support/utils';
 import { boundaryEventSelector, nodeTypes } from '../support/constants';
@@ -18,12 +20,14 @@ const taskPosition = { x: 250, y: 200 };
 const boundaryEventData = [{
   type: 'Boundary Timer Event',
   nodeType: nodeTypes.boundaryTimerEvent,
+  boundaryEventType: 'add-boundary-timer-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Timer Event" attachedToRef="node_2"><bpmn:timerEventDefinition><bpmn:timeDuration>PT1H</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
   invalidTargets: [{ type: nodeTypes.startEvent }],
 }, {
   type: 'Boundary Error Event',
   nodeType: nodeTypes.boundaryErrorEvent,
+  boundaryEventType: 'add-boundary-error-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Error Event" attachedToRef="node_2"><bpmn:errorEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.task,
   invalidTargets: [{ type: nodeTypes.startEvent }],
@@ -31,12 +35,14 @@ const boundaryEventData = [{
   type: 'Boundary Escalation Event',
   skip: true,
   nodeType: nodeTypes.boundaryEscalationEvent,
+  boundaryEventType: 'add-boundary-escalation-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Escalation Event" attachedToRef="node_2"><bpmn:escalationEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.subProcess,
   invalidTargets: [{ type: nodeTypes.startEvent }, { type: nodeTypes.task, color: defaultNodeColor }],
 }, {
   type: 'Boundary Message Event',
   nodeType: nodeTypes.boundaryMessageEvent,
+  boundaryEventType: 'add-boundary-message-event',
   eventXMLSnippet: '<bpmn:boundaryEvent id="node_3" name="New Boundary Message Event" attachedToRef="node_2"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>',
   taskType: nodeTypes.subProcess,
   invalidTargets: [{ type: nodeTypes.startEvent }],
@@ -50,7 +56,7 @@ function testThatBoundaryEventIsCloseToTask(boundaryEvent, task) {
   expect(boundaryPosition.left).to.be.closeTo(taskPosition.left, 118);
 }
 
-function configurePool(poolPosition, nodeType, taskType) {
+function configurePool(poolPosition, boundaryEventType, taskType) {
   getElementAtPosition({ x: 150, y: 150 })
     .click()
     .then($startEvent => {
@@ -58,17 +64,16 @@ function configurePool(poolPosition, nodeType, taskType) {
     });
 
   dragFromSourceToDest(taskType, { x: 250, y: 250 });
-  dragFromSourceToDest(nodeType, boundaryEventPosition);
+  setBoundaryEvent(boundaryEventType, { x: 250, y: 250 }, taskType);
   dragFromSourceToDest(nodeTypes.pool, poolPosition);
 }
 
-boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidTargets, skip = false }) => {
+boundaryEventData.forEach(({ type, nodeType, boundaryEventType, eventXMLSnippet, taskType, invalidTargets, skip = false }) => {
   (skip ? describe.skip : describe)(`Common behaviour test for boundary event type ${type}`, () => {
     it('can render a boundary event of this type', function() {
       dragFromSourceToDest(taskType, taskPosition);
 
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
-
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
       getElementAtPosition(boundaryEventPosition).click();
 
       cy.get('[data-test=downloadXMLBtn]').click();
@@ -83,7 +88,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('removes references of itself when inside of a pool and deleting the pool', function() {
       const poolPosition = { x: 400, y: 300 };
-      configurePool(poolPosition, nodeType, taskType);
+      configurePool(poolPosition, boundaryEventType, taskType);
 
       getElementAtPosition(poolPosition)
         .click()
@@ -101,7 +106,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     });
 
     it('can stay anchored to task when moving pool', function() {
-      configurePool({ x: 300, y: 300 }, nodeType, taskType);
+      configurePool({ x: 300, y: 300 }, boundaryEventType, taskType);
       const taskSelector = '.main-paper ' +
         '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
 
@@ -142,8 +147,8 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       const outgoingTaskPosition = { x: 400, y: 400 };
       dragFromSourceToDest(taskType, outgoingTaskPosition);
 
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
-
+      setBoundaryEvent(boundaryEventType, outgoingTaskPosition, taskType);
+      moveElement(outgoingTaskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
       connectNodesWithFlow('sequence-flow-button', boundaryEventPosition, outgoingTaskPosition);
 
       const numberOfSequenceFlowsAdded = 1;
@@ -167,7 +172,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       dragFromSourceToDest(taskType, firstTaskPosition);
 
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
 
       connectNodesWithFlow('sequence-flow-button', firstTaskPosition, boundaryEventPosition);
 
@@ -182,7 +187,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('snaps back to original position when dragged over empty area', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, taskPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -209,9 +214,10 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     it('does not snap boundary event to new position when selecting', function() {
       dragFromSourceToDest(taskType, taskPosition);
 
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
+      const boundaryEventConnectedPosition = { x: 232, y: 220 };
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      moveElement(taskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
 
-      const boundaryEventConnectedPosition = { x: 232, y: 239 };
       getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);
       getElementAtPosition(boundaryEventPosition).click();
       getElementAtPosition(boundaryEventPosition).getPosition().should('contain', boundaryEventConnectedPosition);
@@ -219,7 +225,8 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('correctly re-renders a boundary event on undo and redo', () => {
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, taskPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
+      moveElement(taskPosition, boundaryEventPosition.x, boundaryEventPosition.y);
 
       cy.get('[data-test=undo]').click({ force: true });
       waitToRenderAllShapes();
@@ -239,7 +246,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('can successfully undo/redo after dragging onto invalid (empty) space ', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, taskPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).as('boundaryEvent').then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -274,7 +281,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('redo positions it in same location as before undo', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, boundaryEventPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
 
       cy.get(boundaryEventSelector).as('boundaryEvent').then($boundaryEvent => {
         const boundaryEventPosition = $boundaryEvent.position();
@@ -295,7 +302,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
 
     it('turns target red when it is an invalid drop target, and snaps back to original position', function() {
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, taskPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
       const invalidNodeTargetPosition = { x: 450, y: 150 };
 
       invalidTargets.forEach(invalidTargetNode => {
@@ -349,7 +356,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
     it('should turn pool red when hovered over and then back to default colour when no longer over pool', function() {
       dragFromSourceToDest(nodeTypes.pool, taskPosition);
       dragFromSourceToDest(taskType, taskPosition);
-      dragFromSourceToDest(nodeType, taskPosition);
+      setBoundaryEvent(boundaryEventType, taskPosition, taskType);
       getElementAtPosition(taskPosition, nodeType).then($boundaryEvent => {
         const overPoolPosition = { x: 450, y: 450 };
         const overTaskPosition = { x: 550, y: 350 };

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -353,7 +353,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, invalidT
       dragFromSourceToDest(nodeTypes.pool, taskPosition);
       dragFromSourceToDest(taskType, taskPosition);
       setBoundaryEvent(nodeType, taskPosition, taskType);
-      getElementAtPosition(taskPosition, nodeType).then($boundaryEvent => {
+      getElementAtPosition(taskPosition).then($boundaryEvent => {
         const overPoolPosition = { x: 450, y: 450 };
         const overTaskPosition = { x: 550, y: 350 };
 

--- a/tests/e2e/specs/BoundaryMessageEvent.spec.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.spec.js
@@ -31,7 +31,7 @@ describe('Boundary Message Event', () => {
     dragFromSourceToDest(taskType, taskPosition);
 
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, taskType);
-    getElementAtPosition(taskPosition, nodeTypes.boundaryMessageEvent).click();
+    getElementAtPosition(taskPosition).click();
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).click();

--- a/tests/e2e/specs/BoundaryMessageEvent.spec.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.spec.js
@@ -1,4 +1,8 @@
-import { dragFromSourceToDest, getElementAtPosition, removeIndentationAndLinebreaks } from '../support/utils';
+import {
+  dragFromSourceToDest,
+  removeIndentationAndLinebreaks,
+  setBoundaryEvent,
+} from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
 describe('Boundary Message Event', () => {
@@ -8,11 +12,7 @@ describe('Boundary Message Event', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(taskType, taskPosition);
 
-    cy.get('[data-test=boundary-event-dropdown]').click();
-    cy.get('[data-test=add-boundary-message-event]').click();
-
-    const boundaryMessageEventPosition = { x: 260, y: 260 };
-    getElementAtPosition(boundaryMessageEventPosition).click();
+    setBoundaryEvent('add-boundary-message-event', taskPosition, taskType);
 
     const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_3" name="New Boundary Message Event" attachedToRef="node_2"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
 
@@ -29,10 +29,7 @@ describe('Boundary Message Event', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(taskType, taskPosition);
 
-    const boundaryMessageEventPosition = { x: 260, y: 260 };
-    dragFromSourceToDest(nodeTypes.boundaryMessageEvent, boundaryMessageEventPosition);
-
-    getElementAtPosition(boundaryMessageEventPosition).click();
+    setBoundaryEvent('add-boundary-message-event', taskPosition, taskType);
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).click();

--- a/tests/e2e/specs/BoundaryMessageEvent.spec.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.spec.js
@@ -1,5 +1,6 @@
 import {
   dragFromSourceToDest,
+  getElementAtPosition,
   removeIndentationAndLinebreaks,
   setBoundaryEvent,
 } from '../support/utils';
@@ -30,6 +31,7 @@ describe('Boundary Message Event', () => {
     dragFromSourceToDest(taskType, taskPosition);
 
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, taskType);
+    getElementAtPosition(taskPosition, nodeTypes.boundaryMessageEvent).click();
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).click();

--- a/tests/e2e/specs/BoundaryMessageEvent.spec.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.spec.js
@@ -12,7 +12,7 @@ describe('Boundary Message Event', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(taskType, taskPosition);
 
-    setBoundaryEvent('add-boundary-message-event', taskPosition, taskType);
+    setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, taskType);
 
     const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_3" name="New Boundary Message Event" attachedToRef="node_2"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
 
@@ -29,7 +29,7 @@ describe('Boundary Message Event', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(taskType, taskPosition);
 
-    setBoundaryEvent('add-boundary-message-event', taskPosition, taskType);
+    setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, taskType);
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).click();

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -14,14 +14,12 @@ import {
 import { nodeTypes } from '../support/constants';
 
 describe('Boundary Timer Event', () => {
-  const boundaryEventType = 'add-boundary-timer-event';
-
   it('update boundary timer event properties element', function() {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
-    setBoundaryEvent(boundaryEventType, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     moveElement(taskPosition, boundaryTimerEventPosition.x, boundaryTimerEventPosition.y);
 
     const name = 'Test name';
@@ -75,14 +73,16 @@ describe('Boundary Timer Event', () => {
       { type: nodeTypes.task, position: { x: 100, y: 300 } },
       { type: nodeTypes.subProcess, position: { x: 240, y: 300 } },
       {
-        type: nodeTypes.task, position: { x: 380, y: 300 },
+        type: nodeTypes.task,
+        subType: nodeTypes.scriptTask,
+        position: { x: 380, y: 300 },
         selector: '[data-test=switch-to-script-task]',
-        nodeType: nodeTypes.scriptTask,
       },
       {
-        type: nodeTypes.task, position: { x: 100, y: 400 },
+        type: nodeTypes.task,
+        subType: nodeTypes.manualTask,
+        position: { x: 100, y: 400 },
         selector: '[data-test=switch-to-manual-task]',
-        nodeType: nodeTypes.manualTask,
       },
     ];
 
@@ -97,8 +97,8 @@ describe('Boundary Timer Event', () => {
     const numberOfElementsAfterAddingTasks = initialNumberOfElements + validBoundaryTimerEventTargets.length;
     getGraphElements().should('have.length', numberOfElementsAfterAddingTasks);
 
-    validBoundaryTimerEventTargets.forEach(({ type, position, nodeType }) => {
-      setBoundaryEvent(boundaryEventType, position, nodeType || type);
+    validBoundaryTimerEventTargets.forEach(({ type, position, subType }) => {
+      setBoundaryEvent(nodeTypes.boundaryTimerEvent, position, subType || type);
 
     });
 
@@ -111,7 +111,7 @@ describe('Boundary Timer Event', () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
-    setBoundaryEvent(boundaryEventType, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     moveElement(taskPosition, boundaryTimerEventPosition.x, boundaryTimerEventPosition.y);
 
     const interrupting = '[name=cancelActivity]';
@@ -153,7 +153,7 @@ describe('Boundary Timer Event', () => {
     const taskPosition = { x: 300, y: 300 };
     const numberOfBoundaryTimerEventsAdded = 1;
     dragFromSourceToDest(nodeTypes.task, taskPosition);
-    setBoundaryEvent(boundaryEventType, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const taskXml = '<bpmn:task id="node_2" name="Task" />';
     const boundaryEventOnTaskXml = '<bpmn:boundaryEvent id="node_3" name="New Boundary Timer Event" attachedToRef="node_2">';
@@ -214,7 +214,7 @@ describe('Boundary Timer Event', () => {
   it('keeps Boundary Timer Event in correct position when dragging and dropping', function() {
     const taskPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
-    setBoundaryEvent(boundaryEventType, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const task2Position = { x: 500, y: 500 };
     dragFromSourceToDest(nodeTypes.task, task2Position);

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -122,7 +122,7 @@ describe('Boundary Timer Event', () => {
     cy.get('[data-test=redo]').click({ force: true });
     waitToRenderAllShapes();
 
-    getElementAtPosition(boundaryTimerEventPosition).click();
+    getElementAtPosition(boundaryTimerEventPosition, nodeTypes.boundaryTimerEvent).click();
 
     cy.get(interrupting).should('be.checked');
     cy.get(interrupting).uncheck({ force: true });
@@ -135,14 +135,14 @@ describe('Boundary Timer Event', () => {
 
     const boundaryTimerEventPositions = [{ x: 277, y: 162 }, { x: 225, y: 379 }];
 
-    getElementAtPosition(boundaryTimerEventPositions[0]).click();
+    getElementAtPosition(boundaryTimerEventPositions[0], nodeTypes.boundaryTimerEvent).click();
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).should('be.checked');
     cy.get(interrupting).uncheck({ force: true });
     cy.get(interrupting).should('not.be.checked');
 
-    getElementAtPosition(boundaryTimerEventPositions[1]).click({ force: true });
+    getElementAtPosition(boundaryTimerEventPositions[1], nodeTypes.boundaryTimerEvent).click({ force: true });
 
     cy.get(interrupting).should('be.checked');
     cy.get(interrupting).uncheck({ force: true });

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -201,7 +201,7 @@ describe('Pools', () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
-    setBoundaryEvent('add-boundary-timer-event', taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     moveElement(taskPosition, boundaryTimerEventPosition.x, boundaryTimerEventPosition.y);
 
     const pool1taskXml = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /><bpmn:task id="node_4" name="Task" /><bpmn:boundaryEvent id="node_5" name="New Boundary Timer Event" attachedToRef="node_4">';

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -8,6 +8,7 @@ import {
   moveElement,
   moveElementRelativeTo,
   removeIndentationAndLinebreaks,
+  setBoundaryEvent,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -200,7 +201,8 @@ describe('Pools', () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
-    dragFromSourceToDest(nodeTypes.boundaryTimerEvent, boundaryTimerEventPosition);
+    setBoundaryEvent('add-boundary-timer-event', taskPosition);
+    moveElement(taskPosition, boundaryTimerEventPosition.x, boundaryTimerEventPosition.y);
 
     const pool1taskXml = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /><bpmn:task id="node_4" name="Task" /><bpmn:boundaryEvent id="node_5" name="New Boundary Timer Event" attachedToRef="node_4">';
     cy.get('[data-test=downloadXMLBtn]').click();

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -345,7 +345,7 @@ describe('Undo/redo', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
-    setBoundaryEvent('add-boundary-timer-event', taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const initialNumberOfElements = 3;
     const numberOfElementsToRemove = 1;

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -6,6 +6,7 @@ import {
   getGraphElements,
   getLinksConnectedToElement,
   removeIndentationAndLinebreaks,
+  setBoundaryEvent,
   testNumberOfVertices,
   typeIntoTextInput,
   waitToRenderAllShapes,
@@ -344,8 +345,7 @@ describe('Undo/redo', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
-    const boundaryTimerEventPosition = { x: 260, y: 260 };
-    dragFromSourceToDest(nodeTypes.boundaryTimerEvent, boundaryTimerEventPosition);
+    setBoundaryEvent('add-boundary-timer-event', taskPosition);
 
     const initialNumberOfElements = 3;
     const numberOfElementsToRemove = 1;

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -1,7 +1,16 @@
 import { saveDebounce } from '../../../src/components/inspectors/inspectorConstants';
 import path from 'path';
+import { nodeTypes } from './constants';
 
 const renderTime = 300;
+
+export function setBoundaryEvent(boundaryEvent, taskPosition, taskType = nodeTypes.task) {
+  waitToRenderAllShapes();
+  getElementAtPosition(taskPosition, taskType).click();
+  cy.get('[data-test="boundary-event-dropdown"]').click();
+  cy.get(`[data-test="${boundaryEvent}"`).click();
+  getElementAtPosition(taskPosition).click();
+}
 
 export function getGraphElements() {
   return cy.window()

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -6,12 +6,13 @@ const renderTime = 300;
 
 export function setBoundaryEvent(nodeType, taskPosition, taskType = nodeTypes.task) {
   const dataTest = nodeType.replace('processmaker-modeler-', 'add-');
-
   waitToRenderAllShapes();
-  getElementAtPosition(taskPosition, taskType).click();
-  cy.get('[data-test="boundary-event-dropdown"]').click();
-  cy.get(`[data-test="${dataTest}"`).click();
-  getElementAtPosition(taskPosition).click();
+
+  getElementAtPosition(taskPosition, taskType).click({force: true});
+
+  cy.get('[data-test="boundary-event-dropdown"]').click({force: true});
+  cy.get(`[data-test="${dataTest}"`).click({ force: true });
+  waitToRenderAllShapes();
 }
 
 export function getGraphElements() {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -4,11 +4,13 @@ import { nodeTypes } from './constants';
 
 const renderTime = 300;
 
-export function setBoundaryEvent(boundaryEvent, taskPosition, taskType = nodeTypes.task) {
+export function setBoundaryEvent(nodeType, taskPosition, taskType = nodeTypes.task) {
+  const dataTest = nodeType.replace('processmaker-modeler-', 'add-');
+
   waitToRenderAllShapes();
   getElementAtPosition(taskPosition, taskType).click();
   cy.get('[data-test="boundary-event-dropdown"]').click();
-  cy.get(`[data-test="${boundaryEvent}"`).click();
+  cy.get(`[data-test="${dataTest}"`).click();
   getElementAtPosition(taskPosition).click();
 }
 


### PR DESCRIPTION
Closes #924 

Needs to be updated with code from #932 - it will position the boundary event in the centre first instead of the top, left edge. May also fix the one failing validation issue.