### PR TITLE
Fix node duplication in pools

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -432,7 +432,7 @@ export default {
 
       types.forEach(bpmnType => {
         if (!this.parsers[bpmnType]) {
-          this.parsers[bpmnType] = { custom: [], implementation: [], default: [] };
+          this.parsers[bpmnType] = { custom: [], implementation: [], default: []};
         }
 
         if (customParser) {
@@ -737,7 +737,9 @@ export default {
       diagram.bounds.y -= (diagram.bounds.height / 2);
     },
     addNode(node) {
-      node.pool = this.poolTarget;
+      if (!node.pool) {
+        node.pool = this.poolTarget;
+      }
 
       const targetProcess = node.getTargetProcess(this.processes, this.processNode);
       addNodeToProcess(node, targetProcess);

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -88,6 +88,7 @@ export default class Node {
     const clonedNode = new this.constructor(this.type, definition, diagram);
 
     clonedNode.id = null;
+    clonedNode.pool = this.pool;
     Node.diagramPropertiesToCopy.forEach(prop => clonedNode.diagram.bounds[prop] = this.diagram.bounds[prop]);
     Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach(key => {
       const definition = this.definition.get(key);

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   dragFromSourceToDest,
-  getElementAtPosition,
+  getElementAtPosition, getXml, removeIndentationAndLinebreaks,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -132,5 +132,25 @@ describe('Copy element', () => {
 
     assertDownloadedXmlContainsExpected(process);
 
+  });
+
+  it('only creates a single new node on copy if you have multiple pools', () => {
+    const firstPoolPosition = { x: 100, y: 150 };
+    const secondPoolPosition = { x: 100, y: 450 };
+
+    dragFromSourceToDest(nodeTypes.pool, firstPoolPosition);
+    waitToRenderAllShapes();
+    dragFromSourceToDest(nodeTypes.pool, secondPoolPosition);
+
+    const taskInSecondPoolPosition = {x: 150, y: 500};
+    dragFromSourceToDest(nodeTypes.task, taskInSecondPoolPosition);
+
+    cy.get('[data-test="copy-button"]').click();
+    waitToRenderAllShapes();
+
+    getXml().then(xml => {
+      const numberOfTasks = xml.match(/<bpmn:task/g);
+      expect(numberOfTasks).to.have.lengthOf(2);
+    });
   });
 });

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   dragFromSourceToDest,
-  getElementAtPosition, getXml, removeIndentationAndLinebreaks,
+  getElementAtPosition, getXml,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';


### PR DESCRIPTION
Fixes #1315.

If two or more pools exist, and you press the `copy element` button on a node within a pool other than the first one, the node would be duplicated in the bpmn. This would prevent the process from being able to be saved since there would be duplicate node ids in the bpmn. 

