### PR TITLE
FOUR-2757: Start signal, it only works with the last configured process.

### DIFF
--- a/src/components/inspectors/SignalSelect.vue
+++ b/src/components/inspectors/SignalSelect.vue
@@ -308,7 +308,7 @@ export default {
       this.showNewSignal = false;
     },
     updateOptions(globalSignals) {
-      this.options = uniqBy([...this.localSignals, ...globalSignals], 'id');
+      this.options = uniqBy([ ...globalSignals, ...this.localSignals], 'id');
     },
     loadOptions(filter) {
       const pmql = this.pmql;


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2757](https://processmaker.atlassian.net/browse/FOUR-2757)

To fill the signal list, the name of global signals have precedence over the local ones.