### PR TITLE
Use Cypress.Promise instead of Promise

### DIFF
--- a/tests/e2e/specs/DeletePool.spec.js
+++ b/tests/e2e/specs/DeletePool.spec.js
@@ -78,7 +78,7 @@ function crown(buttonId)
 
 function getBpmn()
 {
-  return new Promise(resolve => {
+  return new Cypress.Promise(resolve => {
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
       .its('xml')


### PR DESCRIPTION
## Issue & Reproduction Steps

When a Pool is removed it is not removing its lanes in BPMN code. DeletePool.spec.js has a test to check that, executed individually it fails but in circleci execution did not report any failing test.

## Solution
- Change `new Promise` by `new new Cypress.Promise`

## How to Test
Run the circleci tests

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-5998

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
