### PR TITLE
Add permission checks when configuring signals

### DIFF
--- a/src/components/inspectors/SignalSelect.vue
+++ b/src/components/inspectors/SignalSelect.vue
@@ -100,8 +100,8 @@
               {{ signal.name }}
             </td>
             <td align="right">
-              <button class="btn-link ml-2" @click="editSignal(signal)"><i class="fa fa-pen" data-cy="events-edit" /></button>
-              <button class="btn-link ml-2" @click="removeSignal(signal)"><i class="fa fa-trash" data-cy="events-remove" /></button>
+              <button class="btn-link ml-2" @click="editSignal(signal)" v-if="can('edit-signals')"><i class="fa fa-pen" data-cy="events-edit" /></button>
+              <button class="btn-link ml-2" @click="removeSignal(signal)" v-if="can('delete-signals')"><i class="fa fa-trash" data-cy="events-remove" /></button>
             </td>
           </tr>
         </tbody>
@@ -249,10 +249,6 @@ export default {
       }
     },
     removeSignal(signal) {
-      if (!this.can('delete-signals')) {
-        window.ProcessMaker.alert(this.$t('You do not have permission to delete signals'), 'danger');
-        return;
-      }
       this.showConfirmDelete = true;
       this.deleteSignal = signal;
     },
@@ -264,10 +260,6 @@ export default {
       this.showListSignals = !this.showListSignals;
     },
     editSignal(signal) {
-      if (!this.can('edit-signals')) {
-        window.ProcessMaker.alert(this.$t('You do not have permission to edit signals'), 'danger');
-        return;
-      }
       this.signalId = signal.id;
       this.signalName = signal.name;
       this.showEditSignal = true;
@@ -307,7 +299,7 @@ export default {
     },
     showAddSignal() {
       if (!this.can('create-signals')) {
-        window.ProcessMaker.alert(this.$t('You do not have permission to add new signals'));
+        window.ProcessMaker.alert(this.$t('You do not have permission to add new signals'), 'danger');
         return;
       }
       this.showNewSignal = true;

--- a/src/components/inspectors/SignalSelect.vue
+++ b/src/components/inspectors/SignalSelect.vue
@@ -326,7 +326,7 @@ export default {
       this.options = uniqBy([ ...globalSignals, ...this.localSignals], 'id');
     },
     loadOptions(filter) {
-      if (!this.can('view-signals')) { return }
+      if (!this.can('view-signals')) { return; }
 
       const pmql = this.pmql;
       window.window.ProcessMaker.apiClient
@@ -349,8 +349,8 @@ export default {
     },
     loadOptionsDebounced() {},
     can(permission) {
-      return _.get(window, `ProcessMaker.modeler.signalPermissions.${permission}`, false);
-    }
+      return get(window, `ProcessMaker.modeler.signalPermissions.${permission}`, false);
+    },
   },
   watch: {
     value: {

--- a/src/components/inspectors/SignalSelect.vue
+++ b/src/components/inspectors/SignalSelect.vue
@@ -16,6 +16,7 @@
         @search-change="loadOptions"
         @open="loadOptions"
         :data-test="`${name}:select`"
+        :disabled="!can('view-signals')"
       >
         <template slot="noResult">
           <slot name="noResult">{{ $t('Not found') }}</slot>
@@ -30,6 +31,9 @@
         </button>
       </div>
     </div>
+    <div v-if="!can('view-signals')" class="invalid-feedback d-block"><div>
+      {{ $t('You do not have permission to view signals') }}
+    </div></div>
     <div v-if="invalid" class="invalid-feedback d-block"><div>
       {{ $t('Signal reference is required') }}
     </div></div>
@@ -245,13 +249,25 @@ export default {
       }
     },
     removeSignal(signal) {
+      if (!this.can('delete-signals')) {
+        window.ProcessMaker.alert(this.$t('You do not have permission to delete signals'), 'danger');
+        return;
+      }
       this.showConfirmDelete = true;
       this.deleteSignal = signal;
     },
     toggleConfigSignal() {
+      if (!this.can('view-signals')) {
+        window.ProcessMaker.alert(this.$t('You do not have permission to view signals'), 'danger');
+        return;
+      }
       this.showListSignals = !this.showListSignals;
     },
     editSignal(signal) {
+      if (!this.can('edit-signals')) {
+        window.ProcessMaker.alert(this.$t('You do not have permission to edit signals'), 'danger');
+        return;
+      }
       this.signalId = signal.id;
       this.signalName = signal.name;
       this.showEditSignal = true;
@@ -290,6 +306,10 @@ export default {
       });
     },
     showAddSignal() {
+      if (!this.can('create-signals')) {
+        window.ProcessMaker.alert(this.$t('You do not have permission to add new signals'));
+        return;
+      }
       this.showNewSignal = true;
       this.signalId = '';
       this.signalName = '';
@@ -314,6 +334,8 @@ export default {
       this.options = uniqBy([ ...globalSignals, ...this.localSignals], 'id');
     },
     loadOptions(filter) {
+      if (!this.can('view-signals')) { return }
+
       const pmql = this.pmql;
       window.window.ProcessMaker.apiClient
         .get(this.api, { params: { filter, pmql } })
@@ -334,6 +356,9 @@ export default {
       }
     },
     loadOptionsDebounced() {},
+    can(permission) {
+      return _.get(window, `ProcessMaker.modeler.signalPermissions.${permission}`, false);
+    }
   },
   watch: {
     value: {

--- a/tests/e2e/specs/BoundarySignalEvent.spec.js
+++ b/tests/e2e/specs/BoundarySignalEvent.spec.js
@@ -9,12 +9,18 @@ import {
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 import { CommonBoundaryEventBehaviour } from '../support/BoundaryEventCommonBehaviour';
+import _ from 'lodash';
 
 describe('Boundary Signal Event', () => {
   const taskPosition = { x: 200, y: 200 };
   const boundarySignalEventPosition = { x: 260, y: 200 };
 
   beforeEach(() => {
+    cy.window().then((win) => {
+      _.set(win, 'ProcessMaker.modeler.signalPermissions', {
+        'create-signals':true,'view-signals':true,'edit-signals':true,'delete-signals':true,
+      });
+    });
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundarySignalEvent, taskPosition);
   });

--- a/tests/e2e/specs/IntermediateSignalThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateSignalThrowEvent.spec.js
@@ -12,7 +12,7 @@ describe('Intermediate Signal Throw Event', () => {
   beforeEach(() => {
     cy.window().then((win) => {
       _.set(win, 'ProcessMaker.modeler.signalPermissions', {
-        "create-signals":true,"view-signals":true,"edit-signals":true,"delete-signals":true
+        'create-signals':true,'view-signals':true,'edit-signals':true,'delete-signals':true,
       });
     });
   });

--- a/tests/e2e/specs/IntermediateSignalThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateSignalThrowEvent.spec.js
@@ -5,8 +5,18 @@ import {
   waitToRenderAllShapes,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
+import _ from 'lodash';
 
 describe('Intermediate Signal Throw Event', () => {
+
+  beforeEach(() => {
+    cy.window().then((win) => {
+      _.set(win, 'ProcessMaker.modeler.signalPermissions', {
+        "create-signals":true,"view-signals":true,"edit-signals":true,"delete-signals":true
+      });
+    });
+  });
+
   it('Can create intermediate signal throw event', () => {
     const intermediateSignalThrowEventPosition = { x: 250, y: 250 };
     addNodeTypeToPaper(intermediateSignalThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-signal-throw-event');

--- a/tests/e2e/specs/SignalPermissions.spec.js
+++ b/tests/e2e/specs/SignalPermissions.spec.js
@@ -1,0 +1,57 @@
+import {
+  addNodeTypeToPaper,
+  waitToRenderAllShapes,
+  selectOptionByName,
+  getElementAtPosition
+} from '../support/utils';
+import { nodeTypes } from '../support/constants';
+import _ from 'lodash';
+
+const intermediateSignalThrowEventPosition = { x: 250, y: 250 };
+
+function setPerm(perm, value) {
+  cy.get('[data-test="paper"]').click();
+  cy.window().then((win) => {
+    _.set(win, 'ProcessMaker.modeler.signalPermissions.' + perm, value);
+  });
+  return getElementAtPosition(intermediateSignalThrowEventPosition).click();
+}
+
+Cypress.on('window:load', (win) => {
+    console.log("-------------- HERE", win.ProcessMaker);
+    win.console.log = console.log;
+});
+
+describe('Intermediate Message Throw Event', () => {
+
+  it('can create a message when intermediate message throw event is dragged on', () => {
+    
+    cy.window().then(win => {
+      cy.stub(win.ProcessMaker, 'alert').as('alert');
+    })
+    
+    addNodeTypeToPaper(intermediateSignalThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-signal-throw-event');
+    waitToRenderAllShapes();
+
+    cy.get('[data-test="signalRef:select"]').should('have.class', 'multiselect--disabled');
+
+    setPerm('view-signals', true);
+    cy.get('[data-cy="events-list"').click();
+    cy.get('[data-cy="events-add"').click();
+
+    cy.get('@alert').should('be.calledWith', "You do not have permission to add new signals", "danger");
+    
+    setPerm('create-signals', true);
+    cy.get('[data-cy="events-list"').click();
+    cy.get('[data-cy="events-add"').click();
+    cy.get('[data-cy="events-add-id"]').should('be.visible');
+    cy.get('[data-cy="events-cancel"').click();
+
+    selectOptionByName('[data-test="signalRef:select"]', 'global signal 1');
+    
+    cy.get('.badge-secondary').contains('global_1').should('be.visible');
+    cy.get('[data-cy="events-edit"]').should('not.exist');
+    cy.get('[data-cy="events-remove"]').should('not.exist');
+
+  });
+});

--- a/tests/e2e/specs/SignalPermissions.spec.js
+++ b/tests/e2e/specs/SignalPermissions.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   waitToRenderAllShapes,
   selectOptionByName,
-  getElementAtPosition
+  getElementAtPosition,
 } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 import _ from 'lodash';
@@ -15,12 +15,7 @@ function setPerm(perm, value) {
     _.set(win, 'ProcessMaker.modeler.signalPermissions.' + perm, value);
   });
   return getElementAtPosition(intermediateSignalThrowEventPosition).click();
-}
-
-Cypress.on('window:load', (win) => {
-    console.log("-------------- HERE", win.ProcessMaker);
-    win.console.log = console.log;
-});
+} 
 
 describe('Intermediate Message Throw Event', () => {
 
@@ -28,7 +23,7 @@ describe('Intermediate Message Throw Event', () => {
     
     cy.window().then(win => {
       cy.stub(win.ProcessMaker, 'alert').as('alert');
-    })
+    });
     
     addNodeTypeToPaper(intermediateSignalThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-signal-throw-event');
     waitToRenderAllShapes();
@@ -39,7 +34,7 @@ describe('Intermediate Message Throw Event', () => {
     cy.get('[data-cy="events-list"').click();
     cy.get('[data-cy="events-add"').click();
 
-    cy.get('@alert').should('be.calledWith', "You do not have permission to add new signals", "danger");
+    cy.get('@alert').should('be.calledWith', 'You do not have permission to add new signals', 'danger');
     
     setPerm('create-signals', true);
     cy.get('[data-cy="events-list"').click();
@@ -52,6 +47,15 @@ describe('Intermediate Message Throw Event', () => {
     cy.get('.badge-secondary').contains('global_1').should('be.visible');
     cy.get('[data-cy="events-edit"]').should('not.exist');
     cy.get('[data-cy="events-remove"]').should('not.exist');
+    
+    setPerm('edit-signals', true);
+    setPerm('delete-signals', true);
+    
+    cy.get('[data-cy="events-list"').click();
+    selectOptionByName('[data-test="signalRef:select"]', 'global signal 1');
+
+    cy.get('[data-cy="events-edit"]').should('be.visible');
+    cy.get('[data-cy="events-remove"]').should('be.visible');
 
   });
 });


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-3247

Adds permission checks anywhere signals are configured in the modeler
![image](https://user-images.githubusercontent.com/2546850/117059725-f5188080-acd4-11eb-8709-902c9d373293.png)

See https://github.com/ProcessMaker/processmaker/pull/3790