### PR TITLE
FOUR-2042: Changing an exclusive gate to parallel disables the save

### DIFF
--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -18,6 +18,11 @@ export default {
     return moddle.create('bpmndi:BPMNEdge');
   },
   inspectorData(node) {
+    // If the flow's source is doesn't have condition remove it:
+    const hasCondition = ['bpmn:ExclusiveGateway', 'bpmn:InclusiveGateway'].includes(node.definition.sourceRef.$type);
+    if (!hasCondition) {
+      delete node.definition.conditionExpression;
+    }
     return Object.entries(node.definition).reduce((data, [key, value]) => {
       if (key === 'conditionExpression') {
         data[key] = value.body;
@@ -37,6 +42,7 @@ export default {
     // If the flow's source is doesn't have condition remove it:
     if (!hasCondition) {
       delete value.conditionExpression;
+      delete node.definition.conditionExpression;
     }
 
     // Go through each property and rebind it to our data

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -34,6 +34,11 @@ export default {
     // Exclusive and inclusive gateways could have conditioned flows
     const hasCondition = ['bpmn:ExclusiveGateway', 'bpmn:InclusiveGateway'].includes(definition.sourceRef.$type);
 
+    // If the flow's source is doesn't have condition remove it:
+    if (!hasCondition) {
+      delete value.conditionExpression;
+    }
+
     // Go through each property and rebind it to our data
     for (const key in value) {
       if (definition[key] === value[key]) {


### PR DESCRIPTION
Resolves [FOUR-2042](https://processmaker.atlassian.net/browse/FOUR-2042)

When a gateway type was modified connected flows maintained the condition expression that is used by exclusive gateways. Now after editing the flow this expression is removed from the node.

