### PR TITLE
Fix for arrow key events incorrectly triggering element movement

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -700,6 +700,10 @@ export default {
   },
   mounted() {
     document.addEventListener('keydown', event => {
+      const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
+      if (formElementHasFocus) {
+        return;
+      }
       moveShapeByKeypress(
         event.key,
         store.getters.highlightedShape,

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -126,7 +126,7 @@ import registerInspectorExtension from '@/components/InspectorExtensionManager';
 import initAnchor from '@/mixins/linkManager.js';
 import ensureShapeIsNotCovered from '@/components/shapeStackUtils';
 import ToolBar from '@/components/toolbar/ToolBar';
-import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
+import { keydownListener } from '@/components/modeler/moveWithArrowKeys';
 import Node from '@/components/nodes/node';
 import { addNodeToProcess } from '@/components/nodeManager';
 
@@ -699,17 +699,7 @@ export default {
     this.linter = new Linter(linterConfig);
   },
   mounted() {
-    document.addEventListener('keydown', event => {
-      const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
-      if (formElementHasFocus) {
-        return;
-      }
-      moveShapeByKeypress(
-        event.key,
-        store.getters.highlightedShape,
-        this.pushToUndoStack,
-      );
-    });
+    document.addEventListener('keydown', keydownListener);
 
     this.graph = new dia.Graph();
     store.commit('setGraph', this.graph);

--- a/src/components/modeler/moveWithArrowKeys.js
+++ b/src/components/modeler/moveWithArrowKeys.js
@@ -1,4 +1,5 @@
 import PaperManager from '@/components/paperManager';
+import store from '@/store';
 
 export const moveAmount = PaperManager.gridSize / 2;
 
@@ -46,4 +47,17 @@ function expandPoolToContainElement(shape) {
   }
 
   pool.component.updateLaneChildren();
+}
+
+export function keydownListener(event) {
+  const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
+  if (formElementHasFocus) {
+    return;
+  }
+
+  moveShapeByKeypress(
+    event.key,
+    store.getters.highlightedShape,
+    this.pushToUndoStack,
+  );
 }


### PR DESCRIPTION
Addresses [Keyboard Navigation Bug (1019)](https://github.com/ProcessMaker/modeler/issues/1019).

This checks to see whether a model element has focus before moving it when pressing arrow keys.

This PR adds an early return to the `keydown` arrow key handler originally defined in `src/components/modeler/Modeler.vue`. I've extracted the event listener logic to `src/components/modeler/moveWithArrowKeys.js`  - and we could consider moving all the event listeners out of the Modeler source to improve the readability of `mounted()`. What do you think?

I've attempted to add some tests for this but the effort of that seems to outweigh the benefit (considering the small size of the change) : Cypress has issues around triggering the `keydown` and then retargeting the now moved element; jest has issues around mocking out `moveShapeByKeypress` that means we'll need to refactor quite a few things to test this. The pragmatic solution seemed to be a manual test.

It's been manually tested in Firefox, Chrome, and Safari.