### PR TITLE
Restored original negation for boundary events in pools

### DIFF
--- a/src/components/nodes/pool/poolUtils.js
+++ b/src/components/nodes/pool/poolUtils.js
@@ -23,7 +23,7 @@ function addAllElementsToPool(graph, pool) {
   graph
     .getElements()
     .filter((shape) => shape !== pool)
-    .filter(({ component }) => component.node.isBpmnType('bpmn:BoundaryEvent'))
+    .filter(({ component }) => !component.node.isBpmnType('bpmn:BoundaryEvent'))
     .forEach(({ component }) => {
       pool.embed(component.shape);
       component.node.pool = pool;

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -14,25 +14,7 @@ import {
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
-
-function boundaryEventIsCloseToTask() {
-  const positionErrorMargin = 30;
-
-  const taskSelector = '.main-paper ' +
-    '[data-type="processmaker.components.nodes.task.Shape"]';
-
-  const boundaryTimerEventSelector = taskSelector +
-    ' ~ [data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
-
-  cy.get(taskSelector).then($task => {
-    const { left: taskLeft, top: taskTop } = $task.position();
-    cy.get(boundaryTimerEventSelector).then($boundaryEvent => {
-      const { left, top } = $boundaryEvent.position();
-      expect(left).to.be.closeTo(taskLeft, positionErrorMargin);
-      expect(top).to.be.closeTo(taskTop, positionErrorMargin);
-    });
-  });
-}
+import { assertBoundaryEventIsCloseToTask } from '../support/utils';
 
 describe('Pools', () => {
   it('Update pool name', () => {
@@ -286,14 +268,14 @@ describe('Pools', () => {
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).then($pool => {
-      boundaryEventIsCloseToTask();
+      assertBoundaryEventIsCloseToTask();
 
       cy.wrap($pool)
         .trigger('mousedown', { which: 1, force: true })
         .trigger('mousemove', { clientX: 800, clientY: 350, force: true })
         .trigger('mouseup', { force: true })
         .then(waitToRenderAllShapes)
-        .then(boundaryEventIsCloseToTask);
+        .then(assertBoundaryEventIsCloseToTask);
     });
   });
 });

--- a/tests/e2e/support/constants.js
+++ b/tests/e2e/support/constants.js
@@ -41,3 +41,6 @@ export const nodeTypes = {
 
 export const boundaryEventSelector = '.main-paper ' +
   '[data-type="processmaker.components.nodes.boundaryEvent.Shape"]';
+
+export const taskSelector = '.main-paper ' +
+  '[data-type="processmaker.components.nodes.task.Shape"]';

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -1,6 +1,6 @@
 import { saveDebounce } from '../../../src/components/inspectors/inspectorConstants';
 import path from 'path';
-import { nodeTypes } from './constants';
+import { boundaryEventSelector, nodeTypes, taskSelector } from './constants';
 
 const renderTime = 300;
 
@@ -274,6 +274,19 @@ export function assertDownloadedXmlContainsExpected(...xmlStrings) {
 export function assertDownloadedXmlDoesNotContainExpected(xmlString) {
   getXml().then(xml => {
     expect(xml).to.not.contain(removeIndentationAndLinebreaks(xmlString));
+  });
+}
+
+export function assertBoundaryEventIsCloseToTask() {
+  const positionErrorMargin = 30;
+
+  cy.get(taskSelector).then($task => {
+    const { left: taskLeft, top: taskTop } = $task.position();
+    cy.get(boundaryEventSelector).then($boundaryEvent => {
+      const { left, top } = $boundaryEvent.position();
+      expect(left).to.be.closeTo(taskLeft, positionErrorMargin);
+      expect(top).to.be.closeTo(taskTop, positionErrorMargin);
+    });
   });
 }
 


### PR DESCRIPTION
Closes #1093 

Small miss during a refactor.
<img width="538" alt="Screen Shot 2020-02-06 at 4 59 53 PM" src="https://user-images.githubusercontent.com/6653340/73982395-22c01f80-4902-11ea-8edd-49d26d6b3243.png">
