### PR TITLE
Fix losing inspector properties when double clicking on a task

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -106,6 +106,7 @@
 
 <script>
 import Vue from 'vue';
+import _ from 'lodash';
 import { dia } from 'jointjs';
 import boundaryEventConfig from '../nodes/boundaryEvent';
 import BpmnModdle from 'bpmn-moddle';
@@ -381,12 +382,22 @@ export default {
       this.collaboration = null;
     },
     highlightNode(node, event) {
+      if (!node || !this.highlightedNode) {
+        return;
+      }
+
       if (event && event.shiftKey) {
         store.commit('addToHighlightedNodes', [node]);
         return;
       }
 
-      store.commit('highlightNode', node);
+      let isSameHighlightedNode = _.isEqual(node.id, this.highlightedNode.id);
+
+      if (!isSameHighlightedNode) {
+        store.commit('highlightNode', node);  
+      }
+
+      return;
     },
     blurFocusedScreenBuilderElement() {
       const elementsToBlur = ['INPUT', 'SELECT'];


### PR DESCRIPTION
**Jira Ticket**

https://processmaker.atlassian.net/browse/FOUR-3029

This PR fixes the issue where the inspector screen assignments were removed when double-clicking a task.

**Video**

https://www.loom.com/share/a1be09c6a51b47908b6dea64b667b09c