### PR TITLE
Modeler validation throws "Element is missing ID." when adding a pool control

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -84,6 +84,7 @@
         :paperManager="paperManager"
         :auto-validate="autoValidate"
         :is-active="node === activeNode"
+        :node-id-generator="nodeIdGenerator"
         @add-node="addNode"
         @remove-node="removeNode"
         @set-cursor="cursor = $event"

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -182,6 +182,7 @@ export default {
     createLaneSet() {
       const laneSet = this.moddle.create('bpmn:LaneSet');
       this.laneSet = laneSet;
+      this.laneSet.set('id', 'laneset_0');
       this.containingProcess.get('laneSets').push(laneSet);
     },
     pushNewLane(definition = Lane.definition(this.moddle, this.$t)) {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -182,7 +182,9 @@ export default {
     createLaneSet() {
       const laneSet = this.moddle.create('bpmn:LaneSet');
       this.laneSet = laneSet;
-      this.laneSet.set('id', 'laneset_0');
+      const generator = this.$parent.nodeIdGenerator;
+      const [laneSetId] = generator.generate();
+      this.laneSet.set('id', laneSetId);
       this.containingProcess.get('laneSets').push(laneSet);
     },
     pushNewLane(definition = Lane.definition(this.moddle, this.$t)) {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -67,6 +67,7 @@ export default {
     'planeElements',
     'isRendering',
     'paperManager',
+    'nodeIdGenerator',
   ],
   mixins: [highlightConfig, resizeConfig, portsConfig],
   data() {
@@ -182,7 +183,7 @@ export default {
     createLaneSet() {
       const laneSet = this.moddle.create('bpmn:LaneSet');
       this.laneSet = laneSet;
-      const generator = this.$parent.nodeIdGenerator;
+      const generator = this.nodeIdGenerator;
       const [laneSetId] = generator.generate();
       this.laneSet.set('id', laneSetId);
       this.containingProcess.get('laneSets').push(laneSet);

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -148,7 +148,7 @@ describe('Pools', () => {
         getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
       });
 
-    const nonEmptyLane = '<bpmn:lane id="node_3" name=""><bpmn:flowNodeRef>node_1</bpmn:flowNodeRef></bpmn:lane>';
+    const nonEmptyLane = '<bpmn:lane id="node_4" name=""><bpmn:flowNodeRef>node_1</bpmn:flowNodeRef></bpmn:lane>';
     assertDownloadedXmlContainsExpected(nonEmptyLane);
 
     const startEventPosition = { x: 150, y: 150 };
@@ -158,7 +158,7 @@ describe('Pools', () => {
         getCrownButtonForElement($startEvent, 'delete-button').click();
       });
 
-    const emptyLane = '<bpmn:lane id="node_3" name="" />';
+    const emptyLane = '<bpmn:lane id="node_4" name="" />';
     assertDownloadedXmlContainsExpected(emptyLane);
     assertDownloadedXmlDoesNotContainExpected('node_1');
   });
@@ -270,5 +270,40 @@ describe('Pools', () => {
         .then(waitToRenderAllShapes)
         .then(assertBoundaryEventIsCloseToTask);
     });
+  });
+
+  it('Check LaneSet IDs', () => {
+    const poolPosition1 = { x: 300, y: 150 };
+    const poolPosition2 = { x: 300, y: 400 };
+
+    // Add pool
+    dragFromSourceToDest(nodeTypes.pool, poolPosition1);
+
+    getElementAtPosition(poolPosition1).click().then($pool => {
+      getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+    });
+
+    dragFromSourceToDest(nodeTypes.pool, poolPosition2);
+
+    getElementAtPosition({ x: 600, y: 600 }).click().then($pool => {
+      getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+    });
+
+    const laneSet1IdBpmn = `
+      <bpmn:laneSet id="node_3">
+        <bpmn:lane id="node_4" name="">
+          <bpmn:flowNodeRef>node_1</bpmn:flowNodeRef>
+        </bpmn:lane>
+        <bpmn:lane id="node_5" name="" />
+      </bpmn:laneSet>
+    `;
+    const laneSet2IdBpmn = `
+      <bpmn:laneSet id="node_7">
+        <bpmn:lane id="node_8" name="" />
+        <bpmn:lane id="node_9" name="" />
+      </bpmn:laneSet>
+    `;
+    assertDownloadedXmlContainsExpected(laneSet1IdBpmn);
+    assertDownloadedXmlContainsExpected(laneSet2IdBpmn);
   });
 });


### PR DESCRIPTION
Fixed [FOUR-1773](https://processmaker.atlassian.net/browse/FOUR-1773)

- Add id by default in LaneSet, this ID has no other functionality only for validations.