### PR TITLE
FOUR-6069 - Update lodash for security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "jest-junit": "^12.0.0",
         "jointjs": "^3.1.1",
         "js-yaml-loader": "^1.2.2",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "luxon": "^1.21.1",
         "mocha-junit-reporter": "^2.0.0",
         "mustache": "^3.2.1",
@@ -99,7 +99,7 @@
         "bpmn-moddle": "^6.0.0",
         "i18next": "^15.0.8",
         "jointjs": "^3.1.1",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.21",
         "luxon": "^1.21.1",
         "vue": "^2.6.12",
         "vue-color": "^2.7.1"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "jest-junit": "^12.0.0",
     "jointjs": "^3.1.1",
     "js-yaml-loader": "^1.2.2",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "luxon": "^1.21.1",
     "mocha-junit-reporter": "^2.0.0",
     "mustache": "^3.2.1",
@@ -122,7 +122,7 @@
     "bpmn-moddle": "^6.0.0",
     "i18next": "^15.0.8",
     "jointjs": "^3.1.1",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.21",
     "luxon": "^1.21.1",
     "vue": "^2.6.12",
     "vue-color": "^2.7.1"


### PR DESCRIPTION
## Issue & Reproduction Steps

It's necessary upgrade to Lodash version **4.17.21** or later to avoid Multiple Vulnerabilities and Prototype Pollution Vulnerability.

## Solution
- Updated lodash to latest version `npm update lodash --save` 

## Related Tickets & Packages
- [FOUR-6069](https://processmaker.atlassian.net/browse/FOUR-6069)
- [Screen Builder Pull Request](https://github.com/ProcessMaker/screen-builder/pull/1236)
- [Core Pull Request](https://github.com/ProcessMaker/processmaker/pull/4428)