### PR TITLE
Copy error and message

### DIFF
--- a/src/components/nodes/errorEndEvent/errorEndEvent.vue
+++ b/src/components/nodes/errorEndEvent/errorEndEvent.vue
@@ -23,8 +23,6 @@ export default {
         this.error = this.node.definition.get('eventDefinitions')[0].errorRef;
         return;
       }
-      // eslint-disable-next-line no-console
-      console.log('add error');
 
       this.error = this.moddle.create('bpmn:Error', {
         id: `${this.id}_error`,

--- a/src/components/nodes/errorEndEvent/errorEndEvent.vue
+++ b/src/components/nodes/errorEndEvent/errorEndEvent.vue
@@ -23,6 +23,8 @@ export default {
         this.error = this.node.definition.get('eventDefinitions')[0].errorRef;
         return;
       }
+      // eslint-disable-next-line no-console
+      console.log('add error');
 
       this.error = this.moddle.create('bpmn:Error', {
         id: `${this.id}_error`,

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -89,8 +89,9 @@ export default class Node {
 
     clonedNode.id = null;
     Node.diagramPropertiesToCopy.forEach(prop => clonedNode.diagram.bounds[prop] = this.diagram.bounds[prop]);
-    Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach((key) => {
-      clonedNode.definition.set(key, cloneDeep(this.definition.get(key)));
+    Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach(key => {
+      const definition = this.definition.get(key);
+      clonedNode.definition.set(key, typeof definition === 'object' ? cloneDeep(definition) : definition);
     });
     Node.eventDefinitionPropertiesToNotCopy.forEach(
       prop => clonedNode.definition.eventDefinitions &&

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -6,9 +6,12 @@ import {
   defaultTaskNames,
 } from '@/components/nodes/defaultNames';
 
+import cloneDeep from 'lodash/cloneDeep';
+
 export default class Node {
   static diagramPropertiesToCopy = ['x', 'y', 'width', 'height'];
   static definitionPropertiesToNotCopy = ['$type', 'id'];
+  static eventDefinitionPropertiesToNotCopy = ['errorRef', 'messageRef'];
 
   type;
   definition;
@@ -86,9 +89,14 @@ export default class Node {
 
     clonedNode.id = null;
     Node.diagramPropertiesToCopy.forEach(prop => clonedNode.diagram.bounds[prop] = this.diagram.bounds[prop]);
-    Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach(key => {
-      clonedNode.definition.set(key, this.definition.get(key));
+    Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach((key) => {
+      clonedNode.definition.set(key, cloneDeep(this.definition.get(key)));
     });
+    Node.eventDefinitionPropertiesToNotCopy.forEach(
+      prop => clonedNode.definition.eventDefinitions &&
+        clonedNode.definition.eventDefinitions[0].hasOwnProperty(prop) &&
+        clonedNode.definition.eventDefinitions[0].set(prop, null)
+    );
 
     return clonedNode;
   }

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -2,7 +2,9 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   dragFromSourceToDest,
-  getElementAtPosition, typeIntoTextInput, waitToRenderAllShapes,
+  getElementAtPosition,
+  typeIntoTextInput,
+  waitToRenderAllShapes,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -1,7 +1,8 @@
 import {
+  addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   dragFromSourceToDest,
-  getElementAtPosition, typeIntoTextInput,
+  getElementAtPosition, typeIntoTextInput, waitToRenderAllShapes,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
@@ -62,5 +63,72 @@ describe('Copy element', () => {
     `;
 
     assertDownloadedXmlContainsExpected(processWithTwoStartEventCopies);
+  });
+
+  it('copies error on Error End Event', () => {
+    const errorEndEventPosition = { x: 250, y: 250 };
+
+    addNodeTypeToPaper(errorEndEventPosition, nodeTypes.endEvent, 'switch-to-error-end-event');
+    waitToRenderAllShapes();
+
+    cy.get('[data-test=copy-button]').click();
+    waitToRenderAllShapes();
+
+    const process = `
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:startEvent id="node_1" name="Start Event" />
+        <bpmn:endEvent id="node_3" name="Error End Event">
+          <bpmn:errorEventDefinition errorRef="node_3_error" />
+        </bpmn:endEvent>
+        <bpmn:endEvent id="node_4" name="Error End Event">
+          <bpmn:errorEventDefinition errorRef="node_4_error" />
+        </bpmn:endEvent>
+      </bpmn:process>
+      <bpmn:error id="node_3_error" name="node_3_error" />
+      <bpmn:error id="node_4_error" name="node_4_error" />
+    `;
+
+    assertDownloadedXmlContainsExpected(process);
+
+  });
+
+  it('copies message on Message Event', () => {
+    const messageEndEventPosition = { x: 250, y: 250 };
+    addNodeTypeToPaper(messageEndEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
+    waitToRenderAllShapes();
+
+    cy.get('[data-test=copy-button]').click();
+    waitToRenderAllShapes();
+
+    const intermediateMessageThrowEventPosition = { x: 250, y: 450 };
+    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
+    cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
+    cy.get('[data-test=copy-button]').click();
+    waitToRenderAllShapes();
+
+    const process = `
+      <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:startEvent id="node_1" name="Start Event" />
+        <bpmn:endEvent id="node_3" name="Message End Event">
+          <bpmn:messageEventDefinition messageRef="node_3_message" />
+        </bpmn:endEvent>
+        <bpmn:endEvent id="node_4" name="Message End Event">
+          <bpmn:messageEventDefinition messageRef="node_4_message" />
+        </bpmn:endEvent>
+        <bpmn:intermediateThrowEvent id="node_6" name="Intermediate Message Throw Event">
+          <bpmn:messageEventDefinition messageRef="node_6_message" />
+        </bpmn:intermediateThrowEvent>
+        <bpmn:intermediateThrowEvent id="node_7" name="Intermediate Message Throw Event">
+          <bpmn:messageEventDefinition messageRef="node_7_message" />
+        </bpmn:intermediateThrowEvent>
+      </bpmn:process>
+      <bpmn:message id="node_3_message" name="node_3_message" />
+      <bpmn:message id="node_4_message" name="node_4_message" />
+      <bpmn:message id="node_6_message" name="node_6_message" />
+      <bpmn:message id="node_7_message" name="node_7_message" />
+    `;
+
+    assertDownloadedXmlContainsExpected(process);
+
   });
 });


### PR DESCRIPTION
Closes #1186 
Closes #1185

Had to use cloneDeep because the eventDefinition seemed to point to the original. Updating the message or error name updated the original copy. 

![Apr-16-2020 17-05-48](https://user-images.githubusercontent.com/6653340/79506791-92d6da00-8004-11ea-89b7-8fce13328755.gif)


Copying a Signal Catch Event and changing the signal selected would also update the signal selected for the original when not using cloneDeep.

cloneDeep did not help with Description #1201 