### PR TITLE
Revert "FOUR-2225: In console error when selecting a collection in the signal"

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -102,7 +102,7 @@ export default {
       }
 
       return value => {
-        if (value && isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
+        if (isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
 
           const documentation = value.documentation
             ? [this.moddle.create('bpmn:Documentation', { text: value.documentation })]


### PR DESCRIPTION
Hi @velkymx, @danloa  - this PR is causing failing tests.

We could look into finding another way to fix the issue should you want it.

The PR we suggest to revert seems to be a fix for another error originally introduced in https://github.com/ProcessMaker/modeler/pull/1243.

https://github.com/ProcessMaker/modeler/pull/1243 contains a dropdown that causes the Inspector to emit an `undefined` value.

A short term workaround could be an early return in the `documentation` handling section of the InspectorPanel, for example:

```js
return value => {
    if (!value) {
      return;
    }
    if (isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
    
      const documentation = value.documentation
        ? [this.moddle.create('bpmn:Documentation', { text: value.documentation })]
        : undefined;
    
      this.setNodeProp(this.highlightedNode, 'documentation', documentation);
    }
    
    inspectorHandler(omit(value, ['documentation']));
};
```

Short circuiting the conditional based on whether `value` is truthy (like it was done in the reverted PR) would still call the `inspectorHandler` with an `undefined` value.

The complete fix would be to find out why the Message Configuration dropdown (from https://github.com/ProcessMaker/modeler/pull/1243) emits twice and fixing that issue.