### PR TITLE
Delete Boundary Event on type change

### DIFF
--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -165,7 +165,7 @@ export default {
   },
   data() {
     return {
-      runningInCypressTest,
+      runningInCypressTest: runningInCypressTest(),
       showCrown: false,
       savePositionOnPointerupEventSet: false,
       style: null,

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -66,6 +66,7 @@
     />
 
     <b-modal
+      :no-fade="runningInCypressTest"
       id="modal-prevent-closing"
       ref="modal"
       :title="$t('Change Type')"
@@ -94,6 +95,7 @@ import pull from 'lodash/pull';
 import store from '@/store';
 import isEqual from 'lodash/isEqual';
 import { getDefaultNodeColors, setShapeColor } from '@/components/nodeColors';
+import runningInCypressTest from '@/runningInCypressTest';
 
 export default {
   components: {
@@ -163,6 +165,7 @@ export default {
   },
   data() {
     return {
+      runningInCypressTest,
       showCrown: false,
       savePositionOnPointerupEventSet: false,
       style: null,

--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -1,29 +1,23 @@
 import pull from 'lodash/pull';
-import {bpmnType as dataOutputAssociationType} from '@/components/nodes/dataOutputAssociation/config';
-import {bpmnType as dataInputAssociationType} from '@/components/nodes/dataInputAssociation/config';
+import { bpmnType as dataOutputAssociationType } from '@/components/nodes/dataOutputAssociation/config';
+import { bpmnType as dataInputAssociationType } from '@/components/nodes/dataInputAssociation/config';
 
-export function removeFlows(graph, shape, keepSequenceFlows = false) {
-  let linkShapes = graph.getConnectedLinks(shape);
-
-  if (keepSequenceFlows) {
-    linkShapes = linkShapes.filter(link => !link.component.node.isBpmnType('bpmn:SequenceFlow'));
-  }
-
+export function removeFlows(graph, shape) {
+  const linkShapes = graph.getConnectedLinks(shape);
 
   linkShapes.forEach(shape => this.$emit('remove-node', shape.component.node));
-  shape.getEmbeddedCells({ deep: true })
+}
+
+export function removeBoundaryEvents(graph, node, removeNode) {
+  const nodeShape = graph.getElements().find(el => el.component && el.component.node === node);
+
+  nodeShape.getEmbeddedCells({ deep: true })
     .filter(cell => {
-      if (keepSequenceFlows) {
-        return cell.component && !cell.component.node.isBpmnType('bpmn:SequenceFlow');
-      }
-
-      return cell.component;
+      return cell.component && cell.component.node.isBpmnType('bpmn:BoundaryEvent');
     })
-    .forEach(cell => {
-      graph.getConnectedLinks(cell).forEach(shape => this.$emit('remove-node', shape.component.node));
-      shape.unembed(cell);
-
-      this.$emit('remove-node', cell.component.node);
+    .forEach(boundaryEventShape => {
+      graph.getConnectedLinks(boundaryEventShape).forEach(shape => this.$emit('remove-node', shape.component.node));
+      removeNode(boundaryEventShape.component.node);
     });
 }
 

--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -9,7 +9,7 @@ export function removeFlows(graph, shape) {
 }
 
 export function removeBoundaryEvents(graph, node, removeNode) {
-  const nodeShape = graph.getElements().find(el => el.component && el.component.node === node);
+  const nodeShape = graph.getCells().find(el => el.component && el.component.node === node);
 
   nodeShape.getEmbeddedCells({ deep: true })
     .filter(cell => {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -140,7 +140,7 @@ import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import TimerEventNode from '@/components/nodes/timerEventNode';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import { removeOutgoingAndIncomingRefsToFlow } from '@/components/crown/utils';
+import { removeOutgoingAndIncomingRefsToFlow, removeBoundaryEvents } from '@/components/crown/utils';
 import { getInvalidNodes } from '@/components/modeler/modelerUtils';
 import { NodeMigrator } from '@/components/modeler/NodeMigrator';
 
@@ -762,6 +762,7 @@ export default {
     },
     async removeNode(node) {
       removeOutgoingAndIncomingRefsToFlow(node);
+      removeBoundaryEvents(this.graph, node, this.removeNode);
 
       this.removeNodeFromLane(node);
       store.commit('removeNode', node);

--- a/tests/e2e/specs/SwitchingElements.spec.js
+++ b/tests/e2e/specs/SwitchingElements.spec.js
@@ -78,7 +78,7 @@ describe('Switching elements', () => {
     cy.clock().invoke('restore');
   });
 
-  it.skip('deletes boundary events on tasks when the task type is switched', () => {
+  it('deletes boundary events on tasks when the task type is switched', () => {
     cy.clock();
 
     const taskPosition = {x: 300, y: 150};

--- a/tests/e2e/specs/SwitchingElements.spec.js
+++ b/tests/e2e/specs/SwitchingElements.spec.js
@@ -31,10 +31,10 @@ function changeGatewayTypeTo(newType, gatewayPosition) {
 }
 
 function changeTypeTo(currentType, newType, position) {
-  getElementAtPosition(position, currentType).click({force:true});
-  cy.tick(modalAnimationTime);
+  getElementAtPosition(position, currentType).click();
   cy.get('[data-test=select-type-dropdown]').click();
   cy.get(`[data-test=${newType}]`).click();
+
   cy.tick(modalAnimationTime);
   modalConfirm();
   cy.tick(modalAnimationTime);
@@ -83,16 +83,12 @@ describe('Switching elements', () => {
   });
 
   it.skip('deletes boundary events on tasks when the task type is switched', () => {
-    const ms = 300;
     cy.clock();
 
     const taskPosition = {x: 300, y: 150};
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-user-task');
-    cy.tick(ms);
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, nodeTypes.task);
-    cy.tick(ms);
     changeTypeTo(nodeTypes.task, 'switch-to-manual-task', taskPosition);
-    cy.tick(ms);
 
     assertDownloadedXmlDoesNotContainExpected('<bpmn:boundaryEvent');
   });

--- a/tests/e2e/specs/SwitchingElements.spec.js
+++ b/tests/e2e/specs/SwitchingElements.spec.js
@@ -64,12 +64,8 @@ describe('Switching elements', () => {
     const replacementStartEvent = '<bpmn:startEvent id="node_2" name="Message Start Event">';
     assertDownloadedXmlContainsExpected(initialStartEvent);
 
-    getElementAtPosition(startEventPosition).click();
-    cy.get('[data-test=select-type-dropdown]').click();
-    cy.get('[data-test=switch-to-message-start-event]').click();
-    cy.tick(ms);
-    modalConfirm();
-    cy.tick(ms);
+    changeTypeTo(nodeTypes.startEvent, 'switch-to-message-start-event', startEventPosition);
+
     // if we see two nodes here the replacement failed completely
     assertDownloadedXmlContainsExpected(replacementStartEvent);
     assertDownloadedXmlDoesNotContainExpected(initialStartEvent);

--- a/tests/e2e/specs/SwitchingElements.spec.js
+++ b/tests/e2e/specs/SwitchingElements.spec.js
@@ -41,7 +41,7 @@ function changeTypeTo(currentType, newType, position) {
 }
 
 describe('Switching elements', () => {
-  it('Switching a exclusive gateway to a parallel gateway should remove conditions from flows', () => {
+  it('Switching an exclusive gateway to a parallel gateway should remove conditions from flows', () => {
     const gatewayPosition = {x: 300, y: 150};
     const taskPosition = {x: 450, y: 150};
     dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition);


### PR DESCRIPTION
Fixes #1318.

Boundary events were not being removed from the bpmn when switching element types. They are now removed from the bpmn when an element is deleted or when it's type is changed. 