### PR TITLE
Bugfix/four 5628 : Error when redesigning a new process in an existing one

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -881,7 +881,7 @@ export default {
           });
         }
         let laneSets = node.definition.processRef.laneSets;
-        if (laneSets != null && laneSets.length > 0) {
+        if (!!laneSets && laneSets.length > 0) {
           laneSets[0].lanes.forEach(lane => {
             const nodeToRemove = this.nodes.find(n => n.definition === lane);
             if (nodeToRemove) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -880,6 +880,15 @@ export default {
             }
           });
         }
+        let laneSets = node.definition.processRef.laneSets;
+        if (laneSets != null && laneSets.length > 0) {
+          laneSets[0].lanes.forEach(lane => {
+            const nodeToRemove = this.nodes.find(n => n.definition === lane);
+            if (nodeToRemove) {
+              this.removeNode(nodeToRemove);
+            }
+          });
+        }
       }
     },
     handleResize() {

--- a/tests/e2e/fixtures/DeletingPoolDeletesRelatedLanes.after.xml
+++ b/tests/e2e/fixtures/DeletingPoolDeletesRelatedLanes.after.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_6" name="Pool" processRef="process_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_2">
+    <bpmn:laneSet id="node_7">
+      <bpmn:lane id="node_8" name="Five" />
+      <bpmn:lane id="node_9" name="Four" />
+      <bpmn:lane id="node_10" name="Six" />
+    </bpmn:laneSet>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="70" y="730" width="600" height="600" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+        <dc:Bounds x="100" y="880" width="570" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="100" y="730" width="570" height="150" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="100" y="1180" width="570" height="150" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/fixtures/DeletingPoolDeletesRelatedLanes.before.xml
+++ b/tests/e2e/fixtures/DeletingPoolDeletesRelatedLanes.before.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:laneSet id="node_2">
+      <bpmn:lane id="node_3" name="Two" />
+      <bpmn:lane id="node_4" name="One" />
+      <bpmn:lane id="node_5" name="Three" />
+    </bpmn:laneSet>
+  </bpmn:process>
+  <bpmn:collaboration id="collaboration_0">
+    <bpmn:participant id="node_1" name="Pool" processRef="Process_1" />
+    <bpmn:participant id="node_6" name="Pool" processRef="process_2" />
+  </bpmn:collaboration>
+  <bpmn:process id="process_2">
+    <bpmn:laneSet id="node_7">
+      <bpmn:lane id="node_8" name="Five" />
+      <bpmn:lane id="node_9" name="Four" />
+      <bpmn:lane id="node_10" name="Six" />
+    </bpmn:laneSet>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="collaboration_0">
+      <bpmndi:BPMNShape id="node_1_di" bpmnElement="node_1">
+        <dc:Bounds x="70" y="80" width="600" height="600" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_3_di" bpmnElement="node_3">
+        <dc:Bounds x="100" y="230" width="570" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_4_di" bpmnElement="node_4">
+        <dc:Bounds x="100" y="80" width="570" height="150" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_5_di" bpmnElement="node_5">
+        <dc:Bounds x="100" y="530" width="570" height="150" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_6_di" bpmnElement="node_6">
+        <dc:Bounds x="70" y="730" width="600" height="600" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_8_di" bpmnElement="node_8">
+        <dc:Bounds x="100" y="880" width="570" height="300" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_9_di" bpmnElement="node_9">
+        <dc:Bounds x="100" y="730" width="570" height="150" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="node_10_di" bpmnElement="node_10">
+        <dc:Bounds x="100" y="1180" width="570" height="150" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/e2e/specs/DeletePoolDeletesRelatedLanes.spec.js
+++ b/tests/e2e/specs/DeletePoolDeletesRelatedLanes.spec.js
@@ -1,0 +1,21 @@
+import {
+    assertDownloadedXmlContainsExpected,
+    getCrownButtonForElement,
+    uploadXml,
+    waitToRenderAllShapes,
+  } from '../support/utils';
+
+  describe('Pool Lanes', () => {
+    it('Deleting first pool deletes One, Two, Three lanes', () => {
+      uploadXml('DeletingPoolDeletesRelatedLanes.before.xml');
+      waitToRenderAllShapes();
+      cy.get('g[data-type="processmaker.modeler.bpmn.pool"]').eq(0)
+        .click({ force: true })
+        .then($pool => {
+          getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+        });
+      cy.fixture('DeletingPoolDeletesRelatedLanes.after.xml', 'base64').then(data => {
+          assertDownloadedXmlContainsExpected(atob(data));
+        });
+    });
+  });

--- a/tests/e2e/specs/DeletePoolDeletesRelatedLanes.spec.js
+++ b/tests/e2e/specs/DeletePoolDeletesRelatedLanes.spec.js
@@ -1,21 +1,21 @@
 import {
-    assertDownloadedXmlContainsExpected,
-    getCrownButtonForElement,
-    uploadXml,
-    waitToRenderAllShapes,
-  } from '../support/utils';
+  assertDownloadedXmlContainsExpected,
+  getCrownButtonForElement,
+  uploadXml,
+  waitToRenderAllShapes,
+} from '../support/utils';
 
-  describe('Pool Lanes', () => {
-    it('Deleting first pool deletes One, Two, Three lanes', () => {
-      uploadXml('DeletingPoolDeletesRelatedLanes.before.xml');
-      waitToRenderAllShapes();
-      cy.get('g[data-type="processmaker.modeler.bpmn.pool"]').eq(0)
-        .click({ force: true })
-        .then($pool => {
-          getCrownButtonForElement($pool, 'delete-button').click({ force: true });
-        });
-      cy.fixture('DeletingPoolDeletesRelatedLanes.after.xml', 'base64').then(data => {
-          assertDownloadedXmlContainsExpected(atob(data));
-        });
+describe('Pool Lanes', () => {
+  it('Deleting first pool deletes One, Two, Three lanes', () => {
+    uploadXml('DeletingPoolDeletesRelatedLanes.before.xml');
+    waitToRenderAllShapes();
+    cy.get('g[data-type="processmaker.modeler.bpmn.pool"]').eq(0)
+      .click({ force: true })
+      .then($pool => {
+        getCrownButtonForElement($pool, 'delete-button').click({ force: true });
+      });
+    cy.fixture('DeletingPoolDeletesRelatedLanes.after.xml', 'base64').then(data => {
+      assertDownloadedXmlContainsExpected(atob(data));
     });
   });
+});


### PR DESCRIPTION
## Issue & Reproduction Steps

1 - Have a process that contains in its design a majority of all the controls or create a new process that has at least the following controls: tasks, gateways, pool with lines, start and end event.
2 - Open the process and remove all controls, after that create a new process design and save it.
3 - Reload the page of the design process.

Expected behavior: 
Lanes to be deleted when the Pool get deleted.

Actual behavior: 
Deleting a pool does not deleted related Lanes.

## Solution
- Defining the deletion of `Pool`'s `Lanes` on `removeNodesFromPool` within the `Modeler`.

## How to Test
Test the steps above

## Related Tickets & Packages
-  None

## Regression
- I suspect that the regression was done in the following change: https://github.com/ProcessMaker/modeler/commit/6bcca1c58b571c537c15874671899a66c3796039

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
