### PR TITLE
Refresh inspector after the node is migrated

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -50,7 +50,6 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import Process from './process';
 import isString from 'lodash/isString';
-import isEqual from 'lodash/isEqual';
 
 Vue.component('FormText', renderer.FormText);
 Vue.component('FormInput', FormInput);
@@ -74,16 +73,13 @@ export default {
     };
   },
   watch: {
-    highlightedNode() {
-      document.activeElement.blur();
-
-      const newConfig = this.prepareConfig();
-      if (isEqual(this.config, newConfig)) {
+    highlightedNode(current, previous) {
+      if (current === previous) {
         return;
       }
-
-      this.config = newConfig;
+      document.activeElement.blur();
       this.prepareData();
+      this.config = this.prepareConfig();
     },
   },
   computed: {

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -79,7 +79,7 @@ export default {
       }
       document.activeElement.blur();
       this.prepareData();
-      this.config = this.prepareConfig();
+      this.setInspectorConfig();
     },
   },
   computed: {
@@ -128,18 +128,20 @@ export default {
     },
   },
   methods: {
-    prepareConfig() {
+    setInspectorConfig() {
       if (!this.highlightedNode) {
-        return this.config = {
+        this.config = {
           name: 'Empty',
           items: [],
         };
+        return;
       }
 
       const { type, definition } = this.highlightedNode;
 
       if (this.highlightedNode === this.processNode) {
-        return this.config = Process.inspectorConfig;
+        this.config = Process.inspectorConfig;
+        return;
       }
 
       const inspectorConfig = cloneDeep(this.nodeRegistry[type].inspectorConfig);
@@ -166,10 +168,9 @@ export default {
         else {
           sequenceFlowConfigurationFormElements.push(expressionConfig);
         }
-
       }
 
-      return inspectorConfig;
+      this.config = inspectorConfig;
     },
     prepareData() {
       if (!this.highlightedNode) {

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -50,6 +50,7 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import Process from './process';
 import isString from 'lodash/isString';
+import isEqual from 'lodash/isEqual';
 
 Vue.component('FormText', renderer.FormText);
 Vue.component('FormInput', FormInput);
@@ -75,8 +76,14 @@ export default {
   watch: {
     highlightedNode() {
       document.activeElement.blur();
+
+      const newConfig = this.prepareConfig();
+      if (isEqual(this.config, newConfig)) {
+        return;
+      }
+
+      this.config = newConfig;
       this.prepareData();
-      this.prepareConfig();
     },
   },
   computed: {
@@ -166,7 +173,7 @@ export default {
 
       }
 
-      return this.config = inspectorConfig;
+      return inspectorConfig;
     },
     prepareData() {
       if (!this.highlightedNode) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -712,10 +712,10 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
-      this.highlightNode(newNode);
       await this.addNode(newNode);
 
       if (!nodeThatWillBeReplaced) {
+        this.highlightNode(newNode);
         return;
       }
 
@@ -729,6 +729,7 @@ export default {
       );
       nodeMigrator.migrate();
 
+      this.highlightNode(newNode);
       return newNode;
     },
     setShapeCenterUnderCursor(diagram) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -712,8 +712,8 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
-      await this.addNode(newNode);
       this.highlightNode(newNode);
+      await this.addNode(newNode);
 
       if (!nodeThatWillBeReplaced) {
         return;
@@ -728,7 +728,7 @@ export default {
         this.collaboration,
       );
       nodeMigrator.migrate();
-      
+
       return newNode;
     },
     setShapeCenterUnderCursor(diagram) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -712,9 +712,8 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
-      await this.addNode(newNode);
-
       if (!nodeThatWillBeReplaced) {
+        await this.addNode(newNode);
         this.highlightNode(newNode);
         return;
       }
@@ -729,6 +728,7 @@ export default {
       );
       nodeMigrator.migrate();
 
+      await this.addNode(newNode);
       this.highlightNode(newNode);
       return newNode;
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -431,7 +431,7 @@ export default {
 
       types.forEach(bpmnType => {
         if (!this.parsers[bpmnType]) {
-          this.parsers[bpmnType] = { custom: [], implementation: [], default: [] };
+          this.parsers[bpmnType] = { custom: [], implementation: [], default: []};
         }
 
         if (customParser) {
@@ -712,9 +712,10 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
+      await this.addNode(newNode);
+      this.highlightNode(newNode);
+
       if (!nodeThatWillBeReplaced) {
-        await this.addNode(newNode);
-        this.highlightNode(newNode);
         return;
       }
 
@@ -727,9 +728,7 @@ export default {
         this.collaboration,
       );
       nodeMigrator.migrate();
-
-      await this.addNode(newNode);
-      this.highlightNode(newNode);
+      
       return newNode;
     },
     setShapeCenterUnderCursor(diagram) {


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-2406

This PR changes:
- Refreshes the inspector after a node type migration completes, to prevent the user from seeing the name blink

![ChangeNode mp4](https://user-images.githubusercontent.com/8028650/101189245-2bba7400-362d-11eb-9d18-9d5284d25925.gif)
