### PR TITLE
Run linter and jest tests before pushing

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "./checkForOnly.sh"
+      "pre-commit": "./checkForOnly.sh",
+      "pre-push": "npm run lint && npm run test-unit"
     }
   }
 }


### PR DESCRIPTION
Use Husky to run the linter and Jest tests before a push.

These take less than 4 seconds and it avoids having the CI tests fail because of minor linting issues.