### PR TITLE
Added confirmation modal to switch type

### DIFF
--- a/src/components/crown/crownButtons/crownTaskDropdown.vue
+++ b/src/components/crown/crownButtons/crownTaskDropdown.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="cog-container" v-if="dropdownData.length > 0" role="menuitem">
     <crown-button
+      data-test="select-type-dropdown"
       id="dropdown-button"
       aria-label="Select a type"
       v-on="$listeners"

--- a/src/components/crown/crownButtons/crownTaskDropdown.vue
+++ b/src/components/crown/crownButtons/crownTaskDropdown.vue
@@ -43,7 +43,7 @@ export default {
         this.$emit('toggle-dropdown-state', false);
         return;
       }
-      this.$emit('confirm-replace', data);
+      this.$emit('replace-node-type', data);
     },
   },
 };

--- a/src/components/crown/crownButtons/crownTaskDropdown.vue
+++ b/src/components/crown/crownButtons/crownTaskDropdown.vue
@@ -42,7 +42,7 @@ export default {
         this.$emit('toggle-dropdown-state', false);
         return;
       }
-      this.$emit('replace-node', data);
+      this.$emit('confirm-replace', data);
     },
   },
 };

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -34,6 +34,7 @@
       :moddle="moddle"
       :shape="shape"
       :task-dropdown-initially-open="taskDropdownInitiallyOpen"
+      @confirm-replace="confirmReplace"
       v-on="$listeners"
     />
 
@@ -43,6 +44,19 @@
       :node="node"
       v-on="$listeners"
     />
+
+    <b-modal
+      id="modal-prevent-closing"
+      ref="modal"
+      :title="$t('Change Type')"
+      :ok-title="$t('Confirm')"
+      :cancel-title="$t('Cancel')"
+      v-model="showReplaceModal"
+      @hidden="showReplaceModal = false"
+      @ok="$emit('replace-node', nodeToReplace)"
+    >
+      <p>{{ $t('Changing this type will replace your current configuration') }}</p>
+    </b-modal>
   </div>
 </template>
 
@@ -105,6 +119,8 @@ export default {
       savePositionOnPointerupEventSet: false,
       style: null,
       taskDropdownInitiallyOpen: true,
+      showReplaceModal: false,
+      nodeToReplace: null,
     };
   },
   created() {
@@ -127,6 +143,14 @@ export default {
     },
   },
   methods: {
+    confirmReplace(node) {
+      if (this.taskDropdownInitiallyOpen) {
+        this.$emit('replace-node', node);
+        return;
+      }
+      this.showReplaceModal = true;
+      this.nodeToReplace = node;
+    },
     setNodePosition() {
       this.shape.stopListening(this.paper, 'element:pointerup', this.setNodePosition);
       this.savePositionOnPointerupEventSet = false;

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -34,7 +34,7 @@
       :moddle="moddle"
       :shape="shape"
       :task-dropdown-initially-open="taskDropdownInitiallyOpen"
-      @confirm-replace="confirmReplace"
+      @replace-node-type="confirmReplace"
       v-on="$listeners"
     />
 

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -281,3 +281,11 @@ export function addNodeTypeToPaper(nodePosition, genericNode, nodeToSwitchTo) {
   dragFromSourceToDest(genericNode, nodePosition);
   cy.get(`[data-test=${nodeToSwitchTo}]`).click();
 }
+
+export function modalConfirm() {
+  cy.get('.modal-footer .btn-primary').click();
+}
+
+export function modalCancel() {
+  cy.get('.modal-footer .btn-secondary').click();
+}


### PR DESCRIPTION
Related #997 

Covers all type switching. Not just on Task.

It will not ask to confirm when type dropdown is initially open (When an element is first added to the diagram). 

It does not ask to confirm switching type after initially uploading a xml. Needs alternative solution to set taskDropdownInitiallyOpen to false after uploading xml.