### PR TITLE
Save pools with data objects and stores

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -35,6 +35,8 @@ import Lane, { id as laneId } from '../poolLane';
 import { id as messageFlowId } from '@/components/nodes/messageFlow/index';
 import { labelWidth, poolPadding } from './poolSizes';
 import { id as textAnnotationId } from '@/components/nodes/textAnnotation/index';
+import { id as dataStoreId } from '@/components/nodes/dataStore/index';
+import { id as dataObjectId } from '@/components/nodes/dataObject/index';
 import pull from 'lodash/pull';
 import store from '@/store';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
@@ -165,7 +167,9 @@ export default {
         this.shape.getEmbeddedCells().filter(element => {
           return element.component &&
             element.component.node.type !== laneId &&
-            element.component.node.type !== textAnnotationId;
+            element.component.node.type !== textAnnotationId &&
+            element.component.node.type !== dataObjectId &&
+            element.component.node.type !== dataStoreId;
         }).forEach(element => {
           definition.get('flowNodeRef').push(element.component.node.definition);
         });
@@ -445,7 +449,9 @@ export default {
           element.component &&
           element.component.node.pool === this.shape &&
           element.component.node.type !== laneId &&
-          element.component.node.type !== textAnnotationId,
+          element.component.node.type !== textAnnotationId &&
+          element.component.node.type !== dataObjectId &&
+          element.component.node.type !== dataStoreId
         )
         .forEach(element => {
           const lane = this.graph

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -34,16 +34,13 @@ import resizeConfig from '@/mixins/resizeConfig';
 import Lane, { id as laneId } from '../poolLane';
 import { id as messageFlowId } from '@/components/nodes/messageFlow/index';
 import { labelWidth, poolPadding } from './poolSizes';
-import { id as textAnnotationId } from '@/components/nodes/textAnnotation/index';
-import { id as dataStoreId } from '@/components/nodes/dataStore/index';
-import { id as dataObjectId } from '@/components/nodes/dataObject/index';
 import pull from 'lodash/pull';
 import store from '@/store';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import AddLaneAboveButton from '@/components/crown/crownButtons/addLaneAboveButton';
 import AddLaneBelowButton from '@/components/crown/crownButtons/addLaneBelowButton';
-import { configurePool } from '@/components/nodes/pool/poolUtils';
+import { configurePool, elementShouldHaveFlowNodeRef } from '@/components/nodes/pool/poolUtils';
 import PoolEventHandlers from '@/components/nodes/pool/poolEventHandlers';
 import Node from '@/components/nodes/node';
 import { aPortEveryXPixels } from '@/portsUtils';
@@ -164,15 +161,10 @@ export default {
         const definition = Lane.definition(this.moddle, this.$t);
 
         /* If there are currently elements in the pool, add them to the first lane */
-        this.shape.getEmbeddedCells().filter(element => {
-          return element.component &&
-            element.component.node.type !== laneId &&
-            element.component.node.type !== textAnnotationId &&
-            element.component.node.type !== dataObjectId &&
-            element.component.node.type !== dataStoreId;
-        }).forEach(element => {
-          definition.get('flowNodeRef').push(element.component.node.definition);
-        });
+        this.shape.getEmbeddedCells().filter(element => elementShouldHaveFlowNodeRef(element))
+          .forEach(element => {
+            definition.get('flowNodeRef').push(element.component.node.definition);
+          });
 
         lanes.push(this.pushNewLane(definition));
       }
@@ -446,12 +438,8 @@ export default {
       this.shape
         .getEmbeddedCells()
         .filter(element =>
-          element.component &&
-          element.component.node.pool === this.shape &&
-          element.component.node.type !== laneId &&
-          element.component.node.type !== textAnnotationId &&
-          element.component.node.type !== dataObjectId &&
-          element.component.node.type !== dataStoreId
+          elementShouldHaveFlowNodeRef(element) &&
+            element.component.node.pool === this.shape
         )
         .forEach(element => {
           const lane = this.graph

--- a/src/components/nodes/pool/poolUtils.js
+++ b/src/components/nodes/pool/poolUtils.js
@@ -2,6 +2,10 @@ import { util } from 'jointjs';
 import { poolColor } from '@/components/nodeColors';
 import { labelWidth, poolPadding } from '@/components/nodes/pool/poolSizes';
 import PoolShape from '@/components/nodes/pool/poolShape';
+import { id as laneId } from '@/components/nodes/poolLane';
+import { id as textAnnotationId } from '@/components/nodes/textAnnotation';
+import { id as dataObjectId } from '@/components/nodes/dataObject';
+import { id as dataStoreId } from '@/components/nodes/dataStore';
 
 function createPool(node, graph) {
   const pool = new PoolShape();
@@ -60,4 +64,12 @@ export function configurePool(collaboration, node, graph) {
   sizePool(pool, node);
 
   return pool;
+}
+
+export function elementShouldHaveFlowNodeRef(element) {
+  return element.component &&
+    element.component.node.type !== laneId &&
+    element.component.node.type !== textAnnotationId &&
+    element.component.node.type !== dataObjectId &&
+    element.component.node.type !== dataStoreId;
 }

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -16,13 +16,13 @@ import {
   waitToRenderAllShapes,
 } from '../support/utils';
 
-import { nodeTypes } from '../support/constants';
+import {nodeTypes} from '../support/constants';
 
 describe('Pools', () => {
   it('Update pool name', () => {
     const testString = 'testing';
 
-    const poolPosition = { x: 200, y: 200 };
+    const poolPosition = {x: 200, y: 200};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).click();
@@ -32,30 +32,30 @@ describe('Pools', () => {
   });
 
   it('Can add top and bottom lane', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
 
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition)
       .click()
       .then($pool => {
-        getCrownButtonForElement($pool, 'lane-above-button').click({ force: true });
-        getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+        getCrownButtonForElement($pool, 'lane-above-button').click({force: true});
+        getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
       });
   });
 
   it('Does not allow pool with only one lane', () => {
-    const poolPosition = { x: 300, y: 300 };
-    const lanePosition = { x: 300, y: 550 };
+    const poolPosition = {x: 300, y: 300};
+    const lanePosition = {x: 300, y: 550};
 
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).click().then($pool => {
-      getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+      getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
     });
 
     getElementAtPosition(poolPosition).click().then($pool => {
-      getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      getCrownButtonForElement($pool, 'delete-button').click({force: true});
     });
 
     getElementAtPosition(lanePosition).getType().should('not.equal', nodeTypes.lane);
@@ -63,9 +63,9 @@ describe('Pools', () => {
   });
 
   it('Can drag elements between pools', () => {
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = {x: 150, y: 150};
 
-    const pool1Position = { x: 200, y: 200 };
+    const pool1Position = {x: 200, y: 200};
     dragFromSourceToDest(nodeTypes.pool, pool1Position);
 
     const startEventIn1stPool = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /></bpmn:process>';
@@ -78,7 +78,7 @@ describe('Pools', () => {
         expect(xml).to.contain(startEventIn1stPool);
       });
 
-    const pool2Position = { x: 200, y: 500 };
+    const pool2Position = {x: 200, y: 500};
     dragFromSourceToDest(nodeTypes.pool, pool2Position);
 
     moveElement(startEventPosition, pool2Position);
@@ -112,19 +112,19 @@ describe('Pools', () => {
   });
 
   it('remove all references of flows when deleting a pool with a process', () => {
-    const startEventPosition = { x: 150, y: 150 };
-    const taskPosition = { x: 350, y: 350 };
+    const startEventPosition = {x: 150, y: 150};
+    const taskPosition = {x: 350, y: 350};
 
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
     connectNodesWithFlow('sequence-flow-button', startEventPosition, taskPosition);
 
     getElementAtPosition(poolPosition)
       .click()
       .then($pool => {
-        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+        getCrownButtonForElement($pool, 'delete-button').click({force: true});
       });
 
     const sequenceFlowReference = '<bpmn:sequenceFlow id="node_3" name="Sequence Flow" sourceRef="node_1" targetRef="node_2" />';
@@ -139,19 +139,19 @@ describe('Pools', () => {
   });
 
   it('Removes all references to element from lane', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition)
       .click()
       .then($pool => {
-        getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+        getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
       });
 
     const nonEmptyLane = '<bpmn:lane id="node_4" name=""><bpmn:flowNodeRef>node_1</bpmn:flowNodeRef></bpmn:lane>';
     assertDownloadedXmlContainsExpected(nonEmptyLane);
 
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = {x: 150, y: 150};
     getElementAtPosition(startEventPosition)
       .click()
       .then($startEvent => {
@@ -164,10 +164,10 @@ describe('Pools', () => {
   });
 
   it('Removes all references to element from a pool', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = {x: 150, y: 150};
     getElementAtPosition(startEventPosition).click().then($startEvent => {
       getCrownButtonForElement($startEvent, 'delete-button').click();
     });
@@ -182,16 +182,16 @@ describe('Pools', () => {
   });
 
   it('moves boundary event to another process when dragged to that pool', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
-    const pool2Position = { x: 100, y: 500 };
+    const pool2Position = {x: 100, y: 500};
     dragFromSourceToDest(nodeTypes.pool, pool2Position);
 
-    const taskPosition = { x: 200, y: 200 };
+    const taskPosition = {x: 200, y: 200};
     dragFromSourceToDest(nodeTypes.task, taskPosition);
 
-    const boundaryTimerEventPosition = { x: 260, y: 260 };
+    const boundaryTimerEventPosition = {x: 260, y: 260};
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     moveElement(taskPosition, boundaryTimerEventPosition.x, boundaryTimerEventPosition.y);
 
@@ -214,10 +214,10 @@ describe('Pools', () => {
   });
 
   it('should revert pool element to initial position on undo after dragging outside of pool onto grid', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
-    const startEventPosition = { x: 150, y: 150 };
+    const startEventPosition = {x: 150, y: 150};
     moveElementRelativeTo(startEventPosition, 600, 600, nodeTypes.startEvent);
 
     waitToRenderAllShapes();
@@ -228,23 +228,23 @@ describe('Pools', () => {
   });
 
   it('should not cover child elements with lane', () => {
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition, nodeTypes.pool)
       .click()
       .then($pool => {
-        getCrownButtonForElement($pool, 'lane-above-button').click({ force: true });
+        getCrownButtonForElement($pool, 'lane-above-button').click({force: true});
       });
 
-    const startEventPosition = { x: 150, y: 150 };
-    const topLanePosition = { x: startEventPosition.x, y: startEventPosition.y - 50 };
-    getPositionInPaperCoords(startEventPosition).then(({ x, y }) => {
+    const startEventPosition = {x: 150, y: 150};
+    const topLanePosition = {x: startEventPosition.x, y: startEventPosition.y - 50};
+    getPositionInPaperCoords(startEventPosition).then(({x, y}) => {
       getElementAtPosition(topLanePosition, nodeTypes.poolLane).click();
 
       cy.get('.main-paper [button-id="bottom-right-resize-button"]')
         .trigger('mousedown')
-        .trigger('mousemove', { clientX: x, clientY: y + 100, force: true })
+        .trigger('mousemove', {clientX: x, clientY: y + 100, force: true})
         .trigger('mouseup');
     });
 
@@ -253,40 +253,40 @@ describe('Pools', () => {
   });
 
   it('does not move boundary events independently from tasks when moving pool', () => {
-    const taskPosition = { x: 200, y: 200 };
+    const taskPosition = {x: 200, y: 200};
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
-    const poolPosition = { x: 300, y: 300 };
+    const poolPosition = {x: 300, y: 300};
     dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).then($pool => {
       assertBoundaryEventIsCloseToTask();
 
       cy.wrap($pool)
-        .trigger('mousedown', { which: 1, force: true })
-        .trigger('mousemove', { clientX: 800, clientY: 350, force: true })
-        .trigger('mouseup', { force: true })
+        .trigger('mousedown', {which: 1, force: true})
+        .trigger('mousemove', {clientX: 800, clientY: 350, force: true})
+        .trigger('mouseup', {force: true})
         .then(waitToRenderAllShapes)
         .then(assertBoundaryEventIsCloseToTask);
     });
   });
 
   it('Check LaneSet IDs', () => {
-    const poolPosition1 = { x: 300, y: 150 };
-    const poolPosition2 = { x: 300, y: 400 };
+    const poolPosition1 = {x: 300, y: 150};
+    const poolPosition2 = {x: 300, y: 400};
 
     // Add pool
     dragFromSourceToDest(nodeTypes.pool, poolPosition1);
 
     getElementAtPosition(poolPosition1).click().then($pool => {
-      getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+      getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
     });
 
     dragFromSourceToDest(nodeTypes.pool, poolPosition2);
 
-    getElementAtPosition({ x: 600, y: 600 }).click().then($pool => {
-      getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
+    getElementAtPosition({x: 600, y: 600}).click().then($pool => {
+      getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
     });
 
     const laneSet1IdBpmn = `

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -307,42 +307,43 @@ describe('Pools', () => {
     assertDownloadedXmlContainsExpected(laneSet2IdBpmn);
   });
 
-  describe('does not add flow node ref to pool lane for excluded items', () => {
-    it('when adding elements to an existing lane', () => {
-      removeStartEvent();
+  describe('does not add flow node references to pool lanes for excluded items', () => {
 
-      const poolPosition = {x: 100, y: 50};
-      dragFromSourceToDest(nodeTypes.pool, poolPosition);
-      getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
+    const poolPosition = {x: 100, y: 50};
+
+    function addLaneBelow() {
+      getElementAtPosition({x: poolPosition.x + 100, y: poolPosition.y + 100}, nodeTypes.pool)
         .click({force: true})
         .then($pool => {
           getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
         });
+    }
 
+    function addElementsThatShouldNotHaveFlowNodeRefs() {
       dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
       dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
       dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
+    }
+
+    it('when adding elements to an existing lane', () => {
+      removeStartEvent();
+      dragFromSourceToDest(nodeTypes.pool, poolPosition);
+
+      addLaneBelow();
+      addElementsThatShouldNotHaveFlowNodeRefs();
 
       assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
     });
 
     it('when adding elements to a pool and then adding a lane', () => {
       removeStartEvent();
-
-      const poolPosition = {x: 100, y: 50};
       dragFromSourceToDest(nodeTypes.pool, poolPosition);
 
-      dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
-      dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
-      dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
-
-      getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
-        .click({force: true})
-        .then($pool => {
-          getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
-        });
+      addElementsThatShouldNotHaveFlowNodeRefs();
+      addLaneBelow();
 
       assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
     });
+
   });
 });

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -307,21 +307,42 @@ describe('Pools', () => {
     assertDownloadedXmlContainsExpected(laneSet2IdBpmn);
   });
 
-  it('does not add flow node ref to pool lane for excluded items', () => {
-    removeStartEvent();
+  describe('does not add flow node ref to pool lane for excluded items', () => {
+    it('when adding elements to an existing lane', () => {
+      removeStartEvent();
 
-    const poolPosition = {x: 100, y: 50};
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
-    getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
-      .click({force: true})
-      .then($pool => {
-        getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
-      });
+      const poolPosition = {x: 100, y: 50};
+      dragFromSourceToDest(nodeTypes.pool, poolPosition);
+      getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
+        .click({force: true})
+        .then($pool => {
+          getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
+        });
 
-    dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
-    dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
-    dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
+      dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
+      dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
+      dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
 
-    assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
+      assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
+    });
+
+    it('when adding elements to a pool and then adding a lane', () => {
+      removeStartEvent();
+
+      const poolPosition = {x: 100, y: 50};
+      dragFromSourceToDest(nodeTypes.pool, poolPosition);
+
+      dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
+      dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
+      dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
+
+      getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
+        .click({force: true})
+        .then($pool => {
+          getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
+        });
+
+      assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
+    });
   });
 });

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -10,7 +10,7 @@ import {
   isElementCovered,
   moveElement,
   moveElementRelativeTo,
-  removeIndentationAndLinebreaks,
+  removeIndentationAndLinebreaks, removeStartEvent,
   setBoundaryEvent,
   typeIntoTextInput,
   waitToRenderAllShapes,
@@ -305,5 +305,23 @@ describe('Pools', () => {
     `;
     assertDownloadedXmlContainsExpected(laneSet1IdBpmn);
     assertDownloadedXmlContainsExpected(laneSet2IdBpmn);
+  });
+
+  it('does not add flow node ref to pool lane for excluded items', () => {
+    removeStartEvent();
+
+    const poolPosition = {x: 100, y: 50};
+    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    getElementAtPosition({ x: poolPosition.x + 100, y: poolPosition.y + 100 }, nodeTypes.pool)
+      .click({force: true})
+      .then($pool => {
+        getCrownButtonForElement($pool, 'lane-below-button').click({force: true});
+      });
+
+    dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
+    dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
+    dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
+
+    assertDownloadedXmlDoesNotContainExpected('<bpmn:flowNodeRef');
   });
 });

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -229,6 +229,19 @@ export function removeIndentationAndLinebreaks(string) {
   return string.replace(/(^\s+)|(\n)/gim, '');
 }
 
+export function removeElementAtPosition(elementPosition) {
+  getElementAtPosition(elementPosition)
+    .click()
+    .then($el => {
+      return getCrownButtonForElement($el, 'delete-button');
+    })
+    .click();
+}
+
+export function removeStartEvent(startEventPosition = {x: 150, y: 150}) {
+  removeElementAtPosition(startEventPosition);
+}
+
 export const modalAnimationTime = 300;
 
 export function uploadXml(filepath) {


### PR DESCRIPTION
Fixes #1316

Removes `flowNodeRef` inside pools and lanes for certain objects (data store, data object, and text annotation).