### PR TITLE
Fix scrollbars on control and inspector panels

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -18,9 +18,9 @@
           </b-btn>
         </div>
       </b-card-header>
-
-      <modeler ref="modeler" @validate="validationErrors = $event" @warnings="warnings = $event" />
-
+      <b-card-body class="overflow-hidden position-relative p-0 vh-100">
+        <modeler ref="modeler" @validate="validationErrors = $event" @warnings="warnings = $event" />
+      </b-card-body>
       <validation-status :validation-errors="validationErrors" :warnings="warnings" />
     </b-card>
 

--- a/src/assets/scss/settings/_settings.variables.scss
+++ b/src/assets/scss/settings/_settings.variables.scss
@@ -10,3 +10,5 @@ $cursors: default, not-allowed, wait;
 // ANIMATION
 $controls-transition: 0.3s;
 $transition-duration: 0.3s;
+
+$toolbar-height: 4rem;

--- a/src/components/controls/controls.scss
+++ b/src/components/controls/controls.scss
@@ -1,9 +1,11 @@
 $controls-column-max-width: 265px;
 $controls-column-compressed-max-width: 95px;
 $controls-transition: 0.3s;
+$toolbar-height: 4rem;
 
 .controls {
   z-index: 1;
+  padding-bottom: $toolbar-height;
 
   &-column {
     max-width: $controls-column-max-width;

--- a/src/components/controls/controls.scss
+++ b/src/components/controls/controls.scss
@@ -1,7 +1,6 @@
 $controls-column-max-width: 265px;
 $controls-column-compressed-max-width: 95px;
 $controls-transition: 0.3s;
-$toolbar-height: 4rem;
 
 .controls {
   z-index: 1;

--- a/src/components/inspectors/inspector.scss
+++ b/src/components/inspectors/inspector.scss
@@ -1,5 +1,4 @@
 $inspector-column-max-width: 265px;
-$toolbar-height: 4rem;
 
 .inspector-column {
   max-width: $inspector-column-max-width;

--- a/src/components/inspectors/inspector.scss
+++ b/src/components/inspectors/inspector.scss
@@ -1,4 +1,5 @@
 $inspector-column-max-width: 265px;
+$toolbar-height: 4rem;
 
 .inspector-column {
   max-width: $inspector-column-max-width;
@@ -10,6 +11,7 @@ $inspector-column-max-width: 265px;
   &-container {
     text-align: left;
     user-select: none;
+    padding-bottom: $toolbar-height;
 
     .form-group {
       padding: 0 0.5rem;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card-body class="overflow-hidden position-relative p-0 vh-100" data-test="body-container">
+  <span data-test="body-container">
     <tool-bar
       :canvas-drag-position="canvasDragPosition"
       :cursor="cursor"
@@ -11,7 +11,6 @@
       @toggle-mini-map-open="miniMapOpen = $event"
       @saveBpmn="$emit('saveBpmn')"
     />
-
     <b-row class="modeler h-100">
       <b-tooltip
         v-if="tooltipTarget"
@@ -93,7 +92,7 @@
         @replace-node="replaceNode"
       />
     </b-row>
-  </b-card-body>
+  </span>
 </template>
 
 <script>

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -1,4 +1,3 @@
-$toolbar-height: 4rem;
 $toolbar-background-color: #FFF;
 
 .toolbar {


### PR DESCRIPTION
Related #1012

Not entirely sure why the `b-card-body` and styling has to be outside of the modeler component.

This has a related pr on processmaker: https://github.com/ProcessMaker/processmaker/pull/2730