### PR TITLE
Fix crown hiding bug

### DIFF
--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -70,6 +70,7 @@ import poolLaneCrownConfig from '@/mixins/poolLaneCrownConfig';
 import { removeFlows } from '@/components/crown/utils.js';
 import pull from 'lodash/pull';
 import store from '@/store';
+import isEqual from 'lodash/isEqual';
 
 export default {
   components: {
@@ -102,7 +103,11 @@ export default {
   },
   mixins: [poolLaneCrownConfig],
   watch: {
-    highlightedShapes() {
+    highlightedShapes(shapes, prevShapes) {
+      if (isEqual(shapes, prevShapes)) {
+        return;
+      }
+
       this.showCrown = this.highlightedShapes[0] === this.shape;
     },
     highlighted(highlighted) {

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -580,4 +580,15 @@ describe('Modeler', () => {
     cy.get('.paper-container').click();
     cy.get('[data-test="inspector-container"]').should('not.be.visible');
   });
+
+  it('should hide the crown when adding a sequence flow', () => {
+    cy.get('.crown-config').should('not.exist');
+
+    const startEventPosition = { x: 150, y: 150 };
+    getElementAtPosition(startEventPosition).click();
+    cy.get('.crown-config').should('exist');
+
+    cy.get('#sequence-flow-button').click();
+    cy.get('.crown-config').should('not.exist');
+  });
 });


### PR DESCRIPTION
Fixes #1158.

This issue was due to the fact that adding a sequence flow caused the `highlightedShapes` array to change. Normally, clicking to add a sequence flow executes `@toggle-crown-state="showCrown = $event"` to hide the crown, but right after that, the sequence flow is added, and the watcher for `highlightedShapes` is run, causing `this.showCrown` to be set back to `true`.