### PR TITLE
Add task change warning after xml uploaded

### DIFF
--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -118,7 +118,7 @@ export default {
       showCrown: false,
       savePositionOnPointerupEventSet: false,
       style: null,
-      taskDropdownInitiallyOpen: true,
+      taskDropdownInitiallyOpen: !this.isRendering,
       showReplaceModal: false,
       nodeToReplace: null,
     };

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -118,7 +118,7 @@ export default {
       showCrown: false,
       savePositionOnPointerupEventSet: false,
       style: null,
-      taskDropdownInitiallyOpen: !this.isRendering,
+      taskDropdownInitiallyOpen: this.paperNotRendered(),
       showReplaceModal: false,
       nodeToReplace: null,
     };
@@ -143,6 +143,9 @@ export default {
     },
   },
   methods: {
+    paperNotRendered() {
+      return !this.isRendering;
+    },
     confirmReplace(node) {
       if (this.taskDropdownInitiallyOpen) {
         this.$emit('replace-node', node);


### PR DESCRIPTION
Closes #997 

If you upload a xml, taskDropdownInitiallyOpen is still true.

Base the state on rendering. isRendering is true when uploading a xml but not when manually adding new nodes to the diagram. The taskDropdownInitiallyOpen data property gets the first state of isRendering and doesn't update it after Modeler is done rendering. Open to other solutions.