### PR TITLE
Fix BPMN error console delay

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -173,6 +173,7 @@ export default {
     defaultInspectorHandler(value) {
       /* Go through each property and rebind it to our data */
       for (const key in omit(value, ['$type', 'eventDefinitions'])) {
+        this.updateState();
         if (this.highlightedNode.definition.get(key) !== value[key]) {
           this.setNodeProp(this.highlightedNode, key, value[key]);
         }


### PR DESCRIPTION
<h2>Changes</h2>
Emit an 'save-state' event when there are updates within the Form Renderer.

<h2>To Test</h2>

1. Toggle the 'Auto Validate' to on and open the error console.
2. Drag a Task onto the paper.
3. Remove the task name within the inspector 'Name' input to produce a BPMN validation error. 

**Expected Behavior**
Notice the 'Name' input field displays and the BPMN error count updates.

4. Add a name to the 'Name' field. 

**Expected Behavior**
Notice the the 'Name' input field errors disappear and the BPMN error count updates.

<a href="https://www.loom.com/share/d8d3bea34e474bb7a5c327b75741961a"> <p>Google Chrome - modeler - Watch Video</p> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/d8d3bea34e474bb7a5c327b75741961a-with-play.gif"> </a>

Closes #1125 