### PR TITLE
Bugfix/FOUR-5407: Connecting gateway and data object and data connector does not work

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -108,12 +108,12 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
   const dataInputId = `data_input_${sourceNodeId}`;
   // Check if ioSpecification exists
   if (!task.definition.ioSpecification) {
-    task.definition.set('ioSpecification', moddle.create('bpmn:InputOutputSpecification', {
+    task.definition.ioSpecification = moddle.create('bpmn:InputOutputSpecification', {
       dataInputs: [],
       dataOutputs: [],
       inputSets: [],
       outputSets: [],
-    }));
+    });
   }
   // Check if dataInput exists
   if (!task.definition.ioSpecification.dataInputs) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Case 1
1. Have any process with a gateway
2. Connect either data object  or data store to a gateway
3. Screen freezes

Case 2
1. Have any process with an end event
2. Connect either data object  or data store to the end event
3. Screen freezes

## Solution
- Replaced ioSpecification.set() to ioSpecification =

## How to Test
Case 1
1. Have any process with a gateway
2. Connect either data object  or data store to a gateway
3. Screen should **not freeze**

Case 2
1. Have any process with an end event
2. Connect either data object  or data store to the end event
3. Screen should **not freeze**

**Working video**

https://user-images.githubusercontent.com/90727999/154754353-a94cfc09-6985-41be-b791-e94595dca340.mov


## Related Tickets & Packages
- [FOUR-5407](https://processmaker.atlassian.net/browse/FOUR-5407)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
