### PR TITLE
FOUR-2718: Signal catch: Inspector for signal start event is showing all process signals

### DIFF
--- a/src/components/inspectors/SignalSelect.vue
+++ b/src/components/inspectors/SignalSelect.vue
@@ -24,7 +24,7 @@
           <slot name="noOptions">{{ $t('No Data Available') }}</slot>
         </template>
       </multiselect>
-      <div class="btn-group ml-1" role="group">
+      <div class="btn-group ml-1" role="group" v-if="canEdit">
         <button type="button" class="btn btn-secondary btn-sm" @click="toggleConfigSignal" data-cy="events-list">
           <i class="fa fa-ellipsis-h" />
         </button>
@@ -118,6 +118,10 @@ export default {
     name: String,
     placeholder: String,
     helper: String,
+    canEdit: {
+      type: Boolean,
+      default: true,
+    },
     trackBy: {
       type: String,
       default: 'id',

--- a/src/components/nodes/intermediateSignalCatchEvent/index.js
+++ b/src/components/nodes/intermediateSignalCatchEvent/index.js
@@ -29,7 +29,7 @@ export default merge(cloneDeep(intermediateEventConfig), {
         {
           items: [
             {},
-            signalSelector('Signal that will catch this intermediate event'),
+            signalSelector('Signal that will catch this intermediate event', false),
             {
               component: 'FormInput',
               config: requestVariableSettings,

--- a/src/components/nodes/signalEventDefinition/index.js
+++ b/src/components/nodes/signalEventDefinition/index.js
@@ -1,13 +1,14 @@
 import omit from 'lodash/omit';
 import SignalSelect from '@/components/inspectors/SignalSelect';
 
-export function signalSelector(helper) {
+export function signalSelector(helper, editEnabled = true) {
   return {
     component: SignalSelect,
     config: {
       label: 'Signal',
       name: 'signalRef',
       helper,
+      canEdit: editEnabled,
     },
   };
 }
@@ -29,10 +30,10 @@ export default {
       if (node.definition[key] === value[key]) {
         continue;
       }
-    
+
       setNodeProp(node, key, value[key]);
     }
-    
+
     let signal = definitions.rootElements.find(element => element.id === value.signalRef);
     if (!signal && value.signalRef) {
       signal = moddle.create('bpmn:Signal', {

--- a/src/components/nodes/signalStartEvent/index.js
+++ b/src/components/nodes/signalStartEvent/index.js
@@ -27,7 +27,7 @@ export default merge(cloneDeep(baseStartEventConfig), {
         {
           items: [
             {},
-            signalSelector('Signal that will trigger this start event'),
+            signalSelector('Signal that will trigger this start event', false),
             {
               component: 'FormInput',
               config: requestVariableSettings,


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2718](https://processmaker.atlassian.net/browse/FOUR-2718)

The option of edit/insert signals is available just in intermediate throw signal event and end signal event.