### PR TITLE
Rename advanced accordion to prevent duplication

### DIFF
--- a/src/components/inspectors/advancedAccordionConfig.js
+++ b/src/components/inspectors/advancedAccordionConfig.js
@@ -8,7 +8,7 @@ export default {
     initiallyOpen: false,
     label: 'Advanced',
     icon: 'cogs',
-    name: 'inspector-accordion',
+    name: 'advanced-accordion',
   },
   items: [
     {


### PR DESCRIPTION
## Changes
- Fixes a bug where the inspector's Advanced accordion would open synchronously with the Configuration accordion

Fixes https://processmaker.atlassian.net/browse/FOUR-2048.