### PR TITLE
Disable unneeded BPMNLint rule

### DIFF
--- a/.bpmnlintrc
+++ b/.bpmnlintrc
@@ -7,6 +7,7 @@
     "no-inclusive-gateway": "off",
     "fake-join": "off",
     "no-duplicate-sequence-flows": "off",
-    "single-blank-start-event": "off"
+    "single-blank-start-event": "off",
+    "processmaker/call-activity-sequence-flow": "off"
   }
 }


### PR DESCRIPTION
Fixes #1083.

The "processmaker/call-activity-sequence-flow" bpmnlint rule is no longer valid, as the start event for a subprocess is selected through the config for the sub process, and not through the connecting sequence flow.