### PR TITLE
Add Boundary Message events to all task types

### DIFF
--- a/src/boundaryEventValidation.js
+++ b/src/boundaryEventValidation.js
@@ -14,10 +14,6 @@ export function canAddBoundaryEventToTarget(boundaryEventType, dropTarget) {
     return getAttachedErrorBoundaryEvents(dropTarget).length === 0;
   }
 
-  if (boundaryEventType === 'processmaker-modeler-boundary-message-event') {
-    return dropTarget.component.node.definition.$type === 'bpmn:CallActivity';
-  }
-
   return true;
 }
 

--- a/src/components/nodes/manualTask/manualTask.vue
+++ b/src/components/nodes/manualTask/manualTask.vue
@@ -4,22 +4,6 @@ import scriptIcon from '@/assets/manual-task.svg';
 
 export default {
   extends: TaskComponent,
-  data() {
-    return {
-      boundaryEventDropdownData: [
-        {
-          label: 'Boundary Timer Event',
-          nodeType: 'processmaker-modeler-boundary-timer-event',
-          dataTest: 'add-boundary-timer-event',
-        },
-        {
-          label: 'Boundary Error Event',
-          nodeType: 'processmaker-modeler-boundary-error-event',
-          dataTest: 'add-boundary-error-event',
-        },
-      ],
-    };
-  },
   mounted() {
     this.shape.attr('image/xlink:href', scriptIcon);
   },

--- a/src/components/nodes/scriptTask/scriptTask.vue
+++ b/src/components/nodes/scriptTask/scriptTask.vue
@@ -4,22 +4,6 @@ import scriptIcon from '@/assets/script.svg';
 
 export default {
   extends: TaskComponent,
-  data() {
-    return {
-      boundaryEventDropdownData: [
-        {
-          label: 'Boundary Timer Event',
-          nodeType: 'processmaker-modeler-boundary-timer-event',
-          dataTest: 'add-boundary-timer-event',
-        },
-        {
-          label: 'Boundary Error Event',
-          nodeType: 'processmaker-modeler-boundary-error-event',
-          dataTest: 'add-boundary-error-event',
-        },
-      ],
-    };
-  },
   mounted() {
     this.shape.attr('image/xlink:href', scriptIcon);
   },

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -51,7 +51,23 @@ export default {
     return {
       shape: null,
       definition: null,
-      boundaryEventDropdownData: null,
+      boundaryEventDropdownData: [
+        {
+          label: 'Boundary Timer Event',
+          nodeType: 'processmaker-modeler-boundary-timer-event',
+          dataTest: 'add-boundary-timer-event',
+        },
+        {
+          label: 'Boundary Error Event',
+          nodeType: 'processmaker-modeler-boundary-error-event',
+          dataTest: 'add-boundary-error-event',
+        },
+        {
+          label: 'Boundary Message Event',
+          nodeType: 'processmaker-modeler-boundary-message-event',
+          dataTest: 'add-boundary-message-event',
+        },
+      ],
     };
   },
   computed: {

--- a/src/components/nodes/userTask/userTask.vue
+++ b/src/components/nodes/userTask/userTask.vue
@@ -50,18 +50,6 @@ export default {
           dataTest: 'switch-to-sub-process',
         },
       ],
-      boundaryEventDropdownData: [
-        {
-          label: 'Boundary Timer Event',
-          nodeType: 'processmaker-modeler-boundary-timer-event',
-          dataTest: 'add-boundary-timer-event',
-        },
-        {
-          label: 'Boundary Error Event',
-          nodeType: 'processmaker-modeler-boundary-error-event',
-          dataTest: 'add-boundary-error-event',
-        },
-      ],
     };
   },
 };


### PR DESCRIPTION
Closes #943 

I propose not removing Boundary Events from anything that currently extends Task. Unless connectors are not supposed to have them.