### PR TITLE
FOUR-1705/1981: Converging parallel gateway throws a BPMN validation error

### DIFF
--- a/src/components/nodes/parallelGateway/parallelGateway.vue
+++ b/src/components/nodes/parallelGateway/parallelGateway.vue
@@ -11,5 +11,15 @@ export default {
       nodeIcon: parallelGatewaySymbol,
     };
   },
+  watch: {
+    'node.definition': {
+      deep:true,
+      immediate:true,
+      handler() {
+        //insure that parallel gateways don't have the 'default' attribute
+        delete this.node.definition.default;
+      },
+    },
+  },
 };
 </script>


### PR DESCRIPTION
Resolves [FOUR-1705](https://processmaker.atlassian.net/browse/FOUR-1705)
Resolves [FOUR-1981](https://processmaker.atlassian.net/browse/FOUR-1981)

The fix removes the "default" attribute from parallel gateways.

Notes:
To fix processes that have this warning open and edit them. Remove the converging gateways and add them again. Save the process and the new bpmn definition will be correct.
