### PR TITLE
Allow closer link connections on shapes

### DIFF
--- a/src/components/nodes/messageFlow/messageFlow.vue
+++ b/src/components/nodes/messageFlow/messageFlow.vue
@@ -60,7 +60,7 @@ export default {
   },
   methods: {
     updateRouter() {
-      this.shape.router('orthogonal');
+      this.shape.router('orthogonal', { padding: 1 });
     },
     updateDefinitionLinks() {
       const targetShape = this.shape.getTargetElement();

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -95,7 +95,7 @@ export default {
   },
   methods: {
     updateRouter() {
-      this.shape.router('orthogonal');
+      this.shape.router('orthogonal', { padding: 1 });
     },
     updateDefinitionLinks() {
       const targetShape = this.shape.getTargetElement();


### PR DESCRIPTION
Fixes #1037.

Looks like padding was added as an option to the orthogonal router in JointJS v2.2.0. Setting this to a small value (1 in this case) allows shapes to get much closer together without looping. Setting it to 0 seems to have the same result as not setting it at all (defaults to 20). Reference: https://resources.jointjs.com/docs/jointjs/v3.1/joint.html#routers.orthogonal.

<img width="339" alt="Screen Shot 2020-01-22 at 10 56 36 AM" src="https://user-images.githubusercontent.com/7561061/72910232-3f573780-3d06-11ea-8bf0-022f39dc6f85.png">
