### PR TITLE
Validate switch-to-event-based-gateway

### DIFF
--- a/src/components/crown/crownButtons/crownTaskDropdown.vue
+++ b/src/components/crown/crownButtons/crownTaskDropdown.vue
@@ -11,14 +11,23 @@
     </crown-button>
 
     <ul class="element-list" v-if="dropdownOpen" role="list">
-      <li class="element-list--item" role="listitem" v-for="{label, nodeType, dataTest} in dropdownData" :key="nodeType">
+      <li class="element-list--item" role="listitem" v-for="{label, nodeType, dataTest, disabled} in dropdownData" :key="nodeType" :id="nodeType">
         <button
           :data-test="dataTest"
           class="element-list--item__button"
           type="button"
+          :disabled="isDisabled(disabled, node, nodeType)"
           @click="replaceNode({ node, typeToReplaceWith: nodeType })"
         >{{ $t(label) }}
         </button>
+        <b-tooltip
+          v-if="isDisabled(disabled, node, nodeType)"
+          :target="nodeType"
+          variant="warning"
+          placement="right"
+        >
+          {{ $t(tooltip(disabled, node, nodeType)) }}
+        </b-tooltip>
       </li>
     </ul>
   </div>
@@ -38,6 +47,12 @@ export default {
     },
   },
   methods: {
+    isDisabled(disabled, node, target) {
+      return disabled && (disabled instanceof Function ? disabled.apply(this, [node, target]): disabled);
+    },
+    tooltip(disabled, node, target) {
+      return this.isDisabled(disabled, node, target) || '';
+    },
     replaceNode(data) {
       if (data.node.type === data.typeToReplaceWith) {
         this.$emit('toggle-dropdown-state', false);

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -71,6 +71,14 @@ export default {
           label: defaultNames['processmaker-modeler-event-based-gateway'],
           nodeType: 'processmaker-modeler-event-based-gateway',
           dataTest: 'switch-to-event-based-gateway',
+          disabled(node) {
+            if (node && node.definition && node.definition.outgoing) {
+              const validTypes = ['bpmn:IntermediateCatchEvent'];
+              const invalid = node.definition.outgoing.find(flow => !validTypes.includes(flow.targetRef.$type));
+              return invalid ? 'It must be connected only to catch events' : false;
+            }
+            return false;
+          },
         },
       ],
     };

--- a/tests/e2e/specs/EventBasedGateway.spec.js
+++ b/tests/e2e/specs/EventBasedGateway.spec.js
@@ -6,6 +6,7 @@ import {
   getElementAtPosition,
   getGraphElements,
   typeIntoTextInput,
+  modalConfirm,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
@@ -134,5 +135,23 @@ describe('Event-Based Gateway', () => {
       .then($textAnnotation => {
         getCrownButtonForElement($textAnnotation, 'delete-button').click({ force: true });
       });
+  });
+
+  it('Only convert to event based gateway with valid outgoing', () => {
+    const startEventPosition = { x: 150, y: 150 };
+    connectNodesWithFlow('sequence-flow-button', startEventPosition, eventBasedGatewayPosition);
+    cy.get('[data-test=select-type-dropdown]').click();
+    cy.get('[data-test=switch-to-parallel-gateway]').click();
+    modalConfirm();
+
+    const taskPosition = { x: 500, y: 250 };
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    connectNodesWithFlow('sequence-flow-button', eventBasedGatewayPosition, taskPosition);
+    getElementAtPosition(eventBasedGatewayPosition).click();
+
+    // Convert to event-based-gateway must be disabled
+    cy.get('[data-test=select-type-dropdown]').click();
+    cy.get('li:has([data-test=switch-to-event-based-gateway])').trigger('mouseenter', {force: true});
+    cy.get('[data-test=switch-to-event-based-gateway]').should('be.disabled');
   });
 });


### PR DESCRIPTION
This PR adds a validation to prevent convert a gateway to event based gateway connected to invalid elements:

Invalid connections:
![image](https://user-images.githubusercontent.com/8028650/95125425-f4117780-0722-11eb-866e-1eb8d63396a6.png)

Valid connections:
![image](https://user-images.githubusercontent.com/8028650/95125674-4e123d00-0723-11eb-8011-2f8b465ff495.png)
