### PR TITLE
Fix lose inspector properties when replacing the generic flow

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -803,6 +803,8 @@ export default {
     replaceGenericFlow({ actualFlow, genericFlow, targetNode }) {
       this.performSingleUndoRedoTransaction(async() => {
         await this.paperManager.performAtomicAction(async() => {
+          await this.highlightNode(null);
+          await this.$nextTick();
           await this.addNode(actualFlow);
           await store.commit('removeNode', genericFlow);
           await this.$nextTick();

--- a/src/store.js
+++ b/src/store.js
@@ -86,7 +86,7 @@ export default new Vuex.Store({
       state.nodes = [];
     },
     highlightNode(state, node) {
-      state.highlightedNodes = [node];
+      state.highlightedNodes = node ? [node] : [];
     },
     addToHighlightedNodes(state, nodes) {
       state.highlightedNodes = uniq([...state.highlightedNodes, ...nodes]);


### PR DESCRIPTION
During the replaceGenericFlow transaction the flow definition is updated, this triggers the reactivity of the current selected Inspector causing conflicts with the transaction changes, then some properties extended in PM4 Core project and PM4 packages get lost after the transaction.

This PR deselects the inspector at the beginning of the transaction to avoid this problem.
