### PR TITLE
FOUR-3253: Review and adjust if needed StartTimerEvent.spec

### DIFF
--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -20,30 +20,29 @@ describe('Start Timer Event', () => {
   const now = new Date();
   const today = now.getDate().toString().padStart(2, '0');
 
-  it('can set a specific start date', () => {
-    const toggledPeriod = moment(now).format('A') === 'AM' ? 'PM' : 'AM';
-    const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 ${toggledPeriod}`;
-
-    addStartTimerEventToPaper();
-    waitToRenderAllShapes();
-
-    cy.contains('Timing Control').click();
-    cy.get('[data-test=start-date-picker]').click();
-    cy.get('[title="Select Time"]').click();
-    cy.get('[title="Pick Hour"]').click();
-    cy.get('.hour').contains('05').click();
-    cy.get('[title="Pick Minute"]').click();
-    cy.get('.minute').contains('30').click();
-    cy.get('[title="Toggle Period"]').click();
-    cy.get('[data-test=start-date-picker]').should('have.value', expectedStartDate);
-
-  });
+  // it('can set a specific start date', () => {
+  //   const toggledPeriod = moment(now).format('A') === 'AM' ? 'PM' : 'AM';
+  //   const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 ${toggledPeriod}`;
+  //
+  //   addStartTimerEventToPaper();
+  //   waitToRenderAllShapes();
+  //
+  //   cy.contains('Timing Control').click();
+  //   cy.get('[data-test=start-date-picker]').click();
+  //   cy.get('[title="Select Time"]').click();
+  //   cy.get('[title="Pick Hour"]').click();
+  //   cy.get('.hour').contains('05').click();
+  //   cy.get('[title="Pick Minute"]').click();
+  //   cy.get('.minute').contains('30').click();
+  //   cy.get('[title="Toggle Period"]').click();
+  //   cy.get('[data-test=start-date-picker]').should('have.value', expectedStartDate);
+  //
+  // });
 
   it('can set a specific end date', () => {
-    const expectedEndDate = getPeriodicityStringUSFormattedDate(now, true);
-
     addStartTimerEventToPaper();
     waitToRenderAllShapes();
+    const expectedEndDate = getPeriodicityStringUSFormattedDate(now, true);
 
     cy.contains('Timing Control').click();
     cy.get('[data-test=end-date-picker]').click({ force: true });

--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -20,24 +20,24 @@ describe('Start Timer Event', () => {
   const now = new Date();
   const today = now.getDate().toString().padStart(2, '0');
 
-  // it('can set a specific start date', () => {
-  //   const toggledPeriod = moment(now).format('A') === 'AM' ? 'PM' : 'AM';
-  //   const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 ${toggledPeriod}`;
-  //
-  //   addStartTimerEventToPaper();
-  //   waitToRenderAllShapes();
-  //
-  //   cy.contains('Timing Control').click();
-  //   cy.get('[data-test=start-date-picker]').click();
-  //   cy.get('[title="Select Time"]').click();
-  //   cy.get('[title="Pick Hour"]').click();
-  //   cy.get('.hour').contains('05').click();
-  //   cy.get('[title="Pick Minute"]').click();
-  //   cy.get('.minute').contains('30').click();
-  //   cy.get('[title="Toggle Period"]').click();
-  //   cy.get('[data-test=start-date-picker]').should('have.value', expectedStartDate);
-  //
-  // });
+  it('can set a specific start date', () => {
+    const toggledPeriod = moment(now).format('A') === 'AM' ? 'PM' : 'AM';
+    const expectedStartDate = `${getPeriodicityStringUSFormattedDate(now)} 5:30 ${toggledPeriod}`;
+
+    addStartTimerEventToPaper();
+    waitToRenderAllShapes();
+
+    cy.contains('Timing Control').click();
+    cy.get('[data-test=start-date-picker]').click();
+    cy.get('[title="Select Time"]').click();
+    cy.get('[title="Pick Hour"]').click();
+    cy.get('.hour').contains('05').click();
+    cy.get('[title="Pick Minute"]').click();
+    cy.get('.minute').contains('30').click();
+    cy.get('[title="Toggle Period"]').click();
+    cy.get('[data-test=start-date-picker]').should('have.value', expectedStartDate);
+
+  });
 
   it('can set a specific end date', () => {
     addStartTimerEventToPaper();

--- a/tests/e2e/specs/StartTimerEvent.spec.js
+++ b/tests/e2e/specs/StartTimerEvent.spec.js
@@ -39,6 +39,7 @@ describe('Start Timer Event', () => {
 
   });
 
+
   it('can set a specific end date', () => {
     addStartTimerEventToPaper();
     waitToRenderAllShapes();


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-3253](https://processmaker.atlassian.net/browse/FOUR-3253)

The variable that stores the expected time has been moved after the UI is rendered.