### PR TITLE
Fix remove pools

### DIFF
--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -39,7 +39,6 @@ export default {
   methods: {
     removeFlows,
     removeShape() {
-      this.removeFlows(this.graph, this.shape);
       this.$emit('remove-node', this.node);
     },
     removePoolLaneShape() {

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -39,6 +39,8 @@ export default {
   methods: {
     removeFlows,
     removeShape() {
+      // @todo this should be handled by the Modeler.vue
+      this.removeFlows(this.graph, this.shape);
       this.$emit('remove-node', this.node);
     },
     removePoolLaneShape() {

--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -8,6 +8,58 @@ export function removeFlows(graph, shape) {
   linkShapes.forEach(shape => this.$emit('remove-node', shape.component.node));
 }
 
+// Remove the incoming and outgoing flows of a node
+export function removeNodeFlows(node, modeler) {
+  if (node.definition.incoming) {
+    node.definition.incoming.forEach((flow) => {
+      const node = modeler.nodes.find(node => node.definition === flow);
+      modeler.removeNode(node);
+    });
+  }
+  if (node.definition.outgoing) {
+    node.definition.outgoing.forEach((flow) => {
+      const node = modeler.nodes.find(node => node.definition === flow);
+      modeler.removeNode(node);
+    });
+  }
+}
+// Remove the associations of a node
+export function removeNodeMessageFlows(node, modeler) {
+  const linkedMessages = modeler.nodes.filter(n => {
+    if (n.definition.sourceRef) {
+      if (n.definition.sourceRef === node.definition) {
+        return true;
+      }
+    }
+    if (n.definition.targetRef) {
+      if (n.definition.targetRef === node.definition) {
+        return true;
+      }
+    }
+  });
+  linkedMessages.forEach((messageFlow) => {
+    modeler.removeNode(messageFlow);
+  });
+}
+// Remove the associations of a node
+export function removeNodeAssociations(node, modeler) {
+  const linkedAssociations = modeler.nodes.filter(n => {
+    if (n.definition.sourceRef) {
+      if (n.definition.sourceRef === node.definition) {
+        return true;
+      }
+    }
+    if (n.definition.targetRef) {
+      if (n.definition.targetRef === node.definition) {
+        return true;
+      }
+    }
+  });
+  linkedAssociations.forEach((association) => {
+    modeler.removeNode(association);
+  });
+}
+
 export function removeBoundaryEvents(graph, node, removeNode) {
   const nodeShape = graph.getCells().find(el => el.component && el.component.node === node);
 
@@ -25,6 +77,8 @@ export function removeOutgoingAndIncomingRefsToFlow(node){
   if (node.isBpmnType(dataOutputAssociationType, dataInputAssociationType)) {
     return;
   }
+  // eslint-disable-next-line no-console
+  console.log('  removeOutgoingAndIncomingRefsToFlow', node.id, node.type, node);
 
   /* Modify source and target refs to remove incoming and outgoing properties pointing to this link */
   const { sourceRef, targetRef } = node.definition;

--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -77,8 +77,6 @@ export function removeOutgoingAndIncomingRefsToFlow(node){
   if (node.isBpmnType(dataOutputAssociationType, dataInputAssociationType)) {
     return;
   }
-  // eslint-disable-next-line no-console
-  console.log('  removeOutgoingAndIncomingRefsToFlow', node.id, node.type, node);
 
   /* Modify source and target refs to remove incoming and outgoing properties pointing to this link */
   const { sourceRef, targetRef } = node.definition;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -142,7 +142,7 @@ import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import TimerEventNode from '@/components/nodes/timerEventNode';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
-import { removeOutgoingAndIncomingRefsToFlow, removeBoundaryEvents, removeSourceDefault } from '@/components/crown/utils';
+import { removeNodeFlows, removeNodeMessageFlows, removeNodeAssociations, removeOutgoingAndIncomingRefsToFlow, removeBoundaryEvents, removeSourceDefault } from '@/components/crown/utils';
 import { getInvalidNodes } from '@/components/modeler/modelerUtils';
 import { NodeMigrator } from '@/components/modeler/NodeMigrator';
 
@@ -779,12 +779,20 @@ export default {
         });
       });
     },
-    async removeNode(node) {
+    async removeNode(node, { removeRelationships = true } = {}) {
+      // eslint-disable-next-line no-console
+      console.log('removeNode', node.type, node.definition.id);
+      if (removeRelationships) {
+        removeNodeFlows(node, this);
+        removeNodeMessageFlows(node, this);
+        removeNodeAssociations(node, this);
+      }
       removeOutgoingAndIncomingRefsToFlow(node);
       removeBoundaryEvents(this.graph, node, this.removeNode);
       removeSourceDefault(node);
 
-      this.removeNodeFromLane(node);
+      this.removeNodesFromLane(node);
+      this.removeNodesFromPool(node);
       store.commit('removeNode', node);
       store.commit('highlightNode', this.processNode);
       await this.$nextTick();
@@ -800,7 +808,7 @@ export default {
             nodeThatWillBeReplaced: node,
           });
 
-          await this.removeNode(node);
+          await this.removeNode(node, { removeRelationships: false });
           this.highlightNode(newNode);
         });
       });
@@ -823,7 +831,7 @@ export default {
       undoRedoStore.commit('enableSavingState');
       this.pushToUndoStack();
     },
-    removeNodeFromLane(node) {
+    removeNodesFromLane(node) {
       const containingLane = node.pool && node.pool.component.laneSet &&
         node.pool.component.laneSet.get('lanes').find(lane => {
           return lane.get('flowNodeRef').includes(node.definition);
@@ -834,6 +842,26 @@ export default {
       }
 
       pull(containingLane.get('flowNodeRef'), node.definition);
+    },
+    removeNodesFromPool(node) {
+      if (node.type === 'processmaker-modeler-pool' && node.definition.processRef) {
+        if (node.definition.processRef.artifacts) {
+          node.definition.processRef.artifacts.forEach(artifact => {
+            const nodeToRemove = this.nodes.find(n => n.definition === artifact);
+            if (nodeToRemove) {
+              this.removeNode(nodeToRemove);
+            }
+          });
+        }
+        if (node.definition.processRef.flowElements) {
+          node.definition.processRef.flowElements.forEach(flowElement => {
+            const nodeToRemove = this.nodes.find(n => n.definition === flowElement);
+            if (nodeToRemove) {
+              this.removeNode(nodeToRemove);
+            }
+          });
+        }
+      }
     },
     handleResize() {
       const { clientWidth, clientHeight } = this.$el.parentElement;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -780,8 +780,6 @@ export default {
       });
     },
     async removeNode(node, { removeRelationships = true } = {}) {
-      // eslint-disable-next-line no-console
-      console.log('removeNode', node.type, node.definition.id);
       if (removeRelationships) {
         removeNodeFlows(node, this);
         removeNodeMessageFlows(node, this);

--- a/tests/e2e/fixtures/AssociationInsidePool.after.xml
+++ b/tests/e2e/fixtures/AssociationInsidePool.after.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event" />
+    <bpmn:textAnnotation id="node_3">
+      <bpmn:text>Text Annotation</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="80" y="110" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="170" y="250" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="440" y="160" width="150" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/AssociationInsidePool.xml
+++ b/tests/e2e/fixtures/AssociationInsidePool.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_6</bpmn:incoming>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_6" sourceRef="node_2" targetRef="node_4" />
+    <bpmn:textAnnotation id="node_3">
+      <bpmn:text>Text Annotation</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="node_7" associationDirection="None" sourceRef="node_3" targetRef="node_4" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="80" y="110" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="170" y="250" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="440" y="160" width="150" height="30" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="290" y="230" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="188" y="268" />
+        <di:waypoint x="348" y="268" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_7_di" bpmnElement="node_7">
+        <di:waypoint x="445" y="174.01" />
+        <di:waypoint x="348" y="268" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-DeleteLastPool.after.xml
+++ b/tests/e2e/fixtures/Pools-DeleteLastPool.after.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-DeleteLastPool.xml
+++ b/tests/e2e/fixtures/Pools-DeleteLastPool.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_3" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_4" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_9</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_6" sourceRef="node_3" targetRef="node_4" />
+    <bpmn:endEvent id="node_7" name="End Event">
+      <bpmn:incoming>node_9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_9" sourceRef="node_4" targetRef="node_7" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_2" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="90" y="100" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="170" y="220" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="300" y="200" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="188" y="238" />
+        <di:waypoint x="358" y="238" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+        <dc:Bounds x="510" y="220" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_9_di" bpmnElement="node_9">
+        <di:waypoint x="358" y="238" />
+        <di:waypoint x="528" y="238" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-DeletePoolCommonSignalEvents.after.xml
+++ b/tests/e2e/fixtures/Pools-DeletePoolCommonSignalEvents.after.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_3" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:endEvent id="node_9" name="Signal End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:signalEventDefinition signalRef="global_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" name="flow2" sourceRef="node_3" targetRef="node_9" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:signal id="global_1" name="global signal 1" />
+  <bpmn:signal id="global_2" name="global signal 2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="90" y="110" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="160" y="230" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="290" y="210" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="178" y="248" />
+        <di:waypoint x="348" y="248" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="500" y="230" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="348" y="248" />
+        <di:waypoint x="518" y="248" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-DeletePoolCommonSignalEvents.xml
+++ b/tests/e2e/fixtures/Pools-DeletePoolCommonSignalEvents.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_3" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:endEvent id="node_9" name="Signal End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+      <bpmn:signalEventDefinition signalRef="global_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_8" name="flow2" sourceRef="node_3" targetRef="node_9" />
+    <bpmn:sequenceFlow id="node_17" name="flow3" sourceRef="node_14" targetRef="node_15" />
+    <bpmn:sequenceFlow id="node_21" name="flow4" sourceRef="node_15" targetRef="node_19" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+    <bpmn:participant id="node_12" name="Pool" processRef="process_2" />
+  </bpmn:collaboration>
+  <bpmn:signal id="global_1" name="global signal 1" />
+  <bpmn:process id="process_2">
+    <bpmn:startEvent id="node_14" name="Signal Start Event">
+      <bpmn:outgoing>node_17</bpmn:outgoing>
+      <bpmn:signalEventDefinition />
+    </bpmn:startEvent>
+    <bpmn:task id="node_15" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_17</bpmn:incoming>
+      <bpmn:outgoing>node_21</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_19" name="Signal End Event">
+      <bpmn:incoming>node_21</bpmn:incoming>
+      <bpmn:signalEventDefinition signalRef="global_2" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:signal id="global_2" name="global signal 2" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="90" y="110" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="160" y="230" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="290" y="210" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="178" y="248" />
+        <di:waypoint x="348" y="248" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="500" y="230" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="348" y="248" />
+        <di:waypoint x="518" y="248" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+        <dc:Bounds x="90" y="440" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_14_di" bpmnElement="node_14">
+        <dc:Bounds x="170" y="570" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_15_di" bpmnElement="node_15">
+        <dc:Bounds x="310" y="550" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_17_di" bpmnElement="node_17">
+        <di:waypoint x="188" y="588" />
+        <di:waypoint x="368" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_19_di" bpmnElement="node_19">
+        <dc:Bounds x="520" y="570" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_21_di" bpmnElement="node_21">
+        <di:waypoint x="368" y="588" />
+        <di:waypoint x="538" y="588" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-FlowMessageBetweenPools.after.xml
+++ b/tests/e2e/fixtures/Pools-FlowMessageBetweenPools.after.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="node_4" name="Intermediate Message Throw Event">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="node_4_message" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_4" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmn:message id="node_4_message" name="node_4_message" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="100" y="90" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="200" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="400" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="218" y="228" />
+        <di:waypoint x="418" y="228" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/Pools-FlowMessageBetweenPools.xml
+++ b/tests/e2e/fixtures/Pools-FlowMessageBetweenPools.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="node_4" name="Intermediate Message Throw Event">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="node_4_message" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_4" />
+    <bpmn:sequenceFlow id="node_12" name="flow2" sourceRef="node_9" targetRef="node_10" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+    <bpmn:participant id="node_7" name="Pool" processRef="process_2" />
+    <bpmn:messageFlow id="node_14" name="" sourceRef="node_4" targetRef="node_9" />
+  </bpmn:collaboration>
+  <bpmn:message id="node_4_message" name="node_4_message" />
+  <bpmn:process id="process_2">
+    <bpmn:startEvent id="node_9" name="Message Start Event">
+      <bpmn:outgoing>node_12</bpmn:outgoing>
+      <bpmn:messageEventDefinition />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="node_10" name="End Event">
+      <bpmn:incoming>node_12</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="100" y="90" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="200" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="400" y="210" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="218" y="228" />
+        <di:waypoint x="418" y="228" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="node_7_di" bpmnElement="node_7">
+        <dc:Bounds x="100" y="430" width="600" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="400" y="500" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="400" y="620" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_12_di" bpmnElement="node_12">
+        <di:waypoint x="418" y="518" />
+        <di:waypoint x="418" y="638" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_14_di" bpmnElement="node_14">
+        <di:waypoint x="418" y="228" />
+        <di:waypoint x="418" y="518" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/TwoPools.after.xml
+++ b/tests/e2e/fixtures/TwoPools.after.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="node_2" name="Start Event">
+      <bpmn:outgoing>node_6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="node_3" name="Form Task" pm:assignment="requester">
+      <bpmn:incoming>node_6</bpmn:incoming>
+      <bpmn:outgoing>node_8</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="node_4" name="End Event">
+      <bpmn:incoming>node_8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_3" />
+    <bpmn:sequenceFlow id="node_8" name="flow2" sourceRef="node_3" targetRef="node_4" />
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+  </bpmn:collaboration>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="80" y="90" width="366" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+        <dc:Bounds x="130" y="180" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="220" y="160" width="116" height="76" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="390" y="180" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+        <di:waypoint x="148" y="198" />
+        <di:waypoint x="278" y="198" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+        <di:waypoint x="278" y="198" />
+        <di:waypoint x="408" y="198" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/TwoPools.xml
+++ b/tests/e2e/fixtures/TwoPools.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+    <bpmn:process id="Process_1" isExecutable="true">
+        <bpmn:startEvent id="node_2" name="Start Event">
+            <bpmn:outgoing>node_6</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:task id="node_3" name="Form Task" pm:assignment="requester">
+            <bpmn:incoming>node_6</bpmn:incoming>
+            <bpmn:outgoing>node_8</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:endEvent id="node_4" name="End Event">
+            <bpmn:incoming>node_8</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="node_6" name="flow1" sourceRef="node_2" targetRef="node_3" />
+        <bpmn:sequenceFlow id="node_8" name="flow2" sourceRef="node_3" targetRef="node_4" />
+        <bpmn:sequenceFlow id="node_14" name="flow3" sourceRef="node_10" targetRef="node_11" />
+        <bpmn:sequenceFlow id="node_16" name="flow4" sourceRef="node_11" targetRef="node_12" />
+    </bpmn:process>
+    <bpmn:collaboration id="collaboration_0">
+        <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+        <bpmn:participant id="node_9" name="Pool" processRef="process_2" />
+    </bpmn:collaboration>
+    <bpmn:process id="process_2">
+        <bpmn:startEvent id="node_10" name="Start Event">
+            <bpmn:outgoing>node_14</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:task id="node_11" name="Form Task" pm:assignment="requester">
+            <bpmn:incoming>node_14</bpmn:incoming>
+            <bpmn:outgoing>node_16</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:endEvent id="node_12" name="End Event">
+            <bpmn:incoming>node_16</bpmn:incoming>
+        </bpmn:endEvent>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+            <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+                <dc:Bounds x="80" y="90" width="366" height="200" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_2_di" bpmnElement="node_2">
+                <dc:Bounds x="130" y="180" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+                <dc:Bounds x="220" y="160" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+                <dc:Bounds x="390" y="180" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_6_di" bpmnElement="node_6">
+                <di:waypoint x="148" y="198" />
+                <di:waypoint x="278" y="198" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_8_di" bpmnElement="node_8">
+                <di:waypoint x="278" y="198" />
+                <di:waypoint x="408" y="198" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+                <dc:Bounds x="80" y="310" width="376" height="200" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+                <dc:Bounds x="130" y="390" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_11_di" bpmnElement="node_11">
+                <dc:Bounds x="220" y="370" width="116" height="76" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="node_12_di" bpmnElement="node_12">
+                <dc:Bounds x="390" y="390" width="36" height="36" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="node_14_di" bpmnElement="node_14">
+                <di:waypoint x="148" y="408" />
+                <di:waypoint x="278" y="408" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="node_16_di" bpmnElement="node_16">
+                <di:waypoint x="278" y="408" />
+                <di:waypoint x="408" y="408" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/specs/PoolsAdvanced.spec.js
+++ b/tests/e2e/specs/PoolsAdvanced.spec.js
@@ -31,4 +31,17 @@ describe('Pools', () => {
       assertDownloadedXmlContainsExpected(atob(data));
     });
   });
+
+  it('Case 3 Delete a Pool, should remove event messages too', () => {
+    uploadXml('Pools-FlowMessageBetweenPools.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.modeler.bpmn.pool"]:visible').eq(1)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('Pools-FlowMessageBetweenPools.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
+    });
+  });
 });

--- a/tests/e2e/specs/PoolsAdvanced.spec.js
+++ b/tests/e2e/specs/PoolsAdvanced.spec.js
@@ -44,4 +44,17 @@ describe('Pools', () => {
       assertDownloadedXmlContainsExpected(atob(data));
     });
   });
+
+  it('Case 4 Delete a Pool, should remove inner flow events but keep signals definitions, user should remove signals using the UI', () => {
+    uploadXml('Pools-DeletePoolCommonSignalEvents.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.modeler.bpmn.pool"]:visible').eq(1)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('Pools-DeletePoolCommonSignalEvents.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
+    });
+  });
 });

--- a/tests/e2e/specs/PoolsAdvanced.spec.js
+++ b/tests/e2e/specs/PoolsAdvanced.spec.js
@@ -57,4 +57,17 @@ describe('Pools', () => {
       assertDownloadedXmlContainsExpected(atob(data));
     });
   });
+
+  it('Case 5 Delete the last Pool, should back to the default empty process', () => {
+    uploadXml('Pools-DeleteLastPool.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.modeler.bpmn.pool"]:visible').eq(0)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('Pools-DeleteLastPool.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
+    });
+  });
 });

--- a/tests/e2e/specs/PoolsAdvanced.spec.js
+++ b/tests/e2e/specs/PoolsAdvanced.spec.js
@@ -1,0 +1,21 @@
+import {
+  assertDownloadedXmlContainsExpected,
+  getCrownButtonForElement,
+  uploadXml,
+  waitToRenderAllShapes,
+} from '../support/utils';
+
+describe('Pools', () => {
+  it('Case 1 Delete a Pool should remove all elements inside it', () => {
+    uploadXml('TwoPools.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.modeler.bpmn.pool"]:visible').eq(1)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('TwoPools.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
+    });
+  });
+});

--- a/tests/e2e/specs/PoolsAdvanced.spec.js
+++ b/tests/e2e/specs/PoolsAdvanced.spec.js
@@ -18,4 +18,17 @@ describe('Pools', () => {
       assertDownloadedXmlContainsExpected(atob(data));
     });
   });
+
+  it('Case 2 Delete a Task inside a Pool, associations and flow nodes should be removed', () => {
+    uploadXml('AssociationInsidePool.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.components.nodes.task.Shape"]:visible').eq(0)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('AssociationInsidePool.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
+    });
+  });
 });


### PR DESCRIPTION
Fixes:
- http://tickets.pm4overflow.com/tickets/593
- http://tickets.pm4overflow.com/tickets/553
- http://tickets.pm4overflow.com/tickets/556
- http://tickets.pm4overflow.com/tickets/578
- http://tickets.pm4overflow.com/tickets/596

This PR includes:

- Delete elements contained in loops when loops are deleted
- Add tests for:
  - When Delete a Pool should remove all elements inside it
  - When Delete a Task inside a Pool, associations and flows connected to that Task should be removed
  - When Delete a Pool, message flows that are connected to elements inside the removed pool, should also be removed
  - When Delete a Pool, it should remove inner flow events (Intermediate Signal, End Signal) but keep signals definitions (ex. global_signal_1, signal_2), user should remove signals using the UI
  - When Delete the last Pool, the diagram should back to the default empty process

Tests:
https://user-images.githubusercontent.com/8028650/129805367-9ff8ff74-cc3d-47a7-a8c3-bc5311121bf4.mp4

Fixes:

https://user-images.githubusercontent.com/8028650/129809477-f971c933-0cf3-461b-90d8-5cac7d73aacc.mp4


https://user-images.githubusercontent.com/8028650/129810135-7e1ee23c-20c2-4517-a3ab-051c4bec36b4.mp4


https://user-images.githubusercontent.com/8028650/129809487-26935998-3f19-4fc6-b0c3-404936b6c6df.mp4


https://user-images.githubusercontent.com/8028650/129809488-518b91e5-e71b-4af1-aba3-ed99d365860b.mp4


https://user-images.githubusercontent.com/8028650/129809489-5a038d20-8ced-4cf8-9bb5-b120c1cde0aa.mp4

