### PR TITLE
Remove node using the passed-in function instead of emitting

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -16,7 +16,7 @@ export function removeBoundaryEvents(graph, node, removeNode) {
       return cell.component && cell.component.node.isBpmnType('bpmn:BoundaryEvent');
     })
     .forEach(boundaryEventShape => {
-      graph.getConnectedLinks(boundaryEventShape).forEach(shape => this.$emit('remove-node', shape.component.node));
+      graph.getConnectedLinks(boundaryEventShape).forEach(shape => removeNode(shape.component.node));
       removeNode(boundaryEventShape.component.node);
     });
 }


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2783

- Removing connected links was using the old $emit method. Changed to use passed-in removeNode function instead