### PR TITLE
Removed Boundary Message Event from all tasks except Sub Process

### DIFF
--- a/src/boundaryEventValidation.js
+++ b/src/boundaryEventValidation.js
@@ -6,9 +6,17 @@ export function canAddBoundaryEventToTarget(boundaryEventType, dropTarget) {
     return false;
   }
 
-  return getEmptyBoundaryEventPositionsForShape(dropTarget).length !== 0;
+  if (boundaryEventType === 'processmaker-modeler-boundary-message-event') {
+    return dropTarget.component.node.isBpmnType('bpmn:CallActivity') && spaceAvailable(dropTarget);
+  }
+
+  return spaceAvailable(dropTarget);
 }
 
 export function isValidBoundaryEscalationEvent(component) {
   return component && component.node.isBpmnType('bpmn:CallActivity');
+}
+
+function spaceAvailable(dropTarget) {
+  return getEmptyBoundaryEventPositionsForShape(dropTarget).length !== 0;
 }

--- a/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
+++ b/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
@@ -72,7 +72,7 @@ export default {
     addBoundaryEvent(nodeType) {
       this.$emit('toggle-dropdown-state', false);
 
-      if (!canAddBoundaryEventToTarget(nodeType, this.shape)) {
+      if (!this.canAddBoundaryEventToTarget(nodeType, this.shape)) {
         return;
       }
 

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -89,6 +89,7 @@ export default {
           label: 'Boundary Message Event',
           nodeType: 'processmaker-modeler-boundary-message-event',
           dataTest: 'add-boundary-message-event',
+          disabledLabel: 'Allowed on Sub Process',
         },
       ],
     };

--- a/tests/e2e/specs/BoundaryEventValidation.spec.js
+++ b/tests/e2e/specs/BoundaryEventValidation.spec.js
@@ -10,7 +10,7 @@ describe('Boundary event validation', () => {
 
     const numberOfPortsAroundTask = 12;
     for (let i = 0; i < numberOfPortsAroundTask; i++) {
-      setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition);
+      setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     }
 
     getElementAtPosition(taskPosition, nodeTypes.task)
@@ -28,7 +28,7 @@ describe('Boundary event validation', () => {
       .get('.main-paper [data-type="processmaker.components.nodes.boundaryEvent.Shape"]')
       .should('have.length', numberOfPortsAroundTask);
 
-    setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     cy
       .get('.main-paper [data-type="processmaker.components.nodes.boundaryEvent.Shape"]')
@@ -36,7 +36,7 @@ describe('Boundary event validation', () => {
 
     getElementAtPosition(taskPosition, nodeTypes.task).click();
 
-    const dataTest = nodeTypes.boundaryMessageEvent.replace('processmaker-modeler-', 'add-');
+    const dataTest = nodeTypes.boundaryTimerEvent.replace('processmaker-modeler-', 'add-');
     cy.get(`[data-test="${dataTest}"]`)
       .should('exist')
       .should('not.be.enabled');


### PR DESCRIPTION
Closes #1021 

Propose showing the Boundary Message Event disabled and have a tooltip saying why.
Alternative is removing it completely.

<img width="598" alt="Screen Shot 2020-01-14 at 11 43 09 AM" src="https://user-images.githubusercontent.com/6653340/72363590-1958e400-36c3-11ea-9c3b-a96f8fd0f037.png">
