### PR TITLE
Run prepareData when the node definition changes

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -78,6 +78,12 @@ export default {
       this.prepareData();
       this.prepareConfig();
     },
+    'highlightedNode.definition': {
+      handler() {
+        this.prepareData();
+      },
+      deep: true,
+    },
   },
   computed: {
     highlightedNode() {


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2396

There are some inspectors like Task Assignments and Comments where we directly set the property on the node without going though the inspectorHandler. This caused those properties get reset when another property gets set using the inspectorHandler. This fix listens for changes on the node definition and makes sure they are set on the data object