### PR TITLE
Fix duplicated boundary events

### DIFF
--- a/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
+++ b/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
@@ -84,6 +84,7 @@ export default {
       diagram.bounds.y = emptyPort.y - (diagram.bounds.height / 2);
 
       const node = new Node(nodeType, definition, diagram);
+      node.pool = this.node.pool;
 
       store.commit('highlightNode', node);
 

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -1,8 +1,9 @@
 import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
+  assertDownloadedXmlContainsSubstringNTimes,
   dragFromSourceToDest,
-  getElementAtPosition, getXml,
+  getElementAtPosition,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -148,9 +149,6 @@ describe('Copy element', () => {
     cy.get('[data-test="copy-button"]').click();
     waitToRenderAllShapes();
 
-    getXml().then(xml => {
-      const numberOfTasks = xml.match(/<bpmn:task/g);
-      expect(numberOfTasks).to.have.lengthOf(2);
-    });
+    assertDownloadedXmlContainsSubstringNTimes('<bpmn:task', 2, 'Expect exactly two tasks after copying one');
   });
 });

--- a/tests/e2e/specs/ErrorEndEvent.spec.js
+++ b/tests/e2e/specs/ErrorEndEvent.spec.js
@@ -1,10 +1,10 @@
 import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
+  assertDownloadedXmlContainsSubstringNTimes,
   assertDownloadedXmlDoesNotContainExpected,
   getCrownButtonForElement,
   getElementAtPosition,
-  getXml,
   typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../support/utils';
@@ -57,10 +57,6 @@ describe('Error End Event', () => {
     cy.get('[data-test=redo]').click();
     waitToRenderAllShapes();
 
-    getXml().then(xml => {
-      const match = xml.match(/<bpmn:error id=".*?" name=".*?" \/>/g);
-      const numberOfMessages = match && match.length;
-      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
-    });
+    assertDownloadedXmlContainsSubstringNTimes('<bpmn:error id=".*?" name=".*?" />', 1, 'There should only be one message element found');
   });
 });

--- a/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
@@ -1,13 +1,14 @@
 import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
+  assertDownloadedXmlContainsSubstringNTimes,
   assertDownloadedXmlDoesNotContainExpected,
   connectNodesWithFlow,
   dragFromSourceToDest,
   getCrownButtonForElement,
   getElementAtPosition,
   getNumberOfLinks,
-  getXml, waitForAnimations,
+  waitForAnimations,
   waitToRenderAllShapes,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
@@ -125,11 +126,7 @@ describe('Intermediate Message Throw Event', () => {
     cy.get('[data-test=redo]').click();
     waitToRenderAllShapes();
 
-    getXml().then(xml => {
-      const match = xml.match(/<bpmn:message id=".*?" name=".*?" \/>/g);
-      const numberOfMessages = match && match.length;
-      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
-    });
+    assertDownloadedXmlContainsSubstringNTimes('<bpmn:message id=".*?" name=".*?" />', 1, 'Expect single message');
   });
 
   it('retains message name after loading XML', () => {

--- a/tests/e2e/specs/MessageEndEvent.spec.js
+++ b/tests/e2e/specs/MessageEndEvent.spec.js
@@ -1,8 +1,8 @@
 import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
+  assertDownloadedXmlContainsSubstringNTimes,
   getElementAtPosition,
-  getXml,
   waitToRenderAllShapes,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
@@ -31,10 +31,6 @@ describe('Message End Event', () => {
     cy.get('[data-test=redo]').click();
     waitToRenderAllShapes();
 
-    getXml().then(xml => {
-      const match = xml.match(/<bpmn:message id=".*?" name=".*?" \/>/g);
-      const numberOfMessages = match && match.length;
-      expect(numberOfMessages).to.equal(1, 'More than 1 message element was found');
-    });
+    assertDownloadedXmlContainsSubstringNTimes('<bpmn:message id=".*?" name=".*?" />', 1, 'There should only be one message element found');
   });
 });

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -1,12 +1,12 @@
 import {
   addNodeTypeToPaper,
+  assertDownloadedXmlContainsSubstringNTimes,
   connectNodesWithFlow,
   dragFromSourceToDest,
   getCrownButtonForElement,
   getElementAtPosition,
   getGraphElements,
   getLinksConnectedToElement,
-  getXml,
   isElementCovered,
   removeIndentationAndLinebreaks,
   typeIntoTextInput,
@@ -385,10 +385,8 @@ describe('Modeler', () => {
   it('should not generate duplicate diagram IDs', () => {
     uploadXml('setUpForDuplicateDiagramId.xml');
     dragFromSourceToDest(nodeTypes.task, { x: 300, y: 300 });
-    getXml().then(xml => {
-      expect(xml.match(/node_1_di/g)).to.have.length(1);
-      expect(xml.match(/node_2_di/g)).to.have.length(1);
-    });
+    assertDownloadedXmlContainsSubstringNTimes('node_1_di',1,'Node 1 should occur once');
+    assertDownloadedXmlContainsSubstringNTimes('node_2_di',1,'Node 2 should occur once');
   });
 
   it('should only show dropdown for the start event', () => {

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -6,7 +6,7 @@ import {
   dragFromSourceToDest,
   getCrownButtonForElement,
   getElementAtPosition,
-  getPositionInPaperCoords,
+  getPositionInPaperCoords, getXml,
   isElementCovered,
   moveElement,
   moveElementRelativeTo,
@@ -305,5 +305,22 @@ describe('Pools', () => {
     `;
     assertDownloadedXmlContainsExpected(laneSet1IdBpmn);
     assertDownloadedXmlContainsExpected(laneSet2IdBpmn);
+  });
+
+  it('does not duplicate boundary events when added to a task in a pool', () => {
+    const poolPosition1 = { x: 300, y: 150 };
+    const poolPosition2 = { x: 300, y: 400 };
+    const taskPosition = { x: 350, y: 450 };
+
+    dragFromSourceToDest(nodeTypes.pool, poolPosition1);
+    dragFromSourceToDest(nodeTypes.pool, poolPosition2);
+    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    setBoundaryEvent(nodeTypes.boundaryConditionalEvent, taskPosition);
+
+    getXml().then(xml => {
+      const numberOfBoundaryEvents = xml.match(/<bpmn:boundaryEvent/g);
+      expect(numberOfBoundaryEvents).to.have.lengthOf(1);
+    });
+
   });
 });

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -1,12 +1,13 @@
 import {
   assertBoundaryEventIsCloseToTask,
   assertDownloadedXmlContainsExpected,
+  assertDownloadedXmlContainsSubstringNTimes,
   assertDownloadedXmlDoesNotContainExpected,
   connectNodesWithFlow,
   dragFromSourceToDest,
   getCrownButtonForElement,
   getElementAtPosition,
-  getPositionInPaperCoords, getXml,
+  getPositionInPaperCoords,
   isElementCovered,
   moveElement,
   moveElementRelativeTo,
@@ -317,10 +318,6 @@ describe('Pools', () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryConditionalEvent, taskPosition);
 
-    getXml().then(xml => {
-      const numberOfBoundaryEvents = xml.match(/<bpmn:boundaryEvent/g);
-      expect(numberOfBoundaryEvents).to.have.lengthOf(1);
-    });
-
+    assertDownloadedXmlContainsSubstringNTimes('<bpmn:boundaryEvent', 1);
   });
 });

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -332,6 +332,13 @@ export function assertDownloadedXmlDoesNotContainExpected(xmlString) {
   });
 }
 
+export function assertDownloadedXmlContainsSubstringNTimes(substring, expectedCount, message) {
+  getXml().then(xml => {
+    const matches = xml.match(new RegExp(substring, 'g'));
+    expect(matches).to.have.lengthOf(expectedCount, message);
+  });
+}
+
 export function assertBoundaryEventIsCloseToTask() {
   const positionErrorMargin = 30;
 


### PR DESCRIPTION
Fixes #1317.

In this PR:
 * Boundary events are assigned a pool to prevent the duplication bug.
 * A util function is factored out.