### PR TITLE
Implements default gateway flow

### DIFF
--- a/src/assets/default-flow.svg
+++ b/src/assets/default-flow.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+  version="1.1" width="16px" height="20px" viewBox="7 7 16 20">
+	<defs />
+	<g>
+		<path d="M 7 27 L 17.93 13.34" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke" />
+		<path d="M 22.3 7.87 L 20.66 15.53 L 15.2 11.15 Z" fill="#ffffff" stroke="#ffffff" stroke-miterlimit="10" pointer-events="all" />
+		<path d="M 7 20 L 18 20" fill="none" stroke="#ffffff" stroke-miterlimit="10" pointer-events="stroke" />
+	</g>
+</svg>

--- a/src/components/crown/crownButtons/defaultFlowButton.vue
+++ b/src/components/crown/crownButtons/defaultFlowButton.vue
@@ -1,0 +1,32 @@
+<template>
+  <crown-button
+    v-if="node.canBeDefaultFlow()"
+    :title="$t('Default Flow')"
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
+    aria-label="Default Flow"
+    data-test="default-flow"
+    role="menuitem"
+    :src="icon"
+    @click="click"
+  />
+</template>
+
+<script>
+import CrownButton from '@/components/crown/crownButtons/crownButton';
+import icon from '@/assets/default-flow.svg';
+
+export default {
+  components: { CrownButton },
+  props: ['node'],
+  data() {
+    return {
+      icon,
+    };
+  },
+  methods: {
+    click() {
+      this.$emit('default-flow', this.node);
+    },
+  },
+};
+</script>

--- a/src/components/crown/crownButtons/defaultFlowButton.vue
+++ b/src/components/crown/crownButtons/defaultFlowButton.vue
@@ -1,7 +1,7 @@
 <template>
   <crown-button
     v-if="node.canBeDefaultFlow()"
-    :title="$t('Default Flow')"
+    :title="$t('Set as Default Flow')"
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     aria-label="Default Flow"
     data-test="default-flow"

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -26,6 +26,11 @@
       @toggle-crown-state="showCrown = $event"
     />
 
+    <default-flow
+      :node="node"
+      v-on="$listeners"
+    />
+
     <crown-dropdowns
       :dropdown-data="dropdownData"
       :boundary-event-dropdown-data="boundaryEventDropdownData"
@@ -72,6 +77,7 @@ import SequenceFlowButton from '@/components/crown/crownButtons/sequenceFlowButt
 import AssociationFlowButton from '@/components/crown/crownButtons/associationFlowButton';
 import CopyButton from '@/components/crown/crownButtons/copyButton.vue';
 import CrownDropdowns from '@/components/crown/crownButtons/crownDropdowns';
+import DefaultFlow from '@/components/crown/crownButtons/defaultFlowButton.vue';
 import poolLaneCrownConfig from '@/mixins/poolLaneCrownConfig';
 import { removeFlows } from '@/components/crown/utils.js';
 import pull from 'lodash/pull';
@@ -87,6 +93,7 @@ export default {
     SequenceFlowButton,
     AssociationFlowButton,
     CopyButton,
+    DefaultFlow,
   },
   props: {
     highlighted: Boolean,

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -253,6 +253,9 @@ export default {
   methods: {
     defaultFlow(flow) {
       const source = flow.definition.sourceRef;
+      if (source.default && source.default.id === flow.id) {
+        flow = null;
+      }
       store.commit('setDefaultFlow', { source, flow });
     },
     copyElement(node, copyCount) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -96,7 +96,7 @@
         @setTooltip="tooltipTarget = $event"
         @replace-node="replaceNode"
         @copy-element="copyElement"
-        @default-flow="defaultFlow"
+        @default-flow="toggleDefaultFlow"
       />
     </b-row>
   </span>
@@ -251,12 +251,12 @@ export default {
     },
   },
   methods: {
-    defaultFlow(flow) {
+    toggleDefaultFlow(flow) {
       const source = flow.definition.sourceRef;
       if (source.default && source.default.id === flow.id) {
         flow = null;
       }
-      store.commit('setDefaultFlow', { source, flow });
+      source.set('default', flow);
     },
     copyElement(node, copyCount) {
       const clonedNode = node.clone(this.nodeRegistry, this.moddle, this.$t);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -96,6 +96,7 @@
         @setTooltip="tooltipTarget = $event"
         @replace-node="replaceNode"
         @copy-element="copyElement"
+        @default-flow="defaultFlow"
       />
     </b-row>
   </span>
@@ -250,6 +251,10 @@ export default {
     },
   },
   methods: {
+    defaultFlow(flow) {
+      const source = flow.definition.sourceRef;
+      store.commit('setDefaultFlow', { source, flow });
+    },
     copyElement(node, copyCount) {
       const clonedNode = node.clone(this.nodeRegistry, this.moddle, this.$t);
       const yOffset = (node.diagram.bounds.height + 30) * copyCount;

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -42,6 +42,11 @@ export default {
     'isRendering',
   ],
   mixins: [highlightConfig, portsConfig, hideLabelOnDrag],
+  created() {
+    const flow = this.node.definition.default || null;
+    delete this.node.definition.default;
+    this.$set(this.node.definition, 'default', flow);
+  },
   data() {
     return {
       shape: null,
@@ -89,7 +94,6 @@ export default {
 
     this.shape.addTo(this.graph);
     this.shape.component = this;
-    this.$set(this.node.definition, 'default', null);
   },
 };
 </script>

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -89,6 +89,7 @@ export default {
 
     this.shape.addTo(this.graph);
     this.shape.component = this;
+    this.$set(this.node.definition, 'default', null);
   },
 };
 </script>

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -31,7 +31,7 @@ export default class Node {
       'bpmn:InclusiveGateway',
     ];
     return this.definition.$type === 'bpmn:SequenceFlow'
-      && validSources.indexOf(this.definition.sourceRef.$type) > -1;
+      && validSources.includes(this.definition.sourceRef.$type);
   }
 
   isType(type) {

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -25,6 +25,10 @@ export default class Node {
     return types.includes(this.definition.$type);
   }
 
+  canBeDefaultFlow() {
+    return true;
+  }
+
   isType(type) {
     return this.type === type;
   }

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -26,7 +26,12 @@ export default class Node {
   }
 
   canBeDefaultFlow() {
-    return true;
+    const validSources = [
+      'bpmn:ExclusiveGateway',
+      'bpmn:InclusiveGateway',
+    ];
+    return this.definition.$type === 'bpmn:SequenceFlow'
+      && validSources.indexOf(this.definition.sourceRef.$type) > -1;
   }
 
   isType(type) {

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -137,11 +137,21 @@ export default {
         position: namePosition,
       }]);
     },
+    createDefaultFlowMarker() {
+      this.shape.attr('line', {
+        sourceMarker: {
+          'type': 'polyline',
+          'stroke-width': 0,
+          points: '2,6 4,-6',
+        },
+      });
+    },
   },
   mounted() {
     this.shape = new shapes.standard.Link();
     this.shape.connector('rounded', { radius: 5 });
     this.createLabel();
+    this.createDefaultFlowMarker();
 
     this.shape.addTo(this.graph);
     this.shape.component = this;

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -68,18 +68,6 @@ export default {
         });
       },
     },
-    defaultFlow: {
-      get() {
-        return this.shape.attr('line').sourceMarker['stroke-width'] > 0;
-      },
-      set(value) {
-        this.shape.attr('line', {
-          sourceMarker: {
-            'stroke-width': value ? 2 : 0,
-          },
-        });
-      },
-    },
   },
   watch: {
     'node.definition': {
@@ -89,18 +77,25 @@ export default {
         if (newNameLabel !== this.nameLabel) {
           this.nameLabel = newNameLabel;
         }
-        this.defaultFlow = this.isDefaultFlow();
+        this.setDefaultMarker(this.isDefaultFlow());
       },
       deep: true,
     },
     'node.definition.sourceRef': {
       handler() {
-        this.defaultFlow = this.isDefaultFlow();
+        this.setDefaultMarker(this.isDefaultFlow());
       },
       deep: true,
     },
   },
   methods: {
+    setDefaultMarker(value) {
+      this.shape.attr('line', {
+        sourceMarker: {
+          'stroke-width': value ? 2 : 0,
+        },
+      });
+    },
     isDefaultFlow() {
       return this.node.definition.sourceRef
         && this.node.definition.sourceRef.default
@@ -162,11 +157,10 @@ export default {
       }]);
     },
     createDefaultFlowMarker() {
-      const isDefault = this.isDefaultFlow();
       this.shape.attr('line', {
         sourceMarker: {
           'type': 'polyline',
-          'stroke-width': isDefault ? 2 : 0,
+          'stroke-width': this.isDefaultFlow() ? 2 : 0,
           points: '2,6 6,-6',
         },
       });

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -68,6 +68,18 @@ export default {
         });
       },
     },
+    defaultFlow: {
+      get() {
+        return this.shape.attr('line').sourceMarker['stroke-width'] > 0;
+      },
+      set(value) {
+        this.shape.attr('line', {
+          sourceMarker: {
+            'stroke-width': value ? 2 : 0,
+          },
+        });
+      },
+    },
   },
   watch: {
     'node.definition': {
@@ -77,6 +89,19 @@ export default {
         if (newNameLabel !== this.nameLabel) {
           this.nameLabel = newNameLabel;
         }
+        window.aa = (window.aa || 0) + 1;
+        this.defaultFlow = this.node.definition.sourceRef
+          && this.node.definition.sourceRef.default
+          && this.node.definition.sourceRef.default.id === this.node.definition.id;
+      },
+      deep: true,
+    },
+    'node.definition.sourceRef': {
+      handler() {
+        window.aa = (window.aa || 0) + 1;
+        this.defaultFlow = this.node.definition.sourceRef
+          && this.node.definition.sourceRef.default
+          && this.node.definition.sourceRef.default.id === this.node.definition.id;
       },
       deep: true,
     },
@@ -142,7 +167,7 @@ export default {
         sourceMarker: {
           'type': 'polyline',
           'stroke-width': 0,
-          points: '2,6 4,-6',
+          points: '2,6 6,-6',
         },
       });
     },

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -89,7 +89,6 @@ export default {
         if (newNameLabel !== this.nameLabel) {
           this.nameLabel = newNameLabel;
         }
-        window.aa = (window.aa || 0) + 1;
         this.defaultFlow = this.node.definition.sourceRef
           && this.node.definition.sourceRef.default
           && this.node.definition.sourceRef.default.id === this.node.definition.id;
@@ -98,7 +97,6 @@ export default {
     },
     'node.definition.sourceRef': {
       handler() {
-        window.aa = (window.aa || 0) + 1;
         this.defaultFlow = this.node.definition.sourceRef
           && this.node.definition.sourceRef.default
           && this.node.definition.sourceRef.default.id === this.node.definition.id;
@@ -163,10 +161,13 @@ export default {
       }]);
     },
     createDefaultFlowMarker() {
+      const isDefault = this.node.definition.sourceRef
+        && this.node.definition.sourceRef.default
+        && this.node.definition.sourceRef.default.id === this.node.definition.id;
       this.shape.attr('line', {
         sourceMarker: {
           'type': 'polyline',
-          'stroke-width': 0,
+          'stroke-width': isDefault ? 2 : 0,
           points: '2,6 6,-6',
         },
       });

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -89,22 +89,23 @@ export default {
         if (newNameLabel !== this.nameLabel) {
           this.nameLabel = newNameLabel;
         }
-        this.defaultFlow = this.node.definition.sourceRef
-          && this.node.definition.sourceRef.default
-          && this.node.definition.sourceRef.default.id === this.node.definition.id;
+        this.defaultFlow = this.isDefaultFlow();
       },
       deep: true,
     },
     'node.definition.sourceRef': {
       handler() {
-        this.defaultFlow = this.node.definition.sourceRef
-          && this.node.definition.sourceRef.default
-          && this.node.definition.sourceRef.default.id === this.node.definition.id;
+        this.defaultFlow = this.isDefaultFlow();
       },
       deep: true,
     },
   },
   methods: {
+    isDefaultFlow() {
+      return this.node.definition.sourceRef
+        && this.node.definition.sourceRef.default
+        && this.node.definition.sourceRef.default.id === this.node.definition.id;
+    },
     updateRouter() {
       this.shape.router('orthogonal', { padding: 1 });
     },
@@ -161,9 +162,7 @@ export default {
       }]);
     },
     createDefaultFlowMarker() {
-      const isDefault = this.node.definition.sourceRef
-        && this.node.definition.sourceRef.default
-        && this.node.definition.sourceRef.default.id === this.node.definition.id;
+      const isDefault = this.isDefaultFlow();
       this.shape.attr('line', {
         sourceMarker: {
           'type': 'polyline',

--- a/src/store.js
+++ b/src/store.js
@@ -52,10 +52,6 @@ export default new Vuex.Store({
     allowSavingElementPosition: state => state.allowSavingElementPosition,
   },
   mutations: {
-    setDefaultFlow(state, { source, flow }) {
-      source.set('default', flow);
-      makeDefinitionPropertyReactive(source, 'default', flow);
-    },
     preventSavingElementPosition(state) {
       state.allowSavingElementPosition = false;
     },

--- a/src/store.js
+++ b/src/store.js
@@ -52,6 +52,10 @@ export default new Vuex.Store({
     allowSavingElementPosition: state => state.allowSavingElementPosition,
   },
   mutations: {
+    setDefaultFlow(state, { source, flow }) {
+      source.set('default', flow);
+      makeDefinitionPropertyReactive(source, 'default', flow);
+    },
     preventSavingElementPosition(state) {
       state.allowSavingElementPosition = false;
     },


### PR DESCRIPTION
Resolves #1182

This PR includes:
- Add a crown button for sequence flow to set it as default. This button is enabled only for outgoing flows of gateways (exclusive and inclusive)
- The default assignment can be removed clicking in the same button
- Add a marker for the sequence flow assigned as default
- One gateway can have only one default flow
![image](https://user-images.githubusercontent.com/8028650/78912601-c7bbbd80-7a55-11ea-9beb-eff970ad33d0.png)
![image](https://user-images.githubusercontent.com/8028650/78913303-d0f95a00-7a56-11ea-8012-dcd08ce57a12.png)
