### PR TITLE
  FOUR-4331: Error in auto-validate with Data connector

### DIFF
--- a/src/components/nodes/subProcess/SubProcessFormSelect.vue
+++ b/src/components/nodes/subProcess/SubProcessFormSelect.vue
@@ -91,7 +91,8 @@ export default {
   methods: {
     filterValidProcesses(processes) {
       return processes.filter(process => {
-        return this.filterValidStartEvents(process.events).length > 0;
+        return process.category.is_system == false
+            && this.filterValidStartEvents(process.events).length > 0;
       });
     },
     filterValidStartEvents(events) {

--- a/src/setup/mockProcesses.json
+++ b/src/setup/mockProcesses.json
@@ -23,7 +23,15 @@
           "ownerProcessId": "ProcessId",
           "ownerProcessName": "Process Name"
         }
-      ]
+      ],
+      "category": {
+        "id": 1,
+        "name": "Uncategorized",
+        "status": "ACTIVE",
+        "is_system": 0,
+        "created_at": "2021-09-01T06:11:30-07:00",
+        "updated_at": "2021-09-01T06:11:30-07:00"
+      }
     },
     {
       "id": 3,
@@ -48,7 +56,15 @@
           "ownerProcessId": "ProcessId",
           "ownerProcessName": "Process Name"
         }
-      ]
+      ],
+      "category": {
+        "id": 1,
+        "name": "Uncategorized",
+        "status": "ACTIVE",
+        "is_system": 0,
+        "created_at": "2021-09-01T06:11:30-07:00",
+        "updated_at": "2021-09-01T06:11:30-07:00"
+      }
     },
     {
       "id": 5,
@@ -93,7 +109,15 @@
           "ownerProcessId": "Subprocess2",
           "ownerProcessName": "Subprocess Two"
         }
-      ]
+      ],
+      "category": {
+        "id": 1,
+        "name": "Uncategorized",
+        "status": "ACTIVE",
+        "is_system": 0,
+        "created_at": "2021-09-01T06:11:30-07:00",
+        "updated_at": "2021-09-01T06:11:30-07:00"
+      }
     },
     {
       "id": 1,
@@ -107,7 +131,15 @@
       "deleted_at": null,
       "created_at": "2019-04-01T16:02:14+00:00",
       "updated_at": "2019-04-02T19:11:03+00:00",
-      "events": []
+      "events": [],
+      "category": {
+        "id": 1,
+        "name": "Uncategorized",
+        "status": "ACTIVE",
+        "is_system": 0,
+        "created_at": "2021-09-01T06:11:30-07:00",
+        "updated_at": "2021-09-01T06:11:30-07:00"
+      }
     },
     {
       "id": 13,
@@ -132,7 +164,15 @@
           "ownerProcessId": "Subprocess1",
           "ownerProcessName": "Subprocess One"
         }
-      ]
+      ],
+      "category": {
+        "id": 1,
+        "name": "Uncategorized",
+        "status": "ACTIVE",
+        "is_system": 0,
+        "created_at": "2021-09-01T06:11:30-07:00",
+        "updated_at": "2021-09-01T06:11:30-07:00"
+      }
     }
   ],
   "meta": {

--- a/src/store.js
+++ b/src/store.js
@@ -130,8 +130,8 @@ export default new Vuex.Store({
           params: {
             order_direction: 'asc',
             per_page: 1000,
-            status: 'active',
-            include: 'events',
+            status: 'all',
+            include: 'events,category',
           },
         });
         commit('setGlobalProcesses', data.data);


### PR DESCRIPTION
As part of fixes for [https://processmaker.atlassian.net/browse/FOUR-4331](https://processmaker.atlassian.net/browse/FOUR-4331)

- Now gets all active processes (system and not system) so that system processes are considered for validation if a callActivity is using an existing process.
- Include the category attribute in the process list for cypress tests
- Filter system processes from the list of available processes for selecting a sub-process