### PR TITLE
Fix radio button alignment

### DIFF
--- a/src/components/inspectors/TimerExpression.vue
+++ b/src/components/inspectors/TimerExpression.vue
@@ -49,7 +49,7 @@
       <label class="mt-1 ">{{ $t('Ends') }}</label>
       <div>
         <b-form-group class="m-0 mb-2">
-          <b-form-radio v-model="ends" data-test="ends-never" class="pl-3" name="optradio" value="never">{{ $t('Never') }}</b-form-radio>
+          <b-form-radio v-model="ends" data-test="ends-never" name="optradio" value="never">{{ $t('Never') }}</b-form-radio>
         </b-form-group>
 
         <b-form-group class="p-0 mb-1" :description="`${$t('Click On to select a date')}.`">


### PR DESCRIPTION
This PR fixes the alignment on the "Never" radio button for the Start Timer Event.

Before:
<img width="551" alt="Screen Shot 2019-12-19 at 2 11 21 PM" src="https://user-images.githubusercontent.com/7561061/71202118-81a1da80-2269-11ea-870d-4fbd496373fe.png">

After:
<img width="429" alt="Screen Shot 2019-12-19 at 2 10 48 PM" src="https://user-images.githubusercontent.com/7561061/71202124-85356180-2269-11ea-90bd-bd12ddbf6f8c.png">
