### PR TITLE
[FOUR-4933] When clicking on Flow for the first time, console.error appears in the console

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -44,6 +44,7 @@ export default {
           line: { stroke: '#5096db' },
           '.joint-highlight-stroke': { 'display': 'none' },
         });
+        this.shapeView.showTools();
       } else {
         resetShapeColor(this.shape);
         this.shapeView.hideTools();
@@ -244,7 +245,9 @@ export default {
     this.setSource(this.sourceShape);
 
     this.$once('click', () => {
-      this.setupLinkTools();
+      this.$nextTick(() => {
+        this.setupLinkTools();
+      });
     });
 
     const targetRef = this.getTargetRef

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -44,7 +44,6 @@ export default {
           line: { stroke: '#5096db' },
           '.joint-highlight-stroke': { 'display': 'none' },
         });
-        this.shapeView.showTools();
       } else {
         resetShapeColor(this.shape);
         this.shapeView.hideTools();


### PR DESCRIPTION
## Issue & Reproduction Steps
When clicking on a Flow for the first time, the console would error out saying that the highlight watcher has encountered an issue when checking the length of a null property.
@caleeli pointed out in the ticket that this was working until a dependency bump from 3.2 to 3.4.x for `joint-js`

* Create a Start event
* Create a Task
* Click on the Start Event
* Click flow and click the task
* Click the Flow or link between the two

Expected behavior: 
No console errors shouldn't be shown when clicking the Flow

Actual behavior: 
Console.error showing in the console

## Solution
- Added another `$nextTick` since it looked like the data (vertices) wasn't there yet.
Error has been removed and the vertices toolbox shows

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-4933

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
