### PR TITLE
Revert #1253 and add workaround fix.

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -102,7 +102,10 @@ export default {
       }
 
       return value => {
-        if (value && isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
+        if (!value) {
+          return;
+        }
+        if (isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
 
           const documentation = value.documentation
             ? [this.moddle.create('bpmn:Documentation', { text: value.documentation })]


### PR DESCRIPTION
Hi @velkymx, @danloa  - https://github.com/ProcessMaker/modeler/pull/1253 is causing failing tests.

https://github.com/ProcessMaker/modeler/pull/1253 seems to be a fix for another error originally introduced in https://github.com/ProcessMaker/modeler/pull/1243.

https://github.com/ProcessMaker/modeler/pull/1243 contains a dropdown that causes the Inspector to emit an `undefined` value.

A short term workaround could be an early return in the `documentation` handling section of the InspectorPanel, for example:

```js
return value => {
    if (!value) {
      return;
    }
    if (isString(value.documentation) && get(this.highlightedNode.definition.get('documentation')[0], 'text') !== value.documentation) {
    
      const documentation = value.documentation
        ? [this.moddle.create('bpmn:Documentation', { text: value.documentation })]
        : undefined;
    
      this.setNodeProp(this.highlightedNode, 'documentation', documentation);
    }
    
    inspectorHandler(omit(value, ['documentation']));
};
```

Short circuiting the conditional based on whether `value` is truthy (like it was done in 1253) would still call the `inspectorHandler` with an `undefined` value.

The complete fix would be to find out why the Message Configuration dropdown (from https://github.com/ProcessMaker/modeler/pull/1243) emits twice and fixing that issue.