### PR TITLE
Stop bootstrap from disabling focus on modal with tinymce

### DIFF
--- a/src/components/inspectors/DocumentationFormTextArea.vue
+++ b/src/components/inspectors/DocumentationFormTextArea.vue
@@ -25,6 +25,7 @@
       ok-only
       ok-variant="secondary"
       ok-title="Close"
+      no-enforce-focus
     >
       <form-text-area
         v-bind="$attrs"
@@ -82,5 +83,6 @@ export default {
 <style>
   .documentation-input .richtext {
     height: auto;
+    width: 100%;
   }
 </style>


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2636
- Also make the inspector rich text editor 100% since it was only taking up half the width