### PR TITLE
Add tooltip to boundary event crown

### DIFF
--- a/src/components/crown/crownBoundaryEventDropdown.vue
+++ b/src/components/crown/crownBoundaryEventDropdown.vue
@@ -7,6 +7,8 @@
       :src="boundaryEventIcon"
       @click="dropdownOpen = !dropdownOpen"
       data-test="boundary-event-dropdown"
+      v-b-tooltip.hover.viewport.d50
+      :title="$t('Boundary Events')"
     />
 
     <ul class="element-list" v-if="dropdownOpen" role="list">


### PR DESCRIPTION
The purpose of this PR is to add a missing tooltip for the boundary event button on the crown. 
<img width="396" alt="Screen Shot 2019-12-19 at 2 27 36 PM" src="https://user-images.githubusercontent.com/26545455/71203278-b57dff80-226b-11ea-8e81-75b8a6838be7.png">
