### PR TITLE
FOUR-4932: Flow elements have a button for creating new flow eleme (For 4.1 version)

### DIFF
--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -26,6 +26,7 @@ const dontShowOn = [
   'processmaker-modeler-signal-end-event',
   'processmaker-modeler-terminate-end-event',
   'processmaker-modeler-text-annotation',
+  'processmaker-modeler-sequence-flow',
 ];
 
 export default {


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-4932](https://processmaker.atlassian.net/browse/FOUR-4932)

The flow icon has been removed from the sequence flow's crown.

![image](https://user-images.githubusercontent.com/14875032/146803960-6d88c2b8-6777-474e-a2bf-d297fae627ae.png)