### PR TITLE
Set referencs after all moddle nodes have been created

### DIFF
--- a/src/NodeInspector.js
+++ b/src/NodeInspector.js
@@ -80,7 +80,7 @@ export default class NodeInspector {
 
     } else if (value instanceof Object) {
       Object.keys(omit(value, '$type', '$config', 'markerFlags')).forEach(key => {
-        value[key] = this.setReferences(value[key], key)
+        value[key] = this.setReferences(value[key], key);
       });
     } 
 

--- a/src/NodeInspector.js
+++ b/src/NodeInspector.js
@@ -10,6 +10,7 @@ export default class NodeInspector {
     this.options = Object.assign({
       prefix: this.nodeIdGenerator.generate()[0],
     }, options);
+    this.createdModdleNodes = {};
   }
 
   getDefinitionProps(node) {
@@ -47,19 +48,53 @@ export default class NodeInspector {
             delete obj[prop];
           }
           return obj;
-        }, node || moddle.create(value.$type, { id: this.generateId() }));
+        }, node || this.createModdleNode(moddle, value));
       } catch (e) {
         throw `Unable to create moddle node of type "${value.$type}" \n ${e}`;
       }
     }
-    const isReference = key !== undefined && (key.substr(key.length-3) === 'Ref' || key.substr(key.length-4) === 'Refs');
-    if (isReference) {
-      value = value instanceof Array ? value.map(id => this.findById(id)) : this.findById(value);
-    }
+    
     if (node && key !== undefined && value !== undefined && value !== null) {
       node[key] = value;
     }
+
     return value;
+  }
+
+  createModdleNode(moddle, value) {
+    const node = moddle.create(value.$type, { id: this.generateId() });
+    if (value.id) {
+      this.createdModdleNodes[value.id] = node;
+    }
+    return node;
+  }
+
+  setReferences(value, key = null) {
+    if (value === undefined) return;
+
+    if (this.isReference(key)) {
+      value = value instanceof Array ? value.map(id => this.findReference(id)) : this.findReference(value);
+
+    } else if (value instanceof Array) {
+      value = value.map(item => this.setReferences(item, null));
+
+    } else if (value instanceof Object) {
+      Object.keys(omit(value, '$type', '$config', 'markerFlags')).forEach(key => {
+        value[key] = this.setReferences(value[key], key)
+      });
+    } 
+
+    return value;
+  }
+
+  isReference(key)
+  {
+    return !!key && (key.substr(key.length-3) === 'Ref' || key.substr(key.length-4) === 'Refs');
+  }
+
+  findReference(id)
+  {
+    return this.createdModdleNodes[id] || this.findById(id);
   }
 
   generateId() {

--- a/src/components/inspectors/LoopCharacteristics.js
+++ b/src/components/inspectors/LoopCharacteristics.js
@@ -3,9 +3,9 @@ import NodeInspector from '@/NodeInspector';
 import omit from 'lodash/omit';
 
 export const loopCharacteristicsHandler = function(value, node, setNodeProp, moddle, definitions) {
-  
   const nodeInspector = new NodeInspector(definitions, { prefix: `${node.definition.id}_inner` });
-  const update = nodeInspector.setDefinitionProps(value.$loopCharactetistics, setNodeProp, moddle, {});
+  let update = nodeInspector.setDefinitionProps(value.$loopCharactetistics, setNodeProp, moddle, {});
+  update = nodeInspector.setReferences(update);
   if (update.loopCharacteristics) {
     delete node.definition.loopCharacteristics;
     setNodeProp(node, 'loopCharacteristics', update.loopCharacteristics);


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-3304

The original part of the code that resolved references was being run before some of the references were created. This saves the created references and resolves them after the definitions are processed