### PR TITLE
Keep element name when switching type

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,8 +133,7 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import defaultStartNames from '@/components/nodes/startEvent/defaultNames';
-import defaultTaskNames from '@/components/nodes/task/defaultNames';
+import { defaultStartNames, defaultEndNames, defaultTaskNames } from '@/components/nodes/defaultNames';
 
 export default {
   components: {
@@ -617,6 +616,9 @@ export default {
     getDefaultNames(node) {
       if (node.isStartGroup()) {
         return defaultStartNames;
+      }
+      if (node.isEndGroup()) {
+        return defaultEndNames;
       }
       if (node.isTaskGroup()) {
         return defaultTaskNames;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,7 +133,8 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import defaultStartNames from '@/components/nodes/startEvent/startNames';
+import defaultStartNames from '@/components/nodes/startEvent/defaultNames';
+import defaultTaskNames from '@/components/nodes/task/defaultNames';
 
 export default {
   components: {
@@ -613,6 +614,20 @@ export default {
     toXML(cb) {
       this.moddle.toXML(this.definitions, { format: true }, cb);
     },
+    getDefaultNames(group) {
+      if (group === 'StartEvent') {
+        return defaultStartNames;
+      }
+      if (group === 'Task') {
+        return defaultTaskNames;
+      }
+
+      return null;
+    },
+    isNotDefaultName(group, name) {
+      const defaultNames = this.getDefaultNames(group);
+      return defaultNames ? !Object.values(defaultNames).includes(name) : false;
+    },
     handleDrop({ clientX, clientY, control, name }) {
       this.validateDropTarget({ clientX, clientY, control });
 
@@ -621,8 +636,9 @@ export default {
       }
 
       let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
+
       if (name) {
-        if (!Object.values(defaultStartNames).includes(name)) {
+        if (this.isNotDefaultName(control.group, name)) {
           definition.name = name;
         }
       }
@@ -675,7 +691,7 @@ export default {
       this.removeNode(node);
       this.handleDrop({
         clientX, clientY,
-        control: { type: typeToReplaceWith },
+        control: { type: typeToReplaceWith, group: node.definition.get('group') },
         name: node.definition.get('name'),
       });
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -613,14 +613,17 @@ export default {
     toXML(cb) {
       this.moddle.toXML(this.definitions, { format: true }, cb);
     },
-    handleDrop({ clientX, clientY, control }) {
+    handleDrop({ clientX, clientY, control, name }) {
       this.validateDropTarget({ clientX, clientY, control });
 
       if (!this.allowDrop) {
         return;
       }
 
-      const definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
+      let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
+      if (name) {
+        definition.name = name;
+      }
       const diagram = this.nodeRegistry[control.type].diagram(this.moddle);
 
       const { x, y } = this.paperManager.clientToGridPoint(clientX, clientY);
@@ -668,7 +671,11 @@ export default {
     replaceNode({ node, typeToReplaceWith }) {
       const { x: clientX, y: clientY } = this.paper.localToClientPoint(node.diagram.bounds);
       this.removeNode(node);
-      this.handleDrop({ clientX, clientY, control: { type: typeToReplaceWith } });
+      this.handleDrop({
+        clientX, clientY,
+        control: { type: typeToReplaceWith },
+        name: node.definition.get('name'),
+      });
     },
     removeNodeFromLane(node) {
       const containingLane = node.pool && node.pool.component.laneSet &&

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,7 +133,7 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import { defaultStartNames, defaultEndNames, defaultTaskNames } from '@/components/nodes/defaultNames';
+import { defaultStartNames, defaultEndNames, defaultTaskNames, defaultGatewayNames } from '@/components/nodes/defaultNames';
 
 export default {
   components: {
@@ -622,6 +622,9 @@ export default {
       }
       if (node.isTaskGroup()) {
         return defaultTaskNames;
+      }
+      if (node.isGatewayGroup()) {
+        return defaultGatewayNames;
       }
       return null;
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,13 +133,7 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import {
-  defaultStartNames,
-  defaultEndNames,
-  defaultTaskNames,
-  defaultGatewayNames,
-  defaultIntermediateNames,
-} from '@/components/nodes/defaultNames';
+import { shouldSetDefaultName } from '@/components/modeler/modelerUtils';
 
 export default {
   components: {
@@ -619,31 +613,6 @@ export default {
     toXML(cb) {
       this.moddle.toXML(this.definitions, { format: true }, cb);
     },
-    getDefaultNames(node) {
-      if (node.isStartGroup()) {
-        return defaultStartNames;
-      }
-      if (node.isTaskGroup()) {
-        return defaultTaskNames;
-      }
-      if (node.isGatewayGroup()) {
-        return defaultGatewayNames;
-      }
-      if (node.isIntermediateGroup()) {
-        return defaultIntermediateNames;
-      }
-      if (node.isEndGroup()) {
-        return defaultEndNames;
-      }
-      return null;
-    },
-    shouldSetDefaultName(node) {
-      if (!node) {
-        return false;
-      }
-      const defaultNames = this.getDefaultNames(node);
-      return defaultNames ? !Object.values(defaultNames).includes(node.definition.name) : false;
-    },
     handleDrop({ clientX, clientY, control, node }) {
       this.validateDropTarget({ clientX, clientY, control });
 
@@ -653,7 +622,7 @@ export default {
 
       let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
 
-      if (this.shouldSetDefaultName(node)) {
+      if (shouldSetDefaultName(node)) {
         definition.name = node.definition.name;
       }
 

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,7 +133,13 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import { defaultStartNames, defaultEndNames, defaultTaskNames, defaultGatewayNames } from '@/components/nodes/defaultNames';
+import {
+  defaultStartNames,
+  defaultEndNames,
+  defaultTaskNames,
+  defaultGatewayNames,
+  defaultIntermediateNames,
+} from '@/components/nodes/defaultNames';
 
 export default {
   components: {
@@ -617,14 +623,17 @@ export default {
       if (node.isStartGroup()) {
         return defaultStartNames;
       }
-      if (node.isEndGroup()) {
-        return defaultEndNames;
-      }
       if (node.isTaskGroup()) {
         return defaultTaskNames;
       }
       if (node.isGatewayGroup()) {
         return defaultGatewayNames;
+      }
+      if (node.isIntermediateGroup()) {
+        return defaultIntermediateNames;
+      }
+      if (node.isEndGroup()) {
+        return defaultEndNames;
       }
       return null;
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -624,7 +624,10 @@ export default {
 
       return null;
     },
-    isNotDefaultName(group, name) {
+    shouldSetDefaultName(group, name) {
+      if (!name) {
+        return false;
+      }
       const defaultNames = this.getDefaultNames(group);
       return defaultNames ? !Object.values(defaultNames).includes(name) : false;
     },
@@ -637,11 +640,10 @@ export default {
 
       let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
 
-      if (name) {
-        if (this.isNotDefaultName(control.group, name)) {
-          definition.name = name;
-        }
+      if (this.shouldSetDefaultName(control.group, name)) {
+        definition.name = name;
       }
+
       const diagram = this.nodeRegistry[control.type].diagram(this.moddle);
 
       const { x, y } = this.paperManager.clientToGridPoint(clientX, clientY);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -116,8 +116,6 @@ import Process from '../inspectors/process';
 import runningInCypressTest from '@/runningInCypressTest';
 import getValidationProperties from '@/targetValidationUtils';
 import MiniPaper from '@/components/miniPaper/MiniPaper';
-//import defaultStartNames from '@/components/nodes/startEvent/startNames';
-
 import { id as laneId } from '../nodes/poolLane';
 import { id as sequenceFlowId } from '../nodes/sequenceFlow';
 import { id as associationId } from '../nodes/association';
@@ -135,6 +133,7 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
+import defaultStartNames from '@/components/nodes/startEvent/startNames';
 
 export default {
   components: {
@@ -623,7 +622,9 @@ export default {
 
       let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
       if (name) {
-        definition.name = name;
+        if (!Object.values(defaultStartNames).includes(name)) {
+          definition.name = name;
+        }
       }
       const diagram = this.nodeRegistry[control.type].diagram(this.moddle);
 

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -116,6 +116,7 @@ import Process from '../inspectors/process';
 import runningInCypressTest from '@/runningInCypressTest';
 import getValidationProperties from '@/targetValidationUtils';
 import MiniPaper from '@/components/miniPaper/MiniPaper';
+//import defaultStartNames from '@/components/nodes/startEvent/startNames';
 
 import { id as laneId } from '../nodes/poolLane';
 import { id as sequenceFlowId } from '../nodes/sequenceFlow';

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -133,7 +133,7 @@ import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
 import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import { shouldSetDefaultName } from '@/components/modeler/modelerUtils';
+import { keepOriginalName } from '@/components/modeler/modelerUtils';
 
 export default {
   components: {
@@ -622,7 +622,7 @@ export default {
 
       let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
 
-      if (shouldSetDefaultName(node)) {
+      if (keepOriginalName(node)) {
         definition.name = node.definition.name;
       }
 

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -620,7 +620,7 @@ export default {
         return;
       }
 
-      let definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
+      const definition = this.nodeRegistry[control.type].definition(this.moddle, this.$t);
 
       if (keepOriginalName(node)) {
         definition.name = node.definition.name;

--- a/src/components/modeler/modelerUtils.js
+++ b/src/components/modeler/modelerUtils.js
@@ -30,5 +30,5 @@ export function keepOriginalName(node) {
     return false;
   }
   const defaultNames = getDefaultNames(node);
-  return defaultNames ? !Object.values(defaultNames).includes(node.definition.name) : false;
+  return defaultNames ? !Object.values(defaultNames).includes(node.definition.name) : true;
 }

--- a/src/components/modeler/modelerUtils.js
+++ b/src/components/modeler/modelerUtils.js
@@ -7,19 +7,19 @@ import {
 } from '@/components/nodes/defaultNames';
 
 function getDefaultNames(node) {
-  if (node.isStartGroup()) {
+  if (node.isStartEvent()) {
     return defaultStartNames;
   }
-  if (node.isTaskGroup()) {
+  if (node.isTask()) {
     return defaultTaskNames;
   }
-  if (node.isGatewayGroup()) {
+  if (node.isGateway()) {
     return defaultGatewayNames;
   }
-  if (node.isIntermediateGroup()) {
+  if (node.isIntermediateEvent()) {
     return defaultIntermediateNames;
   }
-  if (node.isEndGroup()) {
+  if (node.isEndEvent()) {
     return defaultEndNames;
   }
   return null;

--- a/src/components/modeler/modelerUtils.js
+++ b/src/components/modeler/modelerUtils.js
@@ -1,0 +1,34 @@
+import {
+  defaultStartNames,
+  defaultEndNames,
+  defaultTaskNames,
+  defaultGatewayNames,
+  defaultIntermediateNames,
+} from '@/components/nodes/defaultNames';
+
+function getDefaultNames(node) {
+  if (node.isStartGroup()) {
+    return defaultStartNames;
+  }
+  if (node.isTaskGroup()) {
+    return defaultTaskNames;
+  }
+  if (node.isGatewayGroup()) {
+    return defaultGatewayNames;
+  }
+  if (node.isIntermediateGroup()) {
+    return defaultIntermediateNames;
+  }
+  if (node.isEndGroup()) {
+    return defaultEndNames;
+  }
+  return null;
+}
+
+export function shouldSetDefaultName(node) {
+  if (!node) {
+    return false;
+  }
+  const defaultNames = getDefaultNames(node);
+  return defaultNames ? !Object.values(defaultNames).includes(node.definition.name) : false;
+}

--- a/src/components/modeler/modelerUtils.js
+++ b/src/components/modeler/modelerUtils.js
@@ -25,7 +25,7 @@ function getDefaultNames(node) {
   return null;
 }
 
-export function shouldSetDefaultName(node) {
+export function keepOriginalName(node) {
   if (!node) {
     return false;
   }

--- a/src/components/nodes/defaultNames.js
+++ b/src/components/nodes/defaultNames.js
@@ -2,3 +2,4 @@ export { default as defaultStartNames } from '@/components/nodes/startEvent/defa
 export { default as defaultEndNames } from '@/components/nodes/endEvent/defaultNames';
 export { default as defaultTaskNames } from '@/components/nodes/task/defaultNames';
 export { default as defaultGatewayNames } from '@/components/nodes/gateway/defaultNames';
+export { default as defaultIntermediateNames } from '@/components/nodes/intermediateEvent/defaultNames';

--- a/src/components/nodes/defaultNames.js
+++ b/src/components/nodes/defaultNames.js
@@ -1,0 +1,3 @@
+export { default as defaultStartNames } from '@/components/nodes/startEvent/defaultNames';
+export { default as defaultEndNames } from '@/components/nodes/endEvent/defaultNames';
+export { default as defaultTaskNames } from '@/components/nodes/task/defaultNames';

--- a/src/components/nodes/defaultNames.js
+++ b/src/components/nodes/defaultNames.js
@@ -1,3 +1,4 @@
 export { default as defaultStartNames } from '@/components/nodes/startEvent/defaultNames';
 export { default as defaultEndNames } from '@/components/nodes/endEvent/defaultNames';
 export { default as defaultTaskNames } from '@/components/nodes/task/defaultNames';
+export { default as defaultGatewayNames } from '@/components/nodes/gateway/defaultNames';

--- a/src/components/nodes/endEvent/defaultNames.js
+++ b/src/components/nodes/endEvent/defaultNames.js
@@ -1,0 +1,8 @@
+const defaultNames = {
+  'processmaker-modeler-end-event': 'End Event',
+  'processmaker-modeler-error-end-event': 'Error End Event',
+  'processmaker-modeler-message-end-event': 'Message End Event',
+  'processmaker-modeler-signal-end-event': 'Signal End Event',
+};
+
+export default defaultNames;

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -23,6 +23,7 @@ import EventShape from '../startEvent/eventShape';
 import { endColor } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import defaultNames from '@/components/nodes/endEvent/defaultNames';
 
 export default {
   components: {
@@ -48,21 +49,21 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'End Event',
+          label: defaultNames['processmaker-modeler-end-event'],
           nodeType: 'processmaker-modeler-end-event',
         },
         {
-          label: 'Message End Event',
+          label: defaultNames['processmaker-modeler-message-end-event'],
           nodeType: 'processmaker-modeler-message-end-event',
           dataTest: 'switch-to-message-end-event',
         },
         {
-          label: 'Error End Event',
+          label: defaultNames['processmaker-modeler-error-end-event'],
           nodeType: 'processmaker-modeler-error-end-event',
           dataTest: 'switch-to-error-end-event',
         },
         {
-          label: 'Signal End Event',
+          label: defaultNames['processmaker-modeler-signal-end-event'],
           nodeType: 'processmaker-modeler-signal-end-event',
           dataTest: 'switch-to-signal-end-event',
         },

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -1,19 +1,22 @@
 import component from './endEvent.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/endEvent/defaultNames';
+
+const id = 'processmaker-modeler-end-event';
 
 export default {
-  id: 'processmaker-modeler-end-event',
+  id,
   component,
   bpmnType: 'bpmn:EndEvent',
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/end-event.svg'),
-  label: 'End Event',
+  label: defaultNames[id],
   rank: 3,
   definition(moddle, $t) {
     return moddle.create('bpmn:EndEvent', {
-      name: $t('End Event'),
+      name: $t(defaultNames[id]),
     });
   },
   diagram(moddle) {
@@ -28,7 +31,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'End Event',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/errorEndEvent/index.js
+++ b/src/components/nodes/errorEndEvent/index.js
@@ -3,6 +3,7 @@ import endEventConfig from '../endEvent/index';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/endEvent/defaultNames';
 
 export const id = 'processmaker-modeler-error-end-event';
 
@@ -10,10 +11,10 @@ export default merge(cloneDeep(endEventConfig), {
   id,
   component,
   control: false,
-  label: 'Error End Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:EndEvent', {
-      name: $t('Error End Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:ErrorEventDefinition'),
       ],

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -1,16 +1,19 @@
 import component from './eventBasedGateway.vue';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/gateway/defaultNames';
+
+const id = 'processmaker-modeler-event-based-gateway';
 
 export default {
-  id: 'processmaker-modeler-event-based-gateway',
+  id,
   component,
   bpmnType: 'bpmn:EventBasedGateway',
   control: false,
   category: 'BPMN',
-  label: 'Event-Based Gateway',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:EventBasedGateway', {
-      name: $t('Event-Based Gateway'),
+      name: $t(defaultNames[id]),
     });
   },
   diagram(moddle) {
@@ -23,7 +26,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Event-Based Gateway',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -1,9 +1,12 @@
 import component from './exclusiveGateway.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/gateway/defaultNames';
+
+const id = 'processmaker-modeler-exclusive-gateway';
 
 export default {
-  id: 'processmaker-modeler-exclusive-gateway',
+  id,
   component,
   bpmnType: 'bpmn:ExclusiveGateway',
   control: true,
@@ -13,7 +16,7 @@ export default {
   rank: 5,
   definition(moddle, $t) {
     return moddle.create('bpmn:ExclusiveGateway', {
-      name: $t('Exclusive Gateway'),
+      name: $t(defaultNames[id]),
     });
   },
   diagram(moddle) {
@@ -26,7 +29,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Exclusive Gateway',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/gateway/defaultNames.js
+++ b/src/components/nodes/gateway/defaultNames.js
@@ -1,0 +1,8 @@
+const defaultNames = {
+  'processmaker-modeler-gateway': 'End Event',
+  'processmaker-modeler-error-end-event': 'Error End Event',
+  'processmaker-modeler-message-end-event': 'Message End Event',
+  'processmaker-modeler-signal-end-event': 'Signal End Event',
+};
+
+export default defaultNames;

--- a/src/components/nodes/gateway/defaultNames.js
+++ b/src/components/nodes/gateway/defaultNames.js
@@ -1,8 +1,8 @@
 const defaultNames = {
-  'processmaker-modeler-gateway': 'End Event',
-  'processmaker-modeler-error-end-event': 'Error End Event',
-  'processmaker-modeler-message-end-event': 'Message End Event',
-  'processmaker-modeler-signal-end-event': 'Signal End Event',
+  'processmaker-modeler-exclusive-gateway': 'Exclusive Gateway',
+  'processmaker-modeler-inclusive-gateway': 'Inclusive Gateway',
+  'processmaker-modeler-parallel-gateway': 'Parallel Gateway',
+  'processmaker-modeler-event-based-gateway': 'Event Based Gateway',
 };
 
 export default defaultNames;

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -22,6 +22,7 @@ import GatewayShape from '@/components/nodes/gateway/shape';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import defaultNames from '@/components/nodes/gateway/defaultNames';
 
 export default {
   components: {
@@ -48,21 +49,21 @@ export default {
       labelWidth: 175,
       dropdownData: [
         {
-          label: 'Exclusive Gateway',
+          label: defaultNames['processmaker-modeler-exclusive-gateway'],
           nodeType: 'processmaker-modeler-exclusive-gateway',
         },
         {
-          label: 'Inclusive Gateway',
+          label: defaultNames['processmaker-modeler-inclusive-gateway'],
           nodeType: 'processmaker-modeler-inclusive-gateway',
           dataTest: 'switch-to-inclusive-gateway',
         },
         {
-          label: 'Parallel Gateway',
+          label: defaultNames['processmaker-modeler-parallel-gateway'],
           nodeType: 'processmaker-modeler-parallel-gateway',
           dataTest: 'switch-to-parallel-gateway',
         },
         {
-          label: 'Event Based Gateway',
+          label: defaultNames['processmaker-modeler-event-based-gateway'],
           nodeType: 'processmaker-modeler-event-based-gateway',
           dataTest: 'switch-to-event-based-gateway',
         },

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -3,17 +3,20 @@ import { gatewayDirection } from '../gateway/gatewayConfig';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import DocumentationFormTextArea from '@/components/inspectors/DocumentationFormTextArea';
+import defaultNames from '@/components/nodes/gateway/defaultNames';
+
+const id = 'processmaker-modeler-inclusive-gateway';
 
 export default {
-  id: 'processmaker-modeler-inclusive-gateway',
+  id,
   component,
   bpmnType: 'bpmn:InclusiveGateway',
   control: false,
   category: 'BPMN',
-  label: 'Inclusive Gateway',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:InclusiveGateway', {
-      name: $t('Inclusive Gateway'),
+      name: $t(defaultNames[id]),
       gatewayDirection: gatewayDirection.diverging,
     });
   },
@@ -27,7 +30,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Inclusive Gateway',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/intermediateEvent/defaultNames.js
+++ b/src/components/nodes/intermediateEvent/defaultNames.js
@@ -1,0 +1,9 @@
+const defaultNames = {
+  'processmaker-modeler-intermediate-catch-timer-event': 'Intermediate Timer Event',
+  'processmaker-modeler-intermediate-signal-catch-event': 'Intermediate Signal Catch Event',
+  'processmaker-modeler-intermediate-signal-throw-event': 'Intermediate Signal Throw Event',
+  'processmaker-modeler-intermediate-message-catch-event': 'Intermediate Message Catch Event',
+  'processmaker-modeler-intermediate-message-throw-event': 'Intermediate Message Throw Event',
+};
+
+export default defaultNames;

--- a/src/components/nodes/intermediateEvent/intermediateEvent.vue
+++ b/src/components/nodes/intermediateEvent/intermediateEvent.vue
@@ -23,6 +23,7 @@ import hasMarkers from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
 
 export default {
   components: {
@@ -48,26 +49,26 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'Intermediate Timer Event',
+          label: defaultNames['processmaker-modeler-intermediate-catch-timer-event'],
           nodeType: 'processmaker-modeler-intermediate-catch-timer-event',
         },
         {
-          label: 'Intermediate Signal Catch Event',
+          label: defaultNames['processmaker-modeler-intermediate-signal-catch-event'],
           nodeType: 'processmaker-modeler-intermediate-signal-catch-event',
           dataTest: 'switch-to-intermediate-signal-catch-event',
         },
         {
-          label: 'Intermediate Signal Throw Event',
+          label: defaultNames['processmaker-modeler-intermediate-signal-throw-event'],
           nodeType: 'processmaker-modeler-intermediate-signal-throw-event',
           dataTest: 'switch-to-intermediate-signal-throw-event',
         },
         {
-          label: 'Intermediate Message Catch Event',
+          label: defaultNames['processmaker-modeler-intermediate-message-catch-event'],
           nodeType: 'processmaker-modeler-intermediate-message-catch-event',
           dataTest: 'switch-to-intermediate-message-catch-event',
         },
         {
-          label: 'Intermediate Message Throw Event',
+          label: defaultNames['processmaker-modeler-intermediate-message-throw-event'],
           nodeType: 'processmaker-modeler-intermediate-message-throw-event',
           dataTest: 'switch-to-intermediate-message-throw-event',
         },

--- a/src/components/nodes/intermediateMessageCatchEvent/index.js
+++ b/src/components/nodes/intermediateMessageCatchEvent/index.js
@@ -4,16 +4,19 @@ import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateMessageEventConfig from '@/components/nodes/intermediateMessageEvent';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+
+const id = 'processmaker-modeler-intermediate-message-catch-event';
 
 export default merge(cloneDeep(intermediateMessageEventConfig), {
-  id: 'processmaker-modeler-intermediate-message-catch-event',
+  id,
   component,
   control: false,
   bpmnType: 'bpmn:IntermediateCatchEvent',
-  label: 'Intermediate Message Catch Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateCatchEvent', {
-      name: $t('Intermediate Message Catch Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/intermediateMessageThrowEvent/index.js
+++ b/src/components/nodes/intermediateMessageThrowEvent/index.js
@@ -3,17 +3,20 @@ import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateMessageEventConfig from '@/components/nodes/intermediateMessageEvent';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+
+const id = 'processmaker-modeler-intermediate-message-throw-event';
 
 export default merge(cloneDeep(intermediateMessageEventConfig), {
-  id: 'processmaker-modeler-intermediate-message-throw-event',
+  id,
   component,
   control: false,
   bpmnType: 'bpmn:IntermediateThrowEvent',
-  label: 'Intermediate Message Throw Event',
+  label: defaultNames[id],
   icon: require('@/assets/toolpanel/intermediate-message-throw-event.svg'),
   definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateThrowEvent', {
-      name: $t('Intermediate Message Throw Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/intermediateSignalCatchEvent/index.js
+++ b/src/components/nodes/intermediateSignalCatchEvent/index.js
@@ -2,16 +2,19 @@ import component from './intermediateSignalCatchEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateEventConfig from '@/components/nodes/intermediateEvent';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+
+const id = 'processmaker-modeler-intermediate-signal-catch-event';
 
 export default merge(cloneDeep(intermediateEventConfig), {
-  id: 'processmaker-modeler-intermediate-signal-catch-event',
+  id,
   component,
   control: false,
   bpmnType: 'bpmn:IntermediateCatchEvent',
-  label: 'Intermediate Signal Catch Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateCatchEvent', {
-      name: $t('Intermediate Signal Catch Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/intermediateSignalThrowEvent/index.js
+++ b/src/components/nodes/intermediateSignalThrowEvent/index.js
@@ -3,16 +3,19 @@ import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateEventConfig from '@/components/nodes/intermediateEvent';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+
+const id = 'processmaker-modeler-intermediate-signal-throw-event';
 
 export default merge(cloneDeep(intermediateEventConfig), {
-  id: 'processmaker-modeler-intermediate-signal-throw-event',
+  id,
   component,
   control: false,
   bpmnType: 'bpmn:IntermediateThrowEvent',
-  label: 'Intermediate Signal Throw Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateThrowEvent', {
-      name: $t('Intermediate Signal Throw Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -2,11 +2,13 @@ import component from './intermediateTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
 
 export const defaultDurationValue = 'PT1H';
+const id = 'processmaker-modeler-intermediate-catch-timer-event';
 
 export default {
-  id: 'processmaker-modeler-intermediate-catch-timer-event',
+  id,
   component,
   bpmnType: 'bpmn:IntermediateCatchEvent',
   control: true,
@@ -16,7 +18,7 @@ export default {
   rank: 2,
   definition(moddle, $t) {
     return moddle.create('bpmn:IntermediateCatchEvent', {
-      name: $t('Intermediate Timer Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {
@@ -81,7 +83,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Intermediate Timer Event',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -17,7 +17,6 @@ export default {
   definition(moddle, $t) {
     return moddle.create('bpmn:ManualTask', {
       name: $t(defaultNames[id]),
-      group: 'Task',
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -1,6 +1,7 @@
 import component from './manualTask.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-manual-task';
@@ -12,10 +13,11 @@ export default {
   control: false,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/manualTask.svg'),
-  label: 'Manual Task',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:ManualTask', {
-      name: $t('Manual Task'),
+      name: $t(defaultNames[id]),
+      group: 'Task',
     });
   },
   diagram(moddle) {
@@ -28,7 +30,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'ManualTask',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/messageEndEvent/index.js
+++ b/src/components/nodes/messageEndEvent/index.js
@@ -3,15 +3,18 @@ import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import endEventConfig from '@/components/nodes/endEvent';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/endEvent/defaultNames';
+
+const id = 'processmaker-modeler-message-end-event';
 
 export default merge(cloneDeep(endEventConfig), {
-  id: 'processmaker-modeler-message-end-event',
+  id,
   component,
   control: false,
-  label: 'Message End Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:EndEvent', {
-      name: $t('Message End Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/messageStartEvent/index.js
+++ b/src/components/nodes/messageStartEvent/index.js
@@ -4,15 +4,16 @@ import cloneDeep from 'lodash/cloneDeep';
 import startEventConfig from '../startEvent';
 import CatchEventMessageSelect from '../intermediateMessageCatchEvent/CatchEventMessageSelect';
 import omit from 'lodash/omit';
+import defaultNames from '@/components/nodes/startEvent/startNames';
 
 export default merge(cloneDeep(startEventConfig), {
   id: 'processmaker-modeler-message-start-event',
   control: false,
   component,
-  label: 'Message Start Event',
+  label: defaultNames['start-message'],
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t('Message Start Event'),
+      name: $t(defaultNames['start-message']),
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/messageStartEvent/index.js
+++ b/src/components/nodes/messageStartEvent/index.js
@@ -4,16 +4,19 @@ import cloneDeep from 'lodash/cloneDeep';
 import startEventConfig from '../startEvent';
 import CatchEventMessageSelect from '../intermediateMessageCatchEvent/CatchEventMessageSelect';
 import omit from 'lodash/omit';
-import defaultNames from '@/components/nodes/startEvent/startNames';
+import defaultNames from '@/components/nodes/startEvent/defaultNames';
+
+const id = 'processmaker-modeler-message-start-event';
 
 export default merge(cloneDeep(startEventConfig), {
-  id: 'processmaker-modeler-message-start-event',
+  id,
   control: false,
   component,
-  label: defaultNames['start-message'],
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t(defaultNames['start-message']),
+      name: $t(defaultNames[id]),
+      group: 'StartEvent',
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/messageStartEvent/index.js
+++ b/src/components/nodes/messageStartEvent/index.js
@@ -16,7 +16,6 @@ export default merge(cloneDeep(startEventConfig), {
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
       name: $t(defaultNames[id]),
-      group: 'StartEvent',
       eventDefinitions: [
         moddle.create('bpmn:MessageEventDefinition'),
       ],

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -1,3 +1,5 @@
+import { defaultStartNames, defaultEndNames, defaultTaskNames } from '@/components/nodes/defaultNames';
+
 export default class Node {
   type;
   definition;
@@ -19,21 +21,15 @@ export default class Node {
   }
 
   isStartGroup() {
-    return [
-      'processmaker-modeler-start-event',
-      'processmaker-modeler-message-start-event',
-      'processmaker-modeler-start-timer-event',
-      'processmaker-modeler-signal-start-event',
-    ].includes(this.type);
+    return Object.keys(defaultStartNames).includes(this.type);
+  }
+
+  isEndGroup() {
+    return Object.keys(defaultEndNames).includes(this.type);
   }
 
   isTaskGroup() {
-    return [
-      'processmaker-modeler-task',
-      'processmaker-modeler-manual-task',
-      'processmaker-modeler-script-task',
-      'processmaker-modeler-call-activity',
-    ].includes(this.type);
+    return Object.keys(defaultTaskNames).includes(this.type);
   }
 
   get id() {

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -1,4 +1,10 @@
-import { defaultStartNames, defaultEndNames, defaultTaskNames, defaultGatewayNames } from '@/components/nodes/defaultNames';
+import {
+  defaultStartNames,
+  defaultEndNames,
+  defaultTaskNames,
+  defaultGatewayNames,
+  defaultIntermediateNames,
+} from '@/components/nodes/defaultNames';
 
 export default class Node {
   type;
@@ -34,6 +40,10 @@ export default class Node {
 
   isGatewayGroup() {
     return Object.keys(defaultGatewayNames).includes(this.type);
+  }
+
+  isIntermediateGroup() {
+    return Object.keys(defaultIntermediateNames).includes(this.type);
   }
 
   get id() {

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -26,23 +26,23 @@ export default class Node {
     return this.type === type;
   }
 
-  isStartGroup() {
+  isStartEvent() {
     return Object.keys(defaultStartNames).includes(this.type);
   }
 
-  isEndGroup() {
+  isEndEvent() {
     return Object.keys(defaultEndNames).includes(this.type);
   }
 
-  isTaskGroup() {
+  isTask() {
     return Object.keys(defaultTaskNames).includes(this.type);
   }
 
-  isGatewayGroup() {
+  isGateway() {
     return Object.keys(defaultGatewayNames).includes(this.type);
   }
 
-  isIntermediateGroup() {
+  isIntermediateEvent() {
     return Object.keys(defaultIntermediateNames).includes(this.type);
   }
 

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -1,4 +1,4 @@
-import { defaultStartNames, defaultEndNames, defaultTaskNames } from '@/components/nodes/defaultNames';
+import { defaultStartNames, defaultEndNames, defaultTaskNames, defaultGatewayNames } from '@/components/nodes/defaultNames';
 
 export default class Node {
   type;
@@ -30,6 +30,10 @@ export default class Node {
 
   isTaskGroup() {
     return Object.keys(defaultTaskNames).includes(this.type);
+  }
+
+  isGatewayGroup() {
+    return Object.keys(defaultGatewayNames).includes(this.type);
   }
 
   get id() {

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -18,6 +18,24 @@ export default class Node {
     return this.type === type;
   }
 
+  isStartGroup() {
+    return [
+      'processmaker-modeler-start-event',
+      'processmaker-modeler-message-start-event',
+      'processmaker-modeler-start-timer-event',
+      'processmaker-modeler-signal-start-event',
+    ].includes(this.type);
+  }
+
+  isTaskGroup() {
+    return [
+      'processmaker-modeler-task',
+      'processmaker-modeler-manual-task',
+      'processmaker-modeler-script-task',
+      'processmaker-modeler-call-activity',
+    ].includes(this.type);
+  }
+
   get id() {
     return this.definition.id;
   }

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -17,7 +17,6 @@ export default {
   definition(moddle, $t) {
     return moddle.create('bpmn:ScriptTask', {
       name: $t(defaultNames[id]),
-      group: 'Task',
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -2,8 +2,10 @@ import component from './scriptTask.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import { taskHeight, taskWidth } from '@/components/nodes/task/taskConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 export const id = 'processmaker-modeler-script-task';
+
 export default {
   id,
   component,
@@ -11,10 +13,11 @@ export default {
   control: false,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/scriptTask.svg'),
-  label: 'Script Task',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:ScriptTask', {
-      name: $t('Script Task'),
+      name: $t(defaultNames[id]),
+      group: 'Task',
     });
   },
   diagram(moddle) {
@@ -27,7 +30,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'ScriptTask',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/signalEndEvent/index.js
+++ b/src/components/nodes/signalEndEvent/index.js
@@ -2,6 +2,7 @@ import component from './signalEndEvent.vue';
 import endEventConfig from '../endEvent';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
+import defaultNames from '@/components/nodes/endEvent/defaultNames';
 
 export const id = 'processmaker-modeler-signal-end-event';
 
@@ -9,10 +10,10 @@ export default merge(cloneDeep(endEventConfig), {
   id,
   component,
   control: false,
-  label: 'Signal End Event',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:EndEvent', {
-      name: $t('Signal End Event'),
+      name: $t(defaultNames[id]),
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/signalStartEvent/index.js
+++ b/src/components/nodes/signalStartEvent/index.js
@@ -14,7 +14,6 @@ export default merge(cloneDeep(startEventConfig), {
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
       name: $t(defaultNames[id]),
-      group: 'StartEvent',
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/signalStartEvent/index.js
+++ b/src/components/nodes/signalStartEvent/index.js
@@ -2,15 +2,16 @@ import component from './signalStartEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import startEventConfig from '../startEvent';
+import defaultNames from '@/components/nodes/startEvent/startNames';
 
 export default merge(cloneDeep(startEventConfig), {
   id: 'processmaker-modeler-signal-start-event',
   control: false,
   component,
-  label: 'Signal Start Event',
+  label: defaultNames['start-signal'],
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t('Signal Start Event'),
+      name: $t(defaultNames['start-signal']),
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/signalStartEvent/index.js
+++ b/src/components/nodes/signalStartEvent/index.js
@@ -2,16 +2,19 @@ import component from './signalStartEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import startEventConfig from '../startEvent';
-import defaultNames from '@/components/nodes/startEvent/startNames';
+import defaultNames from '@/components/nodes/startEvent/defaultNames';
+
+const id = 'processmaker-modeler-signal-start-event';
 
 export default merge(cloneDeep(startEventConfig), {
-  id: 'processmaker-modeler-signal-start-event',
+  id,
   control: false,
   component,
-  label: defaultNames['start-signal'],
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t(defaultNames['start-signal']),
+      name: $t(defaultNames[id]),
+      group: 'StartEvent',
       eventDefinitions: [
         moddle.create('bpmn:SignalEventDefinition'),
       ],

--- a/src/components/nodes/startEvent/defaultNames.js
+++ b/src/components/nodes/startEvent/defaultNames.js
@@ -1,0 +1,8 @@
+const defaultNames = {
+  'processmaker-modeler-start-event': 'Start Event',
+  'processmaker-modeler-start-timer-event': 'Start Timer Event',
+  'processmaker-modeler-signal-start-event': 'Signal Start Event',
+  'processmaker-modeler-message-start-event': 'Message Start Event',
+};
+
+export default defaultNames;

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -18,7 +18,6 @@ export default {
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
       name: $t(defaultNames[id]),
-      group: 'StartEvent',
     });
   },
   diagram(moddle) {

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -2,6 +2,7 @@ import component from './startEvent.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import { startEventDiameter } from './startEventConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from './startNames';
 
 export default {
   id: 'processmaker-modeler-start-event',
@@ -10,11 +11,11 @@ export default {
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/start-event.svg'),
-  label: 'Start Event',
+  label: defaultNames['start'],
   rank: 1,
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t('Start Event'),
+      name: $t(defaultNames['start']),
     });
   },
   diagram(moddle) {
@@ -37,7 +38,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Start Event',
+      name: defaultNames['start'],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/startEvent/index.js
+++ b/src/components/nodes/startEvent/index.js
@@ -2,20 +2,23 @@ import component from './startEvent.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import { startEventDiameter } from './startEventConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
-import defaultNames from './startNames';
+import defaultNames from './defaultNames';
+
+const id = 'processmaker-modeler-start-event';
 
 export default {
-  id: 'processmaker-modeler-start-event',
+  id,
   component,
   bpmnType: 'bpmn:StartEvent',
   control: true,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/start-event.svg'),
-  label: defaultNames['start'],
+  label: defaultNames[id],
   rank: 1,
   definition(moddle, $t) {
     return moddle.create('bpmn:StartEvent', {
-      name: $t(defaultNames['start']),
+      name: $t(defaultNames[id]),
+      group: 'StartEvent',
     });
   },
   diagram(moddle) {
@@ -38,7 +41,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: defaultNames['start'],
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -24,7 +24,7 @@ import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import { startColor } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
-import defaultNames from './startNames';
+import defaultNames from './defaultNames';
 
 export default {
   components: {
@@ -50,22 +50,22 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: defaultNames['start'],
+          label: defaultNames['processmaker-modeler-start-event'],
           nodeType: 'processmaker-modeler-start-event',
           dataTest: 'switch-to-start-event',
         },
         {
-          label: defaultNames['start-timer'],
+          label: defaultNames['processmaker-modeler-start-timer-event'],
           nodeType: 'processmaker-modeler-start-timer-event',
           dataTest: 'switch-to-start-timer-event',
         },
         {
-          label: defaultNames['start-signal'],
+          label: defaultNames['processmaker-modeler-signal-start-event'],
           nodeType: 'processmaker-modeler-signal-start-event',
           dataTest: 'switch-to-signal-start-event',
         },
         {
-          label: defaultNames['start-message'],
+          label: defaultNames['processmaker-modeler-message-start-event'],
           nodeType: 'processmaker-modeler-message-start-event',
           dataTest: 'switch-to-message-start-event',
         },

--- a/src/components/nodes/startEvent/startEvent.vue
+++ b/src/components/nodes/startEvent/startEvent.vue
@@ -24,6 +24,7 @@ import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import { startColor } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import defaultNames from './startNames';
 
 export default {
   components: {
@@ -49,22 +50,22 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'Start Event',
+          label: defaultNames['start'],
           nodeType: 'processmaker-modeler-start-event',
           dataTest: 'switch-to-start-event',
         },
         {
-          label: 'Start Timer Event',
+          label: defaultNames['start-timer'],
           nodeType: 'processmaker-modeler-start-timer-event',
           dataTest: 'switch-to-start-timer-event',
         },
         {
-          label: 'Signal Start Event',
+          label: defaultNames['start-signal'],
           nodeType: 'processmaker-modeler-signal-start-event',
           dataTest: 'switch-to-signal-start-event',
         },
         {
-          label: 'Message Start Event',
+          label: defaultNames['start-message'],
           nodeType: 'processmaker-modeler-message-start-event',
           dataTest: 'switch-to-message-start-event',
         },

--- a/src/components/nodes/startEvent/startNames.js
+++ b/src/components/nodes/startEvent/startNames.js
@@ -1,0 +1,8 @@
+const defaultNames = {
+  'start': 'Start Event',
+  'start-timer': 'Start Timer Event',
+  'start-signal': 'Signal Start Event',
+  'start-message': 'Message Start Event',
+};
+
+export default defaultNames;

--- a/src/components/nodes/startEvent/startNames.js
+++ b/src/components/nodes/startEvent/startNames.js
@@ -1,8 +1,0 @@
-const defaultNames = {
-  'start': 'Start Event',
-  'start-timer': 'Start Timer Event',
-  'start-signal': 'Signal Start Event',
-  'start-message': 'Message Start Event',
-};
-
-export default defaultNames;

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -2,18 +2,21 @@ import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
-import defaultNames from '@/components/nodes/startEvent/startNames';
+import defaultNames from '@/components/nodes/startEvent/defaultNames';
+
+const id = 'processmaker-modeler-start-timer-event';
 
 export default {
-  id: 'processmaker-modeler-start-timer-event',
+  id,
   component,
   bpmnType: 'bpmn:StartEvent',
   control: false,
   category: 'BPMN',
-  label: defaultNames['start-timer'],
+  label: defaultNames[id],
   definition(moddle, $t) {
     let startEventDefinition = moddle.create('bpmn:StartEvent', {
-      name: $t(defaultNames['start-timer']),
+      name: $t(defaultNames[id]),
+      group: 'StartEvent',
     });
 
     startEventDefinition.eventDefinitions = [moddle.create('bpmn:TimerEventDefinition', {
@@ -76,7 +79,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: defaultNames['start-timer'],
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -2,6 +2,7 @@ import component from './startTimerEvent.vue';
 import TimerExpression from '../../inspectors/TimerExpression.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/startEvent/startNames';
 
 export default {
   id: 'processmaker-modeler-start-timer-event',
@@ -9,10 +10,10 @@ export default {
   bpmnType: 'bpmn:StartEvent',
   control: false,
   category: 'BPMN',
-  label: 'Start Timer Event',
+  label: defaultNames['start-timer'],
   definition(moddle, $t) {
     let startEventDefinition = moddle.create('bpmn:StartEvent', {
-      name: $t('Start Timer Event'),
+      name: $t(defaultNames['start-timer']),
     });
 
     startEventDefinition.eventDefinitions = [moddle.create('bpmn:TimerEventDefinition', {
@@ -75,7 +76,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Start Timer Event',
+      name: defaultNames['start-timer'],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/startTimerEvent/index.js
+++ b/src/components/nodes/startTimerEvent/index.js
@@ -16,7 +16,6 @@ export default {
   definition(moddle, $t) {
     let startEventDefinition = moddle.create('bpmn:StartEvent', {
       name: $t(defaultNames[id]),
-      group: 'StartEvent',
     });
 
     startEventDefinition.eventDefinitions = [moddle.create('bpmn:TimerEventDefinition', {

--- a/src/components/nodes/subProcess/index.js
+++ b/src/components/nodes/subProcess/index.js
@@ -18,7 +18,6 @@ export default {
   definition(moddle, $t) {
     return moddle.create('bpmn:CallActivity', {
       name: $t(defaultNames[id]),
-      group: 'Task',
       calledElement: '',
       config: '{}',
     });

--- a/src/components/nodes/subProcess/index.js
+++ b/src/components/nodes/subProcess/index.js
@@ -3,6 +3,7 @@ import SubProcessFormSelect from './SubProcessFormSelect';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import { taskHeight, taskWidth } from '@/components/nodes/task/taskConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 export const id = 'processmaker-modeler-call-activity';
 
@@ -13,10 +14,11 @@ export default {
   control: false,
   category: 'BPMN',
   icon: require('@/assets/toolpanel/subProcess.svg'),
-  label: 'Sub Process',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:CallActivity', {
-      name: $t('Sub Process'),
+      name: $t(defaultNames[id]),
+      group: 'Task',
       calledElement: '',
       config: '{}',
     });
@@ -47,7 +49,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Sub Process',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/subProcess/subProcess.vue
+++ b/src/components/nodes/subProcess/subProcess.vue
@@ -27,6 +27,7 @@ import hasMarkers, { markerSize } from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -70,22 +71,22 @@ export default {
       ],
       dropdownData: [
         {
-          label: 'Task',
+          label: defaultNames['processmaker-modeler-task'],
           nodeType: 'processmaker-modeler-task',
           dataTest: 'switch-to-user-task',
         },
         {
-          label: 'Manual Task',
+          label: defaultNames['processmaker-modeler-manual-task'],
           nodeType: 'processmaker-modeler-manual-task',
           dataTest: 'switch-to-manual-task',
         },
         {
-          label: 'Script Task',
+          label: defaultNames['processmaker-modeler-script-task'],
           nodeType: 'processmaker-modeler-script-task',
           dataTest: 'switch-to-script-task',
         },
         {
-          label: 'Sub Process',
+          label: defaultNames['processmaker-modeler-call-activity'],
           nodeType: 'processmaker-modeler-call-activity',
           dataTest: 'switch-to-sub-process',
         },

--- a/src/components/nodes/task/defaultNames.js
+++ b/src/components/nodes/task/defaultNames.js
@@ -1,0 +1,8 @@
+const defaultNames = {
+  'processmaker-modeler-task': 'Form Task',
+  'processmaker-modeler-manual-task': 'Manual Task',
+  'processmaker-modeler-script-task': 'Script Task',
+  'processmaker-modeler-call-activity': 'Sub Process',
+};
+
+export default defaultNames;

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -18,7 +18,6 @@ export default {
   definition(moddle, $t) {
     return moddle.create('bpmn:Task', {
       name: $t(defaultNames[id]),
-      group: 'Task',
       assignment: 'requester',
     });
   },

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -2,6 +2,7 @@ import component from './task.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import { taskHeight, taskWidth } from './taskConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 export const id = 'processmaker-modeler-task';
 
@@ -13,10 +14,11 @@ export default {
   category: 'BPMN',
   rank: 4,
   icon: require('@/assets/toolpanel/task.svg'),
-  label: 'Form Task',
+  label: defaultNames[id],
   definition(moddle, $t) {
     return moddle.create('bpmn:Task', {
-      name: $t('Form Task'),
+      name: $t(defaultNames[id]),
+      group: 'Task',
       assignment: 'requester',
     });
   },
@@ -30,7 +32,7 @@ export default {
   },
   inspectorConfig: [
     {
-      name: 'Form Task',
+      name: defaultNames[id],
       items: [
         {
           component: 'FormAccordion',

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -73,7 +73,7 @@ export default {
           dataTest: 'switch-to-script-task',
         },
         {
-          label: defaultNames['processmaker-modeler-script-task'],
+          label: defaultNames['processmaker-modeler-call-activity'],
           nodeType: 'processmaker-modeler-call-activity',
           dataTest: 'switch-to-sub-process',
         },

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -29,6 +29,7 @@ import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import { gridSize } from '@/graph';
 import sequentialIcon from '@/assets/sequential.svg';
 import parallelIcon from '@/assets/parallel.svg';
+import defaultNames from '@/components/nodes/task/defaultNames';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -57,22 +58,22 @@ export default {
       definition: null,
       dropdownData: [
         {
-          label: 'Form Task',
+          label: defaultNames['processmaker-modeler-task'],
           nodeType: 'processmaker-modeler-task',
           dataTest: 'switch-to-user-task',
         },
         {
-          label: 'Manual Task',
+          label: defaultNames['processmaker-modeler-manual-task'],
           nodeType: 'processmaker-modeler-manual-task',
           dataTest: 'switch-to-manual-task',
         },
         {
-          label: 'Script Task',
+          label: defaultNames['processmaker-modeler-script-task'],
           nodeType: 'processmaker-modeler-script-task',
           dataTest: 'switch-to-script-task',
         },
         {
-          label: 'Sub Process',
+          label: defaultNames['processmaker-modeler-script-task'],
           nodeType: 'processmaker-modeler-call-activity',
           dataTest: 'switch-to-sub-process',
         },

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -79,6 +79,17 @@ describe('Tasks', () => {
     getElementAtPosition(taskPosition).click().getType().should('equal', nodeTypes.manualTask);
   });
 
+  it('Can keep the name when switching task type', () => {
+    addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-sub-process');
+    typeIntoTextInput('[name=name]', testString);
+
+    getElementAtPosition(taskPosition).click().getType().should('equal', nodeTypes.subProcess);
+    cy.get('[data-test=switch-to-manual-task]').click();
+
+    getElementAtPosition(taskPosition).click().getType().should('equal', nodeTypes.manualTask);
+    cy.get('[name=name]').should('have.value', testString);
+  });
+
   it('Can switch task type after initially added', () => {
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-sub-process');
 

--- a/tests/unit/keepOriginalName.spec.js
+++ b/tests/unit/keepOriginalName.spec.js
@@ -8,7 +8,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Unique Task Name' },
       {},
     );
-    expect(keepOriginalName(node)).true;
+    expect(keepOriginalName(node)).toBe(true);
   });
   it('Should switch default Task name', () => {
     const node = new Node(
@@ -16,7 +16,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Form Task' },
       {},
     );
-    expect(keepOriginalName(node)).false;
+    expect(keepOriginalName(node)).toBe(false);
   });
   it('Should keep unique Start name', () => {
     const node = new Node(
@@ -24,7 +24,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Unique Start Event Name' },
       {},
     );
-    expect(keepOriginalName(node)).true;
+    expect(keepOriginalName(node)).toBe(true);
   });
   it('Should switch default Start name', () => {
     const node = new Node(
@@ -32,7 +32,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Start Event' },
       {},
     );
-    expect(keepOriginalName(node)).false;
+    expect(keepOriginalName(node)).toBe(false);
   });
   it('Should keep unique End name', () => {
     const node = new Node(
@@ -40,7 +40,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Unique End Event Name' },
       {},
     );
-    expect(keepOriginalName(node)).true;
+    expect(keepOriginalName(node)).toBe(true);
   });
   it('Should switch default End name', () => {
     const node = new Node(
@@ -48,7 +48,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'End Event' },
       {},
     );
-    expect(keepOriginalName(node)).false;
+    expect(keepOriginalName(node)).toBe(false);
   });
   it('Should keep unique Intermediate name', () => {
     const node = new Node(
@@ -56,15 +56,15 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Unique Intermediate Event Name' },
       {},
     );
-    expect(keepOriginalName(node)).true;
+    expect(keepOriginalName(node)).toBe(true);
   });
   it('Should switch default Intermediate name', () => {
     const node = new Node(
       'processmaker-modeler-intermediate-catch-timer-event',
-      { id: 'test', name: 'Intermediate Event' },
+      { id: 'test', name: 'Intermediate Message Catch Event' },
       {},
     );
-    expect(keepOriginalName(node)).false;
+    expect(keepOriginalName(node)).toBe(false);
   });
   it('Should keep unique Gateway name', () => {
     const node = new Node(
@@ -72,7 +72,7 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Unique Gateway Name' },
       {},
     );
-    expect(keepOriginalName(node)).true;
+    expect(keepOriginalName(node)).toBe(true);
   });
   it('Should switch default Gateway name', () => {
     const node = new Node(
@@ -80,6 +80,6 @@ describe('Switch Types', () => {
       { id: 'test', name: 'Exclusive Gateway' },
       {},
     );
-    expect(keepOriginalName(node)).false;
+    expect(keepOriginalName(node)).toBe(false);
   });
 });

--- a/tests/unit/keepOriginalName.spec.js
+++ b/tests/unit/keepOriginalName.spec.js
@@ -1,0 +1,85 @@
+import { keepOriginalName} from '@/components/modeler/modelerUtils';
+import Node from '@/components/nodes/node';
+
+describe('Switch Types', () => {
+  it('Should keep unique Task name', () => {
+    const node = new Node(
+      'processmaker-modeler-script-task',
+      { id: 'test', name: 'Unique Task Name' },
+      {},
+    );
+    expect(keepOriginalName(node)).true;
+  });
+  it('Should switch default Task name', () => {
+    const node = new Node(
+      'processmaker-modeler-script-task',
+      { id: 'test', name: 'Form Task' },
+      {},
+    );
+    expect(keepOriginalName(node)).false;
+  });
+  it('Should keep unique Start name', () => {
+    const node = new Node(
+      'processmaker-modeler-start-timer-event',
+      { id: 'test', name: 'Unique Start Event Name' },
+      {},
+    );
+    expect(keepOriginalName(node)).true;
+  });
+  it('Should switch default Start name', () => {
+    const node = new Node(
+      'processmaker-modeler-start-timer-event',
+      { id: 'test', name: 'Start Event' },
+      {},
+    );
+    expect(keepOriginalName(node)).false;
+  });
+  it('Should keep unique End name', () => {
+    const node = new Node(
+      'processmaker-modeler-message-end-event',
+      { id: 'test', name: 'Unique End Event Name' },
+      {},
+    );
+    expect(keepOriginalName(node)).true;
+  });
+  it('Should switch default End name', () => {
+    const node = new Node(
+      'processmaker-modeler-message-end-event',
+      { id: 'test', name: 'End Event' },
+      {},
+    );
+    expect(keepOriginalName(node)).false;
+  });
+  it('Should keep unique Intermediate name', () => {
+    const node = new Node(
+      'processmaker-modeler-intermediate-catch-timer-event',
+      { id: 'test', name: 'Unique Intermediate Event Name' },
+      {},
+    );
+    expect(keepOriginalName(node)).true;
+  });
+  it('Should switch default Intermediate name', () => {
+    const node = new Node(
+      'processmaker-modeler-intermediate-catch-timer-event',
+      { id: 'test', name: 'Intermediate Event' },
+      {},
+    );
+    expect(keepOriginalName(node)).false;
+  });
+  it('Should keep unique Gateway name', () => {
+    const node = new Node(
+      'processmaker-modeler-parallel-gateway',
+      { id: 'test', name: 'Unique Gateway Name' },
+      {},
+    );
+    expect(keepOriginalName(node)).true;
+  });
+  it('Should switch default Gateway name', () => {
+    const node = new Node(
+      'processmaker-modeler-parallel-gateway',
+      { id: 'test', name: 'Exclusive Gateway' },
+      {},
+    );
+    expect(keepOriginalName(node)).false;
+  });
+});

--- a/tests/unit/keepOriginalName.spec.js
+++ b/tests/unit/keepOriginalName.spec.js
@@ -2,82 +2,26 @@ import { keepOriginalName} from '@/components/modeler/modelerUtils';
 import Node from '@/components/nodes/node';
 
 describe('Switch Types', () => {
-  it('Should keep unique Task name', () => {
+  const nodeTypes = [
+    ['Form Task', 'processmaker-modeler-script-task'],
+    ['Start Event', 'processmaker-modeler-start-timer-event'],
+    ['End Event', 'processmaker-modeler-message-end-event'],
+    ['Intermediate Message Catch Event', 'processmaker-modeler-intermediate-catch-timer-event'],
+    ['Exclusive Gateway', 'processmaker-modeler-parallel-gateway'],
+  ];
+
+  it.each(nodeTypes)('Should keep unique %s name', (name, type) => {
     const node = new Node(
-      'processmaker-modeler-script-task',
-      { id: 'test', name: 'Unique Task Name' },
+      type,
+      { id: 'test', name: `Unique ${name} Name` },
       {},
     );
     expect(keepOriginalName(node)).toBe(true);
   });
-  it('Should switch default Task name', () => {
+  it.each(nodeTypes)('Should switch default %s name', (name, type) => {
     const node = new Node(
-      'processmaker-modeler-script-task',
-      { id: 'test', name: 'Form Task' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(false);
-  });
-  it('Should keep unique Start name', () => {
-    const node = new Node(
-      'processmaker-modeler-start-timer-event',
-      { id: 'test', name: 'Unique Start Event Name' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(true);
-  });
-  it('Should switch default Start name', () => {
-    const node = new Node(
-      'processmaker-modeler-start-timer-event',
-      { id: 'test', name: 'Start Event' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(false);
-  });
-  it('Should keep unique End name', () => {
-    const node = new Node(
-      'processmaker-modeler-message-end-event',
-      { id: 'test', name: 'Unique End Event Name' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(true);
-  });
-  it('Should switch default End name', () => {
-    const node = new Node(
-      'processmaker-modeler-message-end-event',
-      { id: 'test', name: 'End Event' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(false);
-  });
-  it('Should keep unique Intermediate name', () => {
-    const node = new Node(
-      'processmaker-modeler-intermediate-catch-timer-event',
-      { id: 'test', name: 'Unique Intermediate Event Name' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(true);
-  });
-  it('Should switch default Intermediate name', () => {
-    const node = new Node(
-      'processmaker-modeler-intermediate-catch-timer-event',
-      { id: 'test', name: 'Intermediate Message Catch Event' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(false);
-  });
-  it('Should keep unique Gateway name', () => {
-    const node = new Node(
-      'processmaker-modeler-parallel-gateway',
-      { id: 'test', name: 'Unique Gateway Name' },
-      {},
-    );
-    expect(keepOriginalName(node)).toBe(true);
-  });
-  it('Should switch default Gateway name', () => {
-    const node = new Node(
-      'processmaker-modeler-parallel-gateway',
-      { id: 'test', name: 'Exclusive Gateway' },
+      type,
+      { id: 'test', name },
       {},
     );
     expect(keepOriginalName(node)).toBe(false);


### PR DESCRIPTION
Closes #1150 

Should only switch the name when changing type if it matches a default name for that type.