### PR TITLE
Wait to render before switching task type

### DIFF
--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -279,6 +279,7 @@ export function assertDownloadedXmlDoesNotContainExpected(xmlString) {
 
 export function addNodeTypeToPaper(nodePosition, genericNode, nodeToSwitchTo) {
   dragFromSourceToDest(genericNode, nodePosition);
+  waitToRenderAllShapes();
   cy.get(`[data-test=${nodeToSwitchTo}]`).click();
 }
 


### PR DESCRIPTION
Fix for `should turn pool red when hovered over and then back to default colour when no longer over pool` on Boundary Message Event.

This happens randomly on Boundary Message Event because it is one of the few tests that switches the default task to another task type.