### PR TITLE
FOUR-1533: Trying to copy a start or end event throws a console error

### DIFF
--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -95,6 +95,7 @@ export default class Node {
     });
     Node.eventDefinitionPropertiesToNotCopy.forEach(
       prop => clonedNode.definition.eventDefinitions &&
+        clonedNode.definition.eventDefinitions[0] &&
         clonedNode.definition.eventDefinitions[0].hasOwnProperty(prop) &&
         clonedNode.definition.eventDefinitions[0].set(prop, null)
     );


### PR DESCRIPTION
Resolves [FOUR-1533](https://processmaker.atlassian.net/browse/FOUR-1533)

Added a condition to verify that the eventDefinition array is not empty
