### PR TITLE
Fix undo after upload

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -51,6 +51,7 @@
 import Modeler from './components/modeler/Modeler.vue';
 import FileUpload from 'vue-upload-component';
 import ValidationStatus from '@/components/validationStatus/ValidationStatus';
+import undoRedoStore from '@/undoRedoStore';
 
 const reader = new FileReader();
 
@@ -84,6 +85,7 @@ export default {
   methods: {
     loadXmlIntoModeler() {
       this.$refs.modeler.loadXML(this.uploadedXml);
+      undoRedoStore.dispatch('pushState', this.uploadedXml);
     },
     clearUpload() {
       this.uploadedXml = null;


### PR DESCRIPTION
Fixes #1189.

**Note:** PM core has its own version of `ModelerApp.vue`, so this will only change behaviour for standalone modeler. PM core doesn't have an _Upload XML_ button in the modeler, so this is not an issue there.