### PR TITLE
Add configuration to store signal payloads as part of the request data

### DIFF
--- a/src/components/inspectors/requestVariableSettings.js
+++ b/src/components/inspectors/requestVariableSettings.js
@@ -1,6 +1,6 @@
 const requestVariableSettings = {
   label: 'Request Variable',
-  name: 'request_variable',
+  name: 'config',
   helper: 'Enter the request variable that will store the signal payload',
 };
 

--- a/src/components/inspectors/requestVariableSettings.js
+++ b/src/components/inspectors/requestVariableSettings.js
@@ -2,7 +2,6 @@ const requestVariableSettings = {
   label: 'Request Variable',
   name: 'request_variable',
   helper: 'Enter the request variable that will store the signal payload',
-  validation: 'required',
 };
 
 export default requestVariableSettings;

--- a/src/components/inspectors/requestVariableSettings.js
+++ b/src/components/inspectors/requestVariableSettings.js
@@ -1,0 +1,8 @@
+const requestVariableSettings = {
+  label: 'Request Variable',
+  name: 'request_variable',
+  helper: 'Enter the request variable that will store the signal payload',
+  validation: 'required',
+};
+
+export default requestVariableSettings;

--- a/src/components/nodes/intermediateSignalCatchEvent/index.js
+++ b/src/components/nodes/intermediateSignalCatchEvent/index.js
@@ -1,6 +1,7 @@
 import component from './intermediateSignalCatchEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
+import requestVariableSettings from '@/components/inspectors/requestVariableSettings';
 import intermediateEventConfig from '@/components/nodes/intermediateEvent';
 import {signalSelector, default as signalEventDefinition} from '../signalEventDefinition';
 import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
@@ -29,6 +30,10 @@ export default merge(cloneDeep(intermediateEventConfig), {
           items: [
             {},
             signalSelector('Signal that will catch this intermediate event'),
+            {
+              component: 'FormInput',
+              config: requestVariableSettings,
+            },
           ],
         },
       ],

--- a/src/components/nodes/intermediateSignalThrowEvent/index.js
+++ b/src/components/nodes/intermediateSignalThrowEvent/index.js
@@ -2,6 +2,7 @@ import component from './intermediateSignalThrowEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateEventConfig from '@/components/nodes/intermediateEvent';
+import requestVariableSettings from '@/components/inspectors/requestVariableSettings';
 import {signalSelector, default as signalEventDefinition} from '../signalEventDefinition';
 import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
 
@@ -29,6 +30,10 @@ export default merge(cloneDeep(intermediateEventConfig), {
           items: [
             {},
             signalSelector('Select the signal reference that this element throws'),
+            {
+              component: 'FormInput',
+              config: requestVariableSettings,
+            },
           ],
         },
       ],

--- a/src/components/nodes/intermediateSignalThrowEvent/index.js
+++ b/src/components/nodes/intermediateSignalThrowEvent/index.js
@@ -2,7 +2,6 @@ import component from './intermediateSignalThrowEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
 import intermediateEventConfig from '@/components/nodes/intermediateEvent';
-import requestVariableSettings from '@/components/inspectors/requestVariableSettings';
 import {signalSelector, default as signalEventDefinition} from '../signalEventDefinition';
 import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
 
@@ -30,10 +29,6 @@ export default merge(cloneDeep(intermediateEventConfig), {
           items: [
             {},
             signalSelector('Select the signal reference that this element throws'),
-            {
-              component: 'FormInput',
-              config: requestVariableSettings,
-            },
           ],
         },
       ],

--- a/src/components/nodes/signalStartEvent/index.js
+++ b/src/components/nodes/signalStartEvent/index.js
@@ -1,6 +1,7 @@
 import component from './signalStartEvent.vue';
 import merge from 'lodash/merge';
 import cloneDeep from 'lodash/cloneDeep';
+import requestVariableSettings from '@/components/inspectors/requestVariableSettings';
 import baseStartEventConfig from '../baseStartEvent';
 import { default as signalEventDefinition, signalSelector } from '../signalEventDefinition';
 import defaultNames from '@/components/nodes/baseStartEvent/defaultNames';
@@ -27,6 +28,10 @@ export default merge(cloneDeep(baseStartEventConfig), {
           items: [
             {},
             signalSelector('Signal that will trigger this start event'),
+            {
+              component: 'FormInput',
+              config: requestVariableSettings,
+            },
           ],
         },
       ],


### PR DESCRIPTION
Resolves #1261 

A field to store the request variable name has been added in the signal inspector.