### PR TITLE
Bugfix-5102 Fix missing dataInput reference v4.2

### DIFF
--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -21,6 +21,7 @@ import linkConfig from '@/mixins/linkConfig';
 import get from 'lodash/get';
 import associationHead from '!!url-loader!@/assets/association-head.svg';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
+import { getOrFindDataInput, removeDataInput } from '@/components/crown/utils';
 import { pull } from 'lodash';
 
 export default {
@@ -99,8 +100,9 @@ export default {
     },
     updateDefinitionLinks() {
       const targetShape = this.shape.getTargetElement();
+      const dataInput = getOrFindDataInput(this.moddle, targetShape.component.node, this.sourceNode.definition);
+      this.node.definition.set('targetRef', dataInput);
       this.node.definition.set('sourceRef', [this.sourceNode.definition]);
-      this.node.definition.set('targetRef', null);
       targetShape.component.node.definition.set('dataInputAssociations', [this.node.definition]);
     },
   },
@@ -127,6 +129,7 @@ export default {
     this.shape.component = this;
   },
   destroyed() {
+    removeDataInput(this.targetNode, this.sourceNode.definition);
     pull(this.targetNode.definition.get('dataInputAssociations'), this.node.definition);
   },
 };

--- a/tests/e2e/specs/DataObjectDataStore.spec.js
+++ b/tests/e2e/specs/DataObjectDataStore.spec.js
@@ -1,5 +1,6 @@
 import {
   assertDownloadedXmlContainsExpected, assertDownloadedXmlDoesNotContainExpected, assertElementsAreConnected,
+  assertDownloadedXmlMatch,
   connectNodesWithFlow,
   dragFromSourceToDest, getCrownButtonForElement,
   getElementAtPosition, getNumberOfLinks, uploadXml, waitToRenderAllShapes,
@@ -83,14 +84,14 @@ describe('Data Objects and Data Stores', () => {
 
       const name = nodeType === 'processmaker-modeler-data-object' ? 'Data Object' : 'Data Store';
       getNumberOfLinks().should('equal', 1);
-      assertDownloadedXmlContainsExpected(`
+      assertDownloadedXmlMatch(`
         <bpmn:task id="node_2" name="Form Task" pm:assignment="requester">
-          <bpmn:ioSpecification id="node_5_1">
+          <bpmn:ioSpecification id="*">
             <bpmn:dataInput id="data_input_node_3" name="${name}" isCollection="false" />
-            <bpmn:inputSet id="node_7_3">
+            <bpmn:inputSet id="*">
               <bpmn:dataInputRefs>data_input_node_3</bpmn:dataInputRefs>
             </bpmn:inputSet>
-            <bpmn:outputSet id="node_8_4" />
+            <bpmn:outputSet id="*" />
           </bpmn:ioSpecification>
           <bpmn:dataInputAssociation id="node_4">
             <bpmn:sourceRef>node_3</bpmn:sourceRef>

--- a/tests/e2e/specs/DataObjectDataStore.spec.js
+++ b/tests/e2e/specs/DataObjectDataStore.spec.js
@@ -81,11 +81,20 @@ describe('Data Objects and Data Stores', () => {
       dragFromSourceToDest(nodeType, dataPosition);
       connectNodesWithFlow('association-flow-button', dataPosition, taskPosition);
 
+      const name = nodeType === 'processmaker-modeler-data-object' ? 'Data Object' : 'Data Store';
       getNumberOfLinks().should('equal', 1);
       assertDownloadedXmlContainsExpected(`
         <bpmn:task id="node_2" name="Form Task" pm:assignment="requester">
+          <bpmn:ioSpecification id="node_5_1">
+            <bpmn:dataInput id="data_input_node_3" name="${name}" isCollection="false" />
+            <bpmn:inputSet id="node_7_3">
+              <bpmn:dataInputRefs>data_input_node_3</bpmn:dataInputRefs>
+            </bpmn:inputSet>
+            <bpmn:outputSet id="node_8_4" />
+          </bpmn:ioSpecification>
           <bpmn:dataInputAssociation id="node_4">
             <bpmn:sourceRef>node_3</bpmn:sourceRef>
+            <bpmn:targetRef>data_input_node_3</bpmn:targetRef>
           </bpmn:dataInputAssociation>
         </bpmn:task>
       `);
@@ -101,6 +110,7 @@ describe('Data Objects and Data Stores', () => {
     assertDownloadedXmlContainsExpected(`
       <bpmn:dataInputAssociation id="node_4">
         <bpmn:sourceRef>node_3</bpmn:sourceRef>
+        <bpmn:targetRef>data_input_node_3</bpmn:targetRef>
       </bpmn:dataInputAssociation>
     `);
 
@@ -121,6 +131,7 @@ describe('Data Objects and Data Stores', () => {
     assertDownloadedXmlDoesNotContainExpected(`
       <bpmn:dataInputAssociation id="node_4">
         <bpmn:sourceRef>node_3</bpmn:sourceRef>
+        <bpmn:targetRef>data_input_node_3</bpmn:targetRef>
       </bpmn:dataInputAssociation>
     `);
 


### PR DESCRIPTION
## Issue & Reproduction Steps

- Create a new process
- Add a Task
- Add a Data Object (or Data Store)
- Connect from Data Object to Task
- Save the process

**Expected behavior:** 
The process should be saved without missing DataInput Schema Validation errors.
e.g.
```
  <bpmn:process id="Process_1" isExecutable="true">
    <bpmn:task id="node_1" name="Form Task" pm:assignment="requester">
      <bpmn:ioSpecification id="node_4_1">
        <bpmn:dataInput id="data_input_node_2" name="Data Object" />
        <bpmn:inputSet id="node_6_3">
          <bpmn:dataInputRefs>data_input_node_2</bpmn:dataInputRefs>
        </bpmn:inputSet>
        <bpmn:outputSet id="node_7_4" />
      </bpmn:ioSpecification>
      <bpmn:dataInputAssociation id="node_3">
        <bpmn:sourceRef>node_2</bpmn:sourceRef>
        <bpmn:targetRef>data_input_node_2</bpmn:targetRef>
      </bpmn:dataInputAssociation>
    </bpmn:task>
    <bpmn:dataObjectReference id="node_2" name="Data Object" />
  </bpmn:process>
```
**Actual behavior:** 
The process does not include the required data input references producing Schema Validation errors (Missing targetRef).
e.g.
```
  <bpmn:process id="Process_1" isExecutable="true">
    <bpmn:task id="node_1" name="Form Task" pm:assignment="requester">
      <bpmn:dataInputAssociation id="node_3">
        <bpmn:sourceRef>node_2</bpmn:sourceRef>
      </bpmn:dataInputAssociation>
    </bpmn:task>
    <bpmn:dataObjectReference id="node_2" name="Data Object" />
  </bpmn:process>
```

## Solution
- When connecting a Data Object(or Data Store) add the missing **targetRef** and required references.
- When removing the Data Object or disconnecting from the Task, only the references.

## How to Test
- Create a new process
- Add a Task
- Add a Data Object (or Data Store)
- Connect from Data Object to Task
- Save the process
- A well designed process should be saved without validation errors

![image](https://user-images.githubusercontent.com/8028650/149542176-64a0627b-64c0-41c9-9641-42ca400dd59d.png)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5102

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
