### PR TITLE
Fix duplicate messages and errors

### DIFF
--- a/src/components/nodes/errorEndEvent/errorEndEvent.vue
+++ b/src/components/nodes/errorEndEvent/errorEndEvent.vue
@@ -14,10 +14,24 @@ export default {
       }),
     };
   },
+  methods: {
+    addErrorRef() {
+      if (this.node.definition.get('eventDefinitions')[0].errorRef) {
+        this.error = this.node.definition.get('eventDefinitions')[0].errorRef;
+        return;
+      }
+
+      this.error = this.moddle.create('bpmn:Error', {
+        id: `${this.id}_error`,
+        name: `${this.id}_error`,
+      });
+      this.rootElements.push(this.error);
+      this.node.definition.get('eventDefinitions')[0].errorRef = this.error;
+    },
+  },
   mounted() {
     this.shape.attr('image/xlink:href', errorIcon);
-    this.rootElements.push(this.error);
-    this.node.definition.get('eventDefinitions')[0].errorRef = this.error;
+    this.addErrorRef();
   },
   destroyed() {
     pull(this.rootElements, this.error);

--- a/src/components/nodes/intermediateMessageThrowEvent/intermediateMessageThrowEvent.vue
+++ b/src/components/nodes/intermediateMessageThrowEvent/intermediateMessageThrowEvent.vue
@@ -9,10 +9,25 @@ export default {
   data() {
     return {
       message: this.moddle.create('bpmn:Message', {
-        id: `${ this.id }_message`,
-        name: `${ this.id }_message`,
+        id: `${this.id}_message`,
+        name: `${this.id}_message`,
       }),
     };
+  },
+  methods: {
+    addMessageRef() {
+      if (this.node.definition.get('eventDefinitions')[0].messageRef) {
+        this.message = this.node.definition.get('eventDefinitions')[0].messageRef;
+        return;
+      }
+
+      this.message = this.moddle.create('bpmn:Message', {
+        id: `${this.id}_message`,
+        name: `${this.id}_message`,
+      });
+      this.rootElements.push(this.message);
+      this.node.definition.get('eventDefinitions')[0].messageRef = this.message;
+    },
   },
   mounted() {
     this.shape.attr('image/xlink:href', intermediateMailSymbol);
@@ -24,11 +39,8 @@ export default {
         x: 2,
       },
     });
-    this.rootElements.push(this.message);
 
-    if (!this.node.definition.get('eventDefinitions')[0].messageRef) {
-      this.node.definition.get('eventDefinitions')[0].messageRef = this.message;
-    }
+    this.addMessageRef();
   },
   destroyed() {
     pull(this.rootElements, this.message);

--- a/src/components/nodes/messageEndEvent/messageEndEvent.vue
+++ b/src/components/nodes/messageEndEvent/messageEndEvent.vue
@@ -14,13 +14,24 @@ export default {
       }),
     };
   },
+  methods: {
+    addMessageRef() {
+      if (this.node.definition.get('eventDefinitions')[0].messageRef) {
+        this.message = this.node.definition.get('eventDefinitions')[0].messageRef;
+        return;
+      }
+
+      this.message = this.moddle.create('bpmn:Message', {
+        id: `${this.id}_message`,
+        name: `${this.id}_message`,
+      });
+      this.rootElements.push(this.message);
+      this.node.definition.get('eventDefinitions')[0].messageRef = this.message;
+    },
+  },
   mounted() {
     this.shape.attr('image/xlink:href', messageEndEventSymbol);
-    this.rootElements.push(this.message);
-
-    if (!this.node.definition.get('eventDefinitions')[0].messageRef) {
-      this.node.definition.get('eventDefinitions')[0].messageRef = this.message;
-    }
+    this.addMessageRef();
   },
   destroyed() {
     pull(this.rootElements, this.message);

--- a/tests/e2e/specs/ErrorEndEvent.spec.js
+++ b/tests/e2e/specs/ErrorEndEvent.spec.js
@@ -52,7 +52,7 @@ describe('Error End Event', () => {
     );
   });
 
-  it('should not create duplicate errors on undo/redo', function() {
+  it('should not create duplicate errors on undo/redo', () => {
     cy.get('[data-test=undo]').click();
     waitToRenderAllShapes();
     cy.get('[data-test=redo]').click();

--- a/tests/e2e/specs/ErrorEndEvent.spec.js
+++ b/tests/e2e/specs/ErrorEndEvent.spec.js
@@ -4,6 +4,7 @@ import {
   assertDownloadedXmlDoesNotContainExpected,
   getCrownButtonForElement,
   getElementAtPosition,
+  getXml,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -49,5 +50,18 @@ describe('Error End Event', () => {
       '<bpmn:error id="node_3_error" name="node_3_error" />',
       `<bpmn:error id="node_3_error" name="${errorName}" />`,
     );
+  });
+
+  it('should not create duplicate errors on undo/redo', function() {
+    cy.get('[data-test=undo]').click();
+    waitToRenderAllShapes();
+    cy.get('[data-test=redo]').click();
+    waitToRenderAllShapes();
+
+    getXml().then(xml => {
+      const match = xml.match(/<bpmn:error id=".*?" name=".*?" \/>/g);
+      const numberOfMessages = match && match.length;
+      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
+    });
   });
 });

--- a/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
@@ -1,9 +1,11 @@
 import {
+  addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
   dragFromSourceToDest,
   getCrownButtonForElement,
   getElementAtPosition,
+  getXml,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -97,5 +99,20 @@ describe('Intermediate Message Throw Event', () => {
     cy.get('[name=messageRef]').should('contain', messageName);
 
     assertDownloadedXmlContainsExpected(eventXMLSnippet, catchEventXMLSnippet, messageXMLSnippet);
+  });
+
+  it('should not create duplicate messages on undo/redo', function() {
+    addNodeTypeToPaper({ x: 300, y: 300 }, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-message-throw-event');
+
+    cy.get('[data-test=undo]').click();
+    waitToRenderAllShapes();
+    cy.get('[data-test=redo]').click();
+    waitToRenderAllShapes();
+
+    getXml().then(xml => {
+      const match = xml.match(/<bpmn:message id=".*?" name=".*?" \/>/g);
+      const numberOfMessages = match && match.length;
+      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
+    });
   });
 });

--- a/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
@@ -101,7 +101,7 @@ describe('Intermediate Message Throw Event', () => {
     assertDownloadedXmlContainsExpected(eventXMLSnippet, catchEventXMLSnippet, messageXMLSnippet);
   });
 
-  it('should not create duplicate messages on undo/redo', function() {
+  it('should not create duplicate messages on undo/redo', () => {
     addNodeTypeToPaper({ x: 300, y: 300 }, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-message-throw-event');
 
     cy.get('[data-test=undo]').click();

--- a/tests/e2e/specs/MessageEndEvent.spec.js
+++ b/tests/e2e/specs/MessageEndEvent.spec.js
@@ -2,9 +2,9 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   getElementAtPosition,
+  getXml,
   waitToRenderAllShapes,
 } from '../support/utils';
-
 import { nodeTypes } from '../support/constants';
 
 const messageEndEventPosition = { x: 300, y: 200 };
@@ -24,5 +24,20 @@ describe('Message End Event', () => {
         <bpmn:messageEventDefinition messageRef="node_3_message" />
       </bpmn:endEvent>
     `);
+  });
+
+  it('should not create duplicate messages on undo/redo', function() {
+    addNodeTypeToPaper(messageEndEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
+
+    cy.get('[data-test=undo]').click();
+    waitToRenderAllShapes();
+    cy.get('[data-test=redo]').click();
+    waitToRenderAllShapes();
+
+    getXml().then(xml => {
+      const match = xml.match(/<bpmn:message id=".*?" name=".*?" \/>/g);
+      const numberOfMessages = match && match.length;
+      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
+    });
   });
 });

--- a/tests/e2e/specs/MessageEndEvent.spec.js
+++ b/tests/e2e/specs/MessageEndEvent.spec.js
@@ -26,7 +26,7 @@ describe('Message End Event', () => {
     `);
   });
 
-  it('should not create duplicate messages on undo/redo', function() {
+  it('should not create duplicate messages on undo/redo', () => {
     addNodeTypeToPaper(messageEndEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
 
     cy.get('[data-test=undo]').click();


### PR DESCRIPTION
Fixes #1015.

The issue this PR fixes didn't seem to cause any major usability issues, but since duplicate message elements were being added on reload of the BPMN process, two messages would show up in the dropdown of the associated catch event.

Here is a GIF of that issue:
![duplicate_messages](https://user-images.githubusercontent.com/7561061/72275650-527a5100-35fc-11ea-85be-463b0de092df.gif)
