### PR TITLE
Fix start timer test

### DIFF
--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -7,6 +7,7 @@ import {
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
+import moment from 'moment';
 
 const startTimerEventPosition = { x: 250, y: 250 };
 
@@ -20,7 +21,8 @@ describe('Start Timer Event', () => {
   const today = now.getDate().toString().padStart(2, '0');
 
   it('can set a specific start date', () => {
-    const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 PM`;
+    const toggledPeriod = moment(now).format('A') === 'AM' ? 'PM' : 'AM';
+    const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 ${toggledPeriod}`;
 
     addStartTimerEventToPaper();
     waitToRenderAllShapes();


### PR DESCRIPTION
This PR fixes the start timer test.

- The `expectedStartDate` was incorrect when tests are executed between 00:00 UTC to 11:59 UTC

