### PR TITLE
Add multiple-instance icons

### DIFF
--- a/src/assets/parallel.svg
+++ b/src/assets/parallel.svg
@@ -1,0 +1,6 @@
+<svg width="100" height="150" viewBox="0 0 100 150" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="100" height="150" fill="#E5E5E5"/>
+<rect x="100" width="150" height="25" transform="rotate(90 100 0)" fill="black"/>
+<rect x="25" width="150" height="25" transform="rotate(90 25 0)" fill="black"/>
+<rect x="62" width="150" height="24" transform="rotate(90 62 0)" fill="black"/>
+</svg>

--- a/src/assets/sequential.svg
+++ b/src/assets/sequential.svg
@@ -1,0 +1,6 @@
+<svg width="150" height="100" viewBox="0 0 150 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="150" height="100" fill="#E5E5E5"/>
+<rect width="150" height="25" fill="black"/>
+<rect y="75" width="150" height="25" fill="black"/>
+<rect y="38" width="150" height="24" fill="black"/>
+</svg>

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -27,6 +27,8 @@ import { taskHeight } from './taskConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import { gridSize } from '@/graph';
+import sequentialIcon from '@/assets/sequential.svg';
+import parallelIcon from '@/assets/parallel.svg';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -143,12 +145,23 @@ export default {
     middleIsOddNumber(value) {
       return Math.abs((value / 2) % 2) === 1;
     },
+    setupMultiInstanceMarker() {
+      const loopCharacteristics = this.node.definition.get('loopCharacteristics');
+      const isMultiInstance = loopCharacteristics ?
+        loopCharacteristics.$type === 'bpmn:MultiInstanceLoopCharacteristics' :
+        false;
+      const isSequential = isMultiInstance ? loopCharacteristics.isSequential : false;
+      if (isMultiInstance) {
+        this.$set(this.markers.bottomCenter, 'multiInstance', isSequential ? sequentialIcon : parallelIcon);
+      }
+    },
   },
   mounted() {
     this.shape = new TaskShape();
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);
+    this.setupMultiInstanceMarker();
     this.shape.attr({
       body: {
         rx: 8,


### PR DESCRIPTION
This fixes #1134 .

Adds sequential and parallel icons to multiple instance tasks.

<img width="436" alt="image" src="https://user-images.githubusercontent.com/28595383/76771946-01bbdb80-6798-11ea-9dc9-c3e7735dd035.png">
