### PR TITLE
Add redo-alternative FA icon to color clear button

### DIFF
--- a/src/components/crown/crownButtons/crownColorDropdown.vue
+++ b/src/components/crown/crownButtons/crownColorDropdown.vue
@@ -23,7 +23,7 @@
 
       <button
         type="button"
-        class="color-button"
+        class="color-button clear-color fa fa-redo-alt"
         data-test="clear-color"
         @click="selectedColor = null"
       />
@@ -114,6 +114,10 @@ export default {
       border-radius: 50%;
       border: 2px solid white;
       position: relative;
+    }
+
+    > .clear-color {
+      padding: 0;
     }
   }
 

--- a/src/components/crown/crownButtons/crownColorDropdown.vue
+++ b/src/components/crown/crownButtons/crownColorDropdown.vue
@@ -23,7 +23,7 @@
 
       <button
         type="button"
-        class="color-button clear-color fa fa-redo-alt"
+        class="color-button p-0 fa fa-redo-alt"
         data-test="clear-color"
         @click="selectedColor = null"
       />
@@ -114,10 +114,6 @@ export default {
       border-radius: 50%;
       border: 2px solid white;
       position: relative;
-    }
-
-    > .clear-color {
-      padding: 0;
     }
   }
 


### PR DESCRIPTION
This fixes #1221.

![image](https://user-images.githubusercontent.com/28595383/80751530-7a44e480-8b19-11ea-9461-be1e666ae687.png)
