### PR TITLE
Require arrow functions in tests

### DIFF
--- a/tests/e2e/.eslintrc.js
+++ b/tests/e2e/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
     'object-shorthand': 'error',
     'space-before-function-paren': ['error', 'never'],
     'keyword-spacing': 'error',
+    'prefer-arrow-callback': 'error',
   },
   parserOptions: {
     parser: 'babel-eslint',

--- a/tests/e2e/specs/BoundaryEscalationEvent.spec.js
+++ b/tests/e2e/specs/BoundaryEscalationEvent.spec.js
@@ -3,7 +3,7 @@ import { nodeTypes } from '../support/constants';
 
 describe.skip('Boundary Escalation Event', () => {
 
-  it('can toggle interrupting on Boundary Escalation Events', function() {
+  it('can toggle interrupting on Boundary Escalation Events', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.subProcess, taskPosition);
 
@@ -27,7 +27,7 @@ describe.skip('Boundary Escalation Event', () => {
     cy.get(interrupting).should('not.be.checked');
   });
 
-  it('can only embed onto a sub process', function() {
+  it('can only embed onto a sub process', () => {
     const initialNumberOfElements = 1;
     const inValidBoundaryEscalationEventTargets = [
       { type: nodeTypes.task, position: { x: 100, y: 300 } },

--- a/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
+++ b/tests/e2e/specs/BoundaryEventCommonBehaviour.spec.js
@@ -72,7 +72,7 @@ function configurePool(poolPosition, nodeType, taskType, taskTypeSelector) {
 
 boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskTypeSelector, invalidTargets, skip = false }) => {
   (skip ? describe.skip : describe)(`Common behaviour test for boundary event type ${type}`, () => {
-    it('can render a boundary event of this type', function() {
+    it('can render a boundary event of this type', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
 
       setBoundaryEvent(nodeType, taskPosition, taskType);
@@ -88,7 +88,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
         });
     });
 
-    it('removes references of itself when inside of a pool and deleting the pool', function() {
+    it('removes references of itself when inside of a pool and deleting the pool', () => {
       const poolPosition = { x: 400, y: 300 };
       configurePool(poolPosition, nodeType, taskType, taskTypeSelector);
 
@@ -107,7 +107,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
         });
     });
 
-    it('can stay anchored to task when moving pool', function() {
+    it('can stay anchored to task when moving pool', () => {
       configurePool({ x: 300, y: 300 }, nodeType, taskType, taskTypeSelector);
       const taskSelector = '.main-paper ' +
         '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
@@ -143,7 +143,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
         });
     });
 
-    it('retains outgoing sequence flows on Boundary Events', function() {
+    it('retains outgoing sequence flows on Boundary Events', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
 
       const outgoingTaskPosition = { x: 400, y: 400 };
@@ -169,7 +169,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('cannot attach an incoming sequence flow on Boundary Events', function() {
+    it('cannot attach an incoming sequence flow on Boundary Events', () => {
       const firstTaskPosition = { x: 400, y: 400 };
       addNodeTypeToPaper(firstTaskPosition, nodeTypes.task, taskTypeSelector);
 
@@ -187,7 +187,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('snaps back to original position when dragged over empty area', function() {
+    it('snaps back to original position when dragged over empty area', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
 
@@ -213,7 +213,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('does not snap boundary event to new position when selecting', function() {
+    it('does not snap boundary event to new position when selecting', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
 
       const boundaryEventConnectedPosition = { x: 290, y: 182 };
@@ -247,7 +247,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
         });
     });
 
-    it('can successfully undo/redo after dragging onto invalid (empty) space ', function() {
+    it('can successfully undo/redo after dragging onto invalid (empty) space ', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
 
@@ -282,7 +282,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
         });
     });
 
-    it('redo positions it in same location as before undo', function() {
+    it('redo positions it in same location as before undo', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
 
@@ -303,7 +303,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('turns target red when it is an invalid drop target, and snaps back to original position', function() {
+    it('turns target red when it is an invalid drop target, and snaps back to original position', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
       const invalidNodeTargetPosition = { x: 450, y: 150 };
@@ -356,7 +356,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('should turn pool red when hovered over and then back to default colour when no longer over pool', function() {
+    it('should turn pool red when hovered over and then back to default colour when no longer over pool', () => {
       dragFromSourceToDest(nodeTypes.pool, taskPosition);
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
@@ -386,7 +386,7 @@ boundaryEventData.forEach(({ type, nodeType, eventXMLSnippet, taskType, taskType
       });
     });
 
-    it('highlight boundary event on creation', function() {
+    it('highlight boundary event on creation', () => {
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
 

--- a/tests/e2e/specs/BoundaryEventValidatiion.spec.js
+++ b/tests/e2e/specs/BoundaryEventValidatiion.spec.js
@@ -3,8 +3,8 @@ import { nodeTypes } from '../support/constants';
 import uniqWith from 'lodash/uniqWith';
 import isEqual from 'lodash/isEqual';
 
-describe('Boundary event validation', function() {
-  it('should add boundary events to empty ports around boundary event target, and not allow adding any more', function() {
+describe('Boundary event validation', () => {
+  it('should add boundary events to empty ports around boundary event target, and not allow adding any more', () => {
     const taskPosition = { x: 250, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 

--- a/tests/e2e/specs/BoundaryMessageEvent.spec.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.spec.js
@@ -12,7 +12,7 @@ describe('Boundary Message Event', () => {
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-sub-process');
   });
 
-  it('Render an interrupting boundary message event', function() {
+  it('Render an interrupting boundary message event', () => {
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, nodeTypes.subProcess);
 
     const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_4" name="New Boundary Message Event" attachedToRef="node_3"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
@@ -26,7 +26,7 @@ describe('Boundary Message Event', () => {
       });
   });
 
-  it('Render a non-interrupting boundary message event', function() {
+  it('Render a non-interrupting boundary message event', () => {
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, nodeTypes.subProcess);
     getElementAtPosition(taskPosition).click();
 

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -15,7 +15,7 @@ import {
 import { nodeTypes } from '../support/constants';
 
 describe('Boundary Timer Event', () => {
-  it('update boundary timer event properties element', function() {
+  it('update boundary timer event properties element', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
@@ -60,7 +60,7 @@ describe('Boundary Timer Event', () => {
       });
   });
 
-  it('Can add boundary timer events to valid targets', function() {
+  it('Can add boundary timer events to valid targets', () => {
     const initialNumberOfElements = 1;
     const startEventPosition = { x: 150, y: 150 };
 
@@ -107,7 +107,7 @@ describe('Boundary Timer Event', () => {
     getGraphElements().should('have.length', numberOfElementsAfterAddingTasksAndBoundaryTimerEvents);
   });
 
-  it('can toggle interrupting on Boundary Timer Events', function() {
+  it('can toggle interrupting on Boundary Timer Events', () => {
     const taskPosition = { x: 200, y: 200 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
@@ -131,7 +131,7 @@ describe('Boundary Timer Event', () => {
 
   });
 
-  it('can toggle interrupting on Boundary Timer Events in multiple processes', function() {
+  it('can toggle interrupting on Boundary Timer Events in multiple processes', () => {
     uploadXml('boundaryTimersInPools.xml');
 
     const boundaryTimerEventPositions = [{ x: 277, y: 162 }, { x: 225, y: 379 }];
@@ -150,7 +150,7 @@ describe('Boundary Timer Event', () => {
     cy.get(interrupting).should('not.be.checked');
   });
 
-  it('moves to another task when dragged over', function() {
+  it('moves to another task when dragged over', () => {
     const taskPosition = { x: 300, y: 300 };
     const numberOfBoundaryTimerEventsAdded = 1;
     dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -212,7 +212,7 @@ describe('Boundary Timer Event', () => {
     });
   });
 
-  it('keeps Boundary Timer Event in correct position when dragging and dropping', function() {
+  it('keeps Boundary Timer Event in correct position when dragging and dropping', () => {
     const taskPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);

--- a/tests/e2e/specs/ErrorEndEvent.spec.js
+++ b/tests/e2e/specs/ErrorEndEvent.spec.js
@@ -24,7 +24,7 @@ describe('Error End Event', () => {
     cy.get('[data-test=switch-to-error-end-event]').click();
   });
 
-  it('Can create an error end event', function() {
+  it('Can create an error end event', () => {
     assertDownloadedXmlContainsExpected(errorEndEventXml, '<bpmn:error id="node_3_error" name="node_3_error" />');
   });
 

--- a/tests/e2e/specs/InclusiveGateway.spec.js
+++ b/tests/e2e/specs/InclusiveGateway.spec.js
@@ -24,7 +24,7 @@ describe('Inclusive Gateway', () => {
     cy.get('[name=name]').should('have.value', testString);
   });
 
-  it('Detects gateway direction of converging or diverging', function() {
+  it('Detects gateway direction of converging or diverging', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     connectNodesWithFlow('sequence-flow-button', startEventPosition, inclusivePosition);

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -7,7 +7,7 @@ import {
 import { nodeTypes } from '../support/constants';
 
 describe('Intermediate Catch Event', () => {
-  it('Update delay field on Intermediate Catch Event', function() {
+  it('Update delay field on Intermediate Catch Event', () => {
     const intermediateCatchEventPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
 
@@ -62,7 +62,7 @@ describe('Intermediate Catch Event', () => {
       .should('have', validIntermediateCatchEventXML.trim());
   });
 
-  it('Sets default values when switching between types', function() {
+  it('Sets default values when switching between types', () => {
     cy.clock();
 
     const intermediateCatchEventPosition = { x: 250, y: 250 };

--- a/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
@@ -21,7 +21,7 @@ const messageXMLSnippet = `<bpmn:message id="${ messageRef }" name="${ messageNa
 const intermediateMessageThrowEventPosition = { x: 300, y: 200 };
 
 describe('Intermediate Message Throw Event', () => {
-  it('can render an intermediate message throw event', function() {
+  it('can render an intermediate message throw event', () => {
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
 
@@ -30,7 +30,7 @@ describe('Intermediate Message Throw Event', () => {
     assertDownloadedXmlContainsExpected(eventXMLSnippet);
   });
 
-  it('can create a message when intermediate message throw event is dragged on', function() {
+  it('can create a message when intermediate message throw event is dragged on', () => {
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
 
@@ -41,7 +41,7 @@ describe('Intermediate Message Throw Event', () => {
     assertDownloadedXmlContainsExpected(eventXMLSnippet, messageXMLSnippet);
   });
 
-  it('can remove the message when intermediate message throw event is deleted', function() {
+  it('can remove the message when intermediate message throw event is deleted', () => {
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
 
@@ -58,7 +58,7 @@ describe('Intermediate Message Throw Event', () => {
     assertDownloadedXmlDoesNotContainExpected(messageXMLSnippet);
   });
 
-  it('retains new message name when clicking off and on intermediate message throw event', function() {
+  it('retains new message name when clicking off and on intermediate message throw event', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
@@ -74,7 +74,7 @@ describe('Intermediate Message Throw Event', () => {
     cy.get('[name=messageName]').should('have.value', messageName);
   });
 
-  it('can associate and rename message on intermediate message catch event', function() {
+  it('can associate and rename message on intermediate message catch event', () => {
     const intermediateMessageCatchEventPosition = { x: 200, y: 300 };
     const catchEventXMLSnippet = `
       <bpmn:intermediateCatchEvent id="node_5" name="Intermediate Message Catch Event">

--- a/tests/e2e/specs/MessageEndEvent.spec.js
+++ b/tests/e2e/specs/MessageEndEvent.spec.js
@@ -10,7 +10,7 @@ import { nodeTypes } from '../support/constants';
 const messageEndEventPosition = { x: 300, y: 200 };
 
 describe('Message End Event', () => {
-  it('can render a message end event', function() {
+  it('can render a message end event', () => {
     addNodeTypeToPaper(messageEndEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
     waitToRenderAllShapes();
     cy.get('[data-test=switch-to-message-end-event]').click();

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -74,7 +74,7 @@ describe('Message Flows', () => {
       });
   });
 
-  it('Cannot connect to itself', function() {
+  it('Cannot connect to itself', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     const poolPosition = { x: 100, y: 150 };

--- a/tests/e2e/specs/MessageStartEvent.spec.js
+++ b/tests/e2e/specs/MessageStartEvent.spec.js
@@ -2,7 +2,7 @@ import { assertDownloadedXmlContainsExpected, dragFromSourceToDest, getElementAt
 import { nodeTypes } from '../support/constants';
 
 describe('Message Start Event', () => {
-  it('Can create message start event', function() {
+  it('Can create message start event', () => {
     const messageStartEventPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.startEvent, messageStartEventPosition);
     cy.get('[data-test=switch-to-message-start-event]').click();

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -49,7 +49,7 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements + numberOfNewElementsAdded);
   });
 
-  it('Updates element name and validates xml', function() {
+  it('Updates element name and validates xml', () => {
     waitToRenderAllShapes();
 
     const startEventPosition = { x: 150, y: 150 };
@@ -97,7 +97,7 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements + numberOfNewElementsAdded);
   });
 
-  it('Generates sequential, unique node IDs', function() {
+  it('Generates sequential, unique node IDs', () => {
     waitToRenderAllShapes();
 
     const startEventPosition = { x: 150, y: 150 };
@@ -203,7 +203,7 @@ describe('Modeler', () => {
     cy.get('[data-test=inspector-container]').should('to.contain', 'Process');
   });
 
-  it('Runs custom parser before default parser', function() {
+  it('Runs custom parser before default parser', () => {
     uploadXml('parser.xml');
 
     cy.readFile('tests/e2e/fixtures/parser.xml', 'utf8').then(sourceXML => {
@@ -287,7 +287,7 @@ describe('Modeler', () => {
     });
   });
 
-  it('shows warning for unknown element during parsing', function() {
+  it('shows warning for unknown element during parsing', () => {
     uploadXml('unknownElement.xml');
     const warning = 'DataStoreReference is an unsupported element type in parse';
 
@@ -327,7 +327,7 @@ describe('Modeler', () => {
       .then(xml => expect(xml).to.contain(sequenceFlowXML));
   });
 
-  it('scales mini-map on load', function() {
+  it('scales mini-map on load', () => {
     cy.get('[data-test=mini-map-btn]').click();
     uploadXml('../fixtures/offscreenProcess.xml');
     cy.get('.mini-paper .joint-cell')
@@ -336,7 +336,7 @@ describe('Modeler', () => {
       });
   });
 
-  it('Scales gateways when mini-map is opened', function() {
+  it('Scales gateways when mini-map is opened', () => {
     const gatewayPosition = { x: 400, y: 400 };
     addNodeTypeToPaper(gatewayPosition, nodeTypes.exclusiveGateway, 'switch-to-parallel-gateway');
     cy.get('[data-test=mini-map-btn]').click();
@@ -351,7 +351,7 @@ describe('Modeler', () => {
     });
   });
 
-  it('Does not show cursor when done loading empty process', function() {
+  it('Does not show cursor when done loading empty process', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     getElementAtPosition(startEventPosition)
@@ -369,7 +369,7 @@ describe('Modeler', () => {
     cy.get('.paper-container .joint-paper').should('not.have.css', 'cursor', 'wait');
   });
 
-  it('Hides element label on drag', function() {
+  it('Hides element label on drag', () => {
     const startEventSelector = '.main-paper [data-type="processmaker.components.nodes.startEvent.Shape"]';
     const nonBreakingSpace = String.fromCharCode(160);
     const startEventLabelText = `Start${nonBreakingSpace}Event`;
@@ -439,7 +439,7 @@ describe('Modeler', () => {
     cy.get('[data-test=inspector-column]').should('not.have.class', 'inspector-column-compressed');
   });
 
-  it('can drag elements into collapsed inspector panel space', function() {
+  it('can drag elements into collapsed inspector panel space', () => {
     const taskPosition = { x: 745, y: 200 };
     cy.get('[data-test=panels-btn]').click();
     cy.wait(700);
@@ -448,7 +448,7 @@ describe('Modeler', () => {
       .should('equal', nodeTypes.task);
   });
 
-  it('should not generate duplicate diagram IDs', function() {
+  it('should not generate duplicate diagram IDs', () => {
     uploadXml('setUpForDuplicateDiagramId.xml');
     dragFromSourceToDest(nodeTypes.task, { x: 300, y: 300 });
     getXml().then(xml => {
@@ -457,7 +457,7 @@ describe('Modeler', () => {
     });
   });
 
-  it('should only show dropdown for the start event', function() {
+  it('should only show dropdown for the start event', () => {
     const startEventPosition = { x: 400, y: 400 };
     dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
@@ -471,7 +471,7 @@ describe('Modeler', () => {
     cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
   });
 
-  it('should hide start event dropdown on unhighlight', function() {
+  it('should hide start event dropdown on unhighlight', () => {
     const startEventPosition = { x: 400, y: 400 };
     dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -59,7 +59,7 @@ describe('Pools', () => {
     getElementAtPosition(lanePosition).getType().should('equal', nodeTypes.pool);
   });
 
-  it('Can drag elements between pools', function() {
+  it('Can drag elements between pools', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     const pool1Position = { x: 200, y: 200 };
@@ -135,7 +135,7 @@ describe('Pools', () => {
       });
   });
 
-  it('Removes all references to element from lane', function() {
+  it('Removes all references to element from lane', () => {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
@@ -172,7 +172,7 @@ describe('Pools', () => {
       });
   });
 
-  it('Removes all references to element from a pool', function() {
+  it('Removes all references to element from a pool', () => {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
@@ -190,7 +190,7 @@ describe('Pools', () => {
     });
   });
 
-  it('moves boundary event to another process when dragged to that pool', function() {
+  it('moves boundary event to another process when dragged to that pool', () => {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
@@ -219,7 +219,7 @@ describe('Pools', () => {
     });
   });
 
-  it('should revert pool element to initial position on undo after dragging outside of pool onto grid', function() {
+  it('should revert pool element to initial position on undo after dragging outside of pool onto grid', () => {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
@@ -233,7 +233,7 @@ describe('Pools', () => {
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).should('exist');
   });
 
-  it('should not cover child elements with lane', function() {
+  it('should not cover child elements with lane', () => {
     const poolPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -49,7 +49,7 @@ describe('Sequence Flows', () => {
     cy.get('[name=conditionExpression]').should('have.value', testString);
   });
 
-  it('Allows modifying anchor points', function() {
+  it('Allows modifying anchor points', () => {
     const taskPosition = { x: 200, y: 300 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
@@ -124,7 +124,7 @@ describe('Sequence Flows', () => {
     checkAnchorPoints('target');
   });
 
-  it('Retains target anchor point after parsing and moving shape', function() {
+  it('Retains target anchor point after parsing and moving shape', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 200, y: 300 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -172,7 +172,7 @@ describe('Sequence Flows', () => {
     });
   });
 
-  it('Retains source anchor point after parsing and moving shape', function() {
+  it('Retains source anchor point after parsing and moving shape', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 400, y: 400 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
@@ -220,7 +220,7 @@ describe('Sequence Flows', () => {
     });
   });
 
-  it('connects sequence flows with a straight line', function() {
+  it('connects sequence flows with a straight line', () => {
     const taskPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 

--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -70,7 +70,7 @@ describe('Start Timer Event', () => {
       .should('contain', timerExpression2);
   });
 
-  it('Updates properties for periodicity other than "week"', function() {
+  it('Updates properties for periodicity other than "week"', () => {
     const year = 2019;
     const month = 7;
     const day = 8;
@@ -138,7 +138,7 @@ describe('Start Timer Event', () => {
       .should('contain', endsNeverExpression);
   });
 
-  it('Does not include selected weekdays for periods other than "week"', function() {
+  it('Does not include selected weekdays for periods other than "week"', () => {
     const year = 2019;
     const month = 7;
     const day = 8;

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -35,7 +35,7 @@ describe('Tasks', () => {
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.task);
   });
 
-  it('Can create sub process flow', function() {
+  it('Can create sub process flow', () => {
     const subProcessPosition = { x: 250, y: 250 };
     addNodeTypeToPaper(subProcessPosition, nodeTypes.task, 'switch-to-sub-process');
 

--- a/tests/e2e/specs/TextAnnotation.spec.js
+++ b/tests/e2e/specs/TextAnnotation.spec.js
@@ -22,7 +22,7 @@ describe('Text Annotation', () => {
     cy.get('[name=text]').should('have.value', testString);
   });
 
-  it('Save a process with text annotation, pool and lane', function() {
+  it('Save a process with text annotation, pool and lane', () => {
     const poolPosition = { x: 250, y: 250 };
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -170,7 +170,7 @@ describe('Undo/redo', () => {
     });
   });
 
-  it('Does not include intermediate message flow definition in XML', function() {
+  it('Does not include intermediate message flow definition in XML', () => {
     const validMessageFlowXML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
   <bpmn:process id="Process_1" isExecutable="true">
@@ -228,7 +228,7 @@ describe('Undo/redo', () => {
     cy.get('[name=id]').clear().type(newId).should('have.value', newId);
   });
 
-  it('Correctly parses elements after redo', function() {
+  it('Correctly parses elements after redo', () => {
     const testConnectorPosition = { x: 150, y: 300 };
     dragFromSourceToDest(nodeTypes.testConnector, testConnectorPosition);
 
@@ -266,7 +266,7 @@ describe('Undo/redo', () => {
       });
   });
 
-  it('Can undo/redo modifying sequence flow vertices', function() {
+  it('Can undo/redo modifying sequence flow vertices', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 300, y: 300 };
 
@@ -299,7 +299,7 @@ describe('Undo/redo', () => {
     testNumberOfVertices(initialNumberOfWaypoints);
   });
 
-  it('Can undo/redo modifying association flow vertices', function() {
+  it('Can undo/redo modifying association flow vertices', () => {
     const startEventPosition = { x: 150, y: 150 };
     const textAnnotationPosition = { x: 300, y: 300 };
     dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);


### PR DESCRIPTION
This PR adds an eslint rule to require arrow functions in tests where possible and it includes changes to tests to satisfy this rule.