### PR TITLE
Validate CallActivity Process/StartEvent

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -342,6 +342,9 @@ export default {
       });
     },
     async validateBpmnDiagram() {
+      if (!store.getters.globalProcesses || store.getters.globalProcesses.length === 0) {
+        await store.dispatch('fetchGlobalProcesses');
+      }
       this.validationErrors = await this.linter.lint(this.definitions);
       this.$emit('validate', this.validationErrors);
     },

--- a/src/store.js
+++ b/src/store.js
@@ -135,6 +135,7 @@ export default new Vuex.Store({
           },
         });
         commit('setGlobalProcesses', data.data);
+        window.ProcessMaker.globalProcesses = data.data;
       } catch (error) {
         /* Ignore error */
       }


### PR DESCRIPTION
Fixes: https://processmaker.atlassian.net/browse/FOUR-3910
Ticket: http://tickets.pm4overflow.com/tickets/724
Requires: https://github.com/ProcessMaker/bpmnlint-plugin/pull/16

This PR includes:
- In CallActivity inspector: Filter start events that are not empty, like signal start event, web entries, etc.
- Add validation to check that the selected StartEvent is an Empty Start Event

