### PR TITLE
Disable pointer events for tooltips

### DIFF
--- a/src/assets/scss/utilities/_utilities.cursor.scss
+++ b/src/assets/scss/utilities/_utilities.cursor.scss
@@ -6,3 +6,7 @@
     }
   }
 }
+
+.no-pointer-events {
+  pointer-events: none;
+}

--- a/src/components/controls/controls.vue
+++ b/src/components/controls/controls.vue
@@ -28,7 +28,12 @@
           @dragstart="$event.preventDefault()"
           @mousedown="startDrag($event, control)"
         >
-          <div class="tool" :class="{ 'text-truncate ml-1': !compressed }" v-b-tooltip.hover.viewport.d50 :title="$t(control.label)">
+          <div
+            class="tool"
+            :class="{ 'text-truncate ml-1': !compressed }"
+            v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
+            :title="$t(control.label)"
+          >
             <img :src="control.icon" class="tool-icon" :alt="$t(control.label)">
             <span v-if="!compressed" class="ml-1">{{ $t(control.label) }}</span>
           </div>

--- a/src/components/crown/crownBoundaryEventDropdown.vue
+++ b/src/components/crown/crownBoundaryEventDropdown.vue
@@ -7,7 +7,7 @@
       :src="boundaryEventIcon"
       @click="dropdownOpen = !dropdownOpen"
       data-test="boundary-event-dropdown"
-      v-b-tooltip.hover.viewport.d50
+      v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
       :title="$t('Boundary Events')"
     />
 

--- a/src/components/crown/crownButtons/associationFlowButton.vue
+++ b/src/components/crown/crownButtons/associationFlowButton.vue
@@ -2,7 +2,7 @@
   <crown-button
     v-if="node.type === 'processmaker-modeler-text-annotation'"
     :title="$t('Association Flow')"
-    v-b-tooltip.hover.viewport.d50
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     id="association-flow-button"
     aria-label="Add association flow"
     :src="connectIcon"

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -5,7 +5,7 @@
     id="delete-button"
     aria-label="Delete this node"
     @click="isPoolLane ? removePoolLaneShape() : removeShape()"
-    v-b-tooltip.hover.viewport.d50
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
   >
     <img
       :src="trashIcon"

--- a/src/components/crown/crownButtons/messageFlowButton.vue
+++ b/src/components/crown/crownButtons/messageFlowButton.vue
@@ -1,7 +1,7 @@
 <template>
   <crown-button
     v-if="validMessageFlowSources.includes(node.type)"
-    v-b-tooltip.hover.viewport.d50
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     :title="$t('Message Flow')"
     id="message-flow-button"
     aria-label="Create a message flow"

--- a/src/components/crown/crownButtons/sequenceFlowButton.vue
+++ b/src/components/crown/crownButtons/sequenceFlowButton.vue
@@ -1,7 +1,7 @@
 <template>
   <crown-button
     v-if="!invalidSequenceFlowSources.includes(node.type)"
-    v-b-tooltip.hover.viewport.d50
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     :title="$t('Sequence Flow')"
     id="sequence-flow-button"
     aria-label="Create a sequence flow"


### PR DESCRIPTION
This PR disables pointer events for the controls and crown button tooltips. These tooltips would remain visible if you hover over the element that triggers the tooltip, then hover over the tooltip. This would interfere with interacting with elements behind the tooltip.