### PR TITLE
FOUR-5145: Subprocess does not have option of process

### DIFF
--- a/src/components/nodes/subProcess/SubProcessFormSelect.vue
+++ b/src/components/nodes/subProcess/SubProcessFormSelect.vue
@@ -73,6 +73,13 @@ export default {
       if (!this.selectedProcess) { return []; }
       return this.filterValidStartEvents(this.selectedProcess.events);
     },
+    currentProcessId() {
+      const match = window.location.href.match(/modeler\/(\d+)/);
+      if (match && match[1]) {
+        return parseInt(match[1]);
+      }
+      return null;
+    },
   },
   watch: {
     selectedProcess() {
@@ -105,7 +112,7 @@ export default {
     filterValidProcesses(processes) {
       return processes.filter(process => {
         return this.filterValidStartEvents(process.events).length > 0;
-      });
+      }).filter(process => process.id !== this.currentProcessId);
     },
     filterValidStartEvents(events) {
       return events.filter(event => {

--- a/src/components/nodes/subProcess/SubProcessFormSelect.vue
+++ b/src/components/nodes/subProcess/SubProcessFormSelect.vue
@@ -104,8 +104,7 @@ export default {
     },
     filterValidProcesses(processes) {
       return processes.filter(process => {
-        return process.category.is_system == false
-            && this.filterValidStartEvents(process.events).length > 0;
+        return this.filterValidStartEvents(process.events).length > 0;
       });
     },
     filterValidStartEvents(events) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Sub processes tasks must list non system process without errors

Actual behavior: 
when a process more than 1 category, a console error is registered because the endpoint returns the process with a null category

## Solution
- PM endpoint already return non system processes so this filter is redundant

## How to Test
- Create a process and assign to it 2 or more categories.
- Create a process with a subprocess
- Open the list of subprocesses.
- No errors should be registered in the browsers' console and the list of processes for the subprocess should be accessible

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-5145](https://processmaker.atlassian.net/browse/FOUR-5145)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
