### PR TITLE
Four 5102 Fix processmaker ID required v4.2

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -133,7 +133,7 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
   if (!task.definition.ioSpecification.outputSets) {
     task.definition.ioSpecification.set('outputSets', [
       moddle.create('bpmn:OutputSet', {
-        dataInputRefs: [],
+        dataOutputRefs: [],
       }),
     ]);
   }
@@ -141,7 +141,7 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
   if (!outputSet) {
     task.definition.ioSpecification.set('outputSets', [
       moddle.create('bpmn:OutputSet', {
-        dataInputRefs: [],
+        dataOutputRefs: [],
       }),
     ]);
   }

--- a/tests/e2e/specs/BoundaryEventValidation.spec.js
+++ b/tests/e2e/specs/BoundaryEventValidation.spec.js
@@ -34,7 +34,7 @@ describe('Boundary event validation', () => {
       .get('.main-paper [data-type="processmaker.components.nodes.boundaryEvent.Shape"]')
       .should('have.length', numberOfPortsAroundTask);
 
-    getElementAtPosition(taskPosition, nodeTypes.task).click();
+    getElementAtPosition(taskPosition, nodeTypes.task).click({force:true});
 
     const dataTest = nodeTypes.boundaryTimerEvent.replace('processmaker-modeler-', 'add-');
     cy.get(`[data-test="${dataTest}"]`)


### PR DESCRIPTION
## Issue & Reproduction Steps

1. See the process below
2. Connect a DataObject or DataStore to a Task
3. An validation error is thrown

![image](https://user-images.githubusercontent.com/8028650/151839853-f768a78b-0562-4ac4-afa9-e39d6cc946c0.png)

**Expected behavior:** 
Throw validation errors.

**Actual behavior:** 
No validation errors should be catch when a DataObject/DataStore is connected to a Task.

## Solution
- Fix validation rules: ID is not required for input output specification nodes (Requires: https://github.com/ProcessMaker/bpmnlint-plugin/pull/21)

## How to Test
Create a process like this:
![image](https://user-images.githubusercontent.com/8028650/151840359-324de944-3bca-42c5-95d4-f9915a913f93.png)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5102
- https://github.com/ProcessMaker/bpmnlint-plugin/pull/21
- (Note: PM4.2 core does not require the fix of jointjs)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
