### PR TITLE
Allow undo of keyboard arrow-key moves

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -125,9 +125,9 @@ import registerInspectorExtension from '@/components/InspectorExtensionManager';
 import initAnchor from '@/mixins/linkManager.js';
 import ensureShapeIsNotCovered from '@/components/shapeStackUtils';
 import ToolBar from '@/components/toolbar/ToolBar';
-import { keydownListener } from '@/components/modeler/moveWithArrowKeys';
 import Node from '@/components/nodes/node';
 import { addNodeToProcess } from '@/components/nodeManager';
+import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 
 const version = '1.0';
 
@@ -662,6 +662,18 @@ export default {
 
       this.paperManager.setPaperDimensions(clientWidth, clientHeight);
     },
+    keydownListener(event) {
+      const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
+      if (formElementHasFocus) {
+        return;
+      }
+
+      moveShapeByKeypress(
+        event.key,
+        store.getters.highlightedShape,
+        this.pushToUndoStack,
+      );
+    },
     validateDropTarget({ clientX, clientY, control }) {
       const { allowDrop, poolTarget } = getValidationProperties(clientX, clientY, control, this.paperManager.paper, this.graph, this.collaboration, this.$refs['paper-container']);
       this.allowDrop = allowDrop;
@@ -708,7 +720,7 @@ export default {
     this.linter = new Linter(linterConfig);
   },
   mounted() {
-    document.addEventListener('keydown', keydownListener);
+    document.addEventListener('keydown', this.keydownListener);
 
     this.graph = new dia.Graph();
     store.commit('setGraph', this.graph);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -663,8 +663,8 @@ export default {
       this.paperManager.setPaperDimensions(clientWidth, clientHeight);
     },
     keydownListener(event) {
-      const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
-      if (formElementHasFocus) {
+      const focusIsOutsideDiagram = !event.target.toString().toLowerCase().includes('body');
+      if (focusIsOutsideDiagram) {
         return;
       }
 

--- a/src/components/modeler/moveWithArrowKeys.js
+++ b/src/components/modeler/moveWithArrowKeys.js
@@ -1,5 +1,4 @@
 import PaperManager from '@/components/paperManager';
-import store from '@/store';
 
 export const moveAmount = PaperManager.gridSize / 2;
 
@@ -47,17 +46,4 @@ function expandPoolToContainElement(shape) {
   }
 
   pool.component.updateLaneChildren();
-}
-
-export function keydownListener(event) {
-  const formElementHasFocus = event.target.toString().toLowerCase().indexOf('body') === -1;
-  if (formElementHasFocus) {
-    return;
-  }
-
-  moveShapeByKeypress(
-    event.key,
-    store.getters.highlightedShape,
-    this.pushToUndoStack,
-  );
 }

--- a/src/components/modeler/moveWithArrowKeys.js
+++ b/src/components/modeler/moveWithArrowKeys.js
@@ -2,30 +2,28 @@ import PaperManager from '@/components/paperManager';
 
 export const moveAmount = PaperManager.gridSize / 2;
 
-const translationAmount = new Map();
-translationAmount.set('Up', [0, -moveAmount]);
-translationAmount.set('Down', [0, moveAmount]);
-translationAmount.set('Left', [-moveAmount, 0]);
-translationAmount.set('Right', [moveAmount, 0]);
+const translationVectors = new Map();
+translationVectors.set('Up', [0, -moveAmount]);
+translationVectors.set('Down', [0, moveAmount]);
+translationVectors.set('Left', [-moveAmount, 0]);
+translationVectors.set('Right', [moveAmount, 0]);
 
-const invalidTypes = [
+const immovableShapeTypes = [
   'PoolLane',
   'processmaker.components.nodes.boundaryEvent.Shape',
 ];
 
-export default function moveShapeByKeypress(key, shape, onAfterMove = () => {}) {
-  if (!shape || invalidTypes.includes(shape.get('type'))) {
+export default function moveShapeByKeypress(key, shape, onAfterMove = () => {
+}) {
+  if (!isArrowKey(key)) {
     return;
   }
 
-  const match = key.match(/^(?:Arrow)?(Up|Down|Left|Right)$/);
-  const keyCode = match && match[1];
-
-  if (!keyCode) {
+  if (!isMovableShape(shape)) {
     return;
   }
 
-  const [tx, ty] = translationAmount.get(keyCode) || [0, 0];
+  const [tx, ty] = getTranslationVector(key);
   shape.translate(tx, ty, { movedWithArrowKeys: true });
 
   expandPoolToContainElement(shape);
@@ -33,9 +31,29 @@ export default function moveShapeByKeypress(key, shape, onAfterMove = () => {}) 
   onAfterMove();
 }
 
+function isArrowKey(key) {
+  const arrows = ['up', 'down', 'left', 'right'];
+  return arrows.some(direction => key.toLowerCase().includes(direction));
+}
+
+function isMovableShape(shape) {
+  return shape && !immovableShapeTypes.includes(shape.get('type'));
+}
+
+function getTranslationVector(arrowKey) {
+  const crossBrowserKeyMatch = arrowKey.match(/^(?:Arrow)?(Up|Down|Left|Right)$/);
+  return crossBrowserKeyMatch !== null
+    ? translationVectors.get(crossBrowserKeyMatch[1])
+    : [0, 0];
+}
+
+function shapeParentIsAPool(pool) {
+  return !pool || pool.get('type') !== 'processmaker.modeler.bpmn.pool';
+}
+
 function expandPoolToContainElement(shape) {
   const pool = shape.getParentCell();
-  if (!pool || pool.get('type') !== 'processmaker.modeler.bpmn.pool') {
+  if (shapeParentIsAPool(pool)) {
     return;
   }
 

--- a/tests/e2e/specs/KeyboardMovement.spec.js
+++ b/tests/e2e/specs/KeyboardMovement.spec.js
@@ -1,0 +1,49 @@
+import { dragFromSourceToDest, getElementAtPosition, waitToRenderAllShapes } from '../support/utils';
+import { nodeTypes } from '../support/constants';
+
+const CYPRESS_UNDO_SCROLL_ADJUSTMENT = 60.5;
+
+describe('Keyboard movement interaction', () => {
+  it('Can move a node using the keyboard arrows', () => {
+    const taskPosition = { x: 400, y: 500 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+
+    getElementAtPosition(taskPosition).then($task => {
+      const { top, left } = $task.position();
+      cy.get('body').type('{uparrow}{uparrow}{uparrow}{uparrow}');
+      cy.get('body').type('{leftarrow}{leftarrow}{leftarrow}{leftarrow}');
+      waitToRenderAllShapes();
+
+      getElementAtPosition(taskPosition).then($task => {
+        const { top: newTop, left: newLeft } = $task.position();
+
+        expect(newTop).to.be.lessThan(top);
+        expect(newLeft).to.be.lessThan(left);
+      });
+    });
+  });
+
+  it('can undo keyboard moves', () => {
+    const taskPosition = { x: 400, y: 500 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    getElementAtPosition(taskPosition).then($task => {
+      const { top, left } = $task.position();
+
+      cy.get('body').type('{uparrow}');
+      cy.get('body').type('{leftarrow}');
+      waitToRenderAllShapes();
+
+      cy.get('[data-test=undo]').click({ force: true });
+      cy.get('[data-test=undo]').click({ force: true });
+
+      waitToRenderAllShapes();
+
+      getElementAtPosition(taskPosition).then($task => {
+        const { top: newTop, left: newLeft } = $task.position();
+
+        expect(newTop - CYPRESS_UNDO_SCROLL_ADJUSTMENT).to.be.approximately(top, 2);
+        expect(newLeft).to.be.approximately(left, 2);
+      });
+    });
+  });
+});

--- a/tests/unit/moveWithArrowKeys.spec.js
+++ b/tests/unit/moveWithArrowKeys.spec.js
@@ -48,4 +48,12 @@ describe('moveWithArrowKeys', () => {
     expect(shape.translate).not.toHaveBeenCalled();
     expect(onAfterMove).not.toHaveBeenCalled();
   });
+
+  it('Does nothing when it does not receive a shape', () => {
+    const shape = undefined;
+    const onAfterMove = jest.fn();
+    moveShapeByKeypress('Up', shape, onAfterMove);
+
+    expect(onAfterMove).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Addresses [issue 1043](https://github.com/ProcessMaker/modeler/issues/1043) and also cleanup comments made in PR #1029.

Diagram elements moved with arrow keys can now be moved back via undo.

I've added a new test spec to safeguard the undo behaviour, and a new unit test to describe the movement behaviour when we don't have an actively selected shape.

I've also extracted some functions and renamed some parameters to highlight intent.
