### PR TITLE
Fix text annotation color reset

### DIFF
--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -177,7 +177,7 @@ export default {
       const color = this.node.definition.get('color');
       const { fill, stroke } = getDefaultNodeColors(this.node, color);
 
-      setShapeColor(this.shape, fill, stroke, this.node);
+      setShapeColor(this.shape, fill, stroke);
     },
     paperNotRendered() {
       return !this.isRendering;

--- a/src/components/nodeColors.js
+++ b/src/components/nodeColors.js
@@ -50,8 +50,8 @@ export function getDefaultNodeColors(node, color) {
   return { fill: defaultNodeColor, stroke: defaultNodeColorStroke };
 }
 
-export function setShapeColor(shape, fill, stroke, node) {
-  if (node.isType('processmaker-modeler-text-annotation')) {
+export function setShapeColor(shape, fill, stroke) {
+  if (shape.component.node.isType('processmaker-modeler-text-annotation')) {
     shape.attr('label/fill', stroke);
     shape.attr('body/stroke', stroke);
     return;

--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -108,6 +108,7 @@ export default {
     this.shape.attr({
       body: {
         refPoints: '25 10 3 10 3 3 25 3',
+        fill: 'none',
       },
       label: {
         fill: 'black',

--- a/src/components/resetShapeColor.js
+++ b/src/components/resetShapeColor.js
@@ -5,5 +5,5 @@ export default function resetShapeColor(shape) {
   const color = node.definition.get('color');
   const { fill, stroke } = getDefaultNodeColors(node, color);
 
-  setShapeColor(shape, fill, stroke, node);
+  setShapeColor(shape, fill, stroke);
 }

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -1,7 +1,7 @@
 import { dia, linkTools } from 'jointjs';
 import get from 'lodash/get';
 import debounce from 'lodash/debounce';
-import { invalidNodeColor, validNodeColor } from '@/components/nodeColors';
+import { invalidNodeColor, setShapeColor, validNodeColor } from '@/components/nodeColors';
 import { getDefaultAnchorPoint } from '@/portsUtils';
 import resetShapeColor from '@/components/resetShapeColor';
 
@@ -104,10 +104,6 @@ export default {
     setTarget(targetShape, connectionPoint) {
       this.setEndpoint(targetShape, endpoints.target, connectionPoint);
     },
-    setBodyColor(color, target = this.target) {
-      target.attr('body/fill', color);
-      target.attr('.body/fill', color);
-    },
     completeLink() {
       this.shape.stopListening(this.paper, 'cell:mouseleave');
       this.$emit('set-cursor', null);
@@ -156,7 +152,7 @@ export default {
         });
 
         if (this.target) {
-          this.setBodyColor(invalidNodeColor);
+          setShapeColor(this.target, invalidNodeColor);
         }
 
         return;
@@ -165,7 +161,7 @@ export default {
       this.setTarget(this.target);
       this.updateRouter();
       this.$emit('set-cursor', 'default');
-      this.setBodyColor(validNodeColor);
+      setShapeColor(this.target, validNodeColor);
 
       this.paper.el.removeEventListener('mousemove', this.updateLinkTarget);
       this.shape.listenToOnce(this.paper, 'cell:pointerclick', () => {


### PR DESCRIPTION
Fixes #1195.

All flows (including text annotation's association flows) will now use our `setShapeColor` util, and text annotation fills are unaffected (text annotations have no fill now, as the fill only covered a small rectangular area, and not the entire shape).

![text_annotation_color](https://user-images.githubusercontent.com/7561061/79471619-d57ebf00-7fd0-11ea-9a39-93147a89353a.gif)

![flow_colors](https://user-images.githubusercontent.com/7561061/79471744-fd6e2280-7fd0-11ea-9ab6-4b0a8ce8538c.gif)
