### PR TITLE
Restore validate and clean before parse

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -453,6 +453,10 @@ export default {
       this.processes = this.getProcesses();
       this.plane = this.getPlane();
       this.planeElements = this.getPlaneElements();
+
+      this.validatePlaneElements();
+      this.cleanPlaneElements();
+
       this.processNode = new Node(
         'processmaker-modeler-process',
         this.processes[0],
@@ -534,8 +538,6 @@ export default {
       await this.paperManager.performAtomicAction(async() => {
         await this.waitForCursorToChange();
         this.parse();
-        this.validatePlaneElements();
-        this.cleanPlaneElements();
         this.addPools();
         this.setUpDiagram();
       });


### PR DESCRIPTION
Closes #1048 

Validate and clean plane elements were put after parsing during a refactor. Put them back in their original place to remove the error on some uploaded files.