### PR TITLE
FOUR-6606: Dimensions of Some Modeler Crown-Config Icons are Inconsistent

### DIFF
--- a/src/components/crown/crownButtons/addLaneAboveButton.vue
+++ b/src/components/crown/crownButtons/addLaneAboveButton.vue
@@ -9,7 +9,6 @@
       :src="laneAboveIcon"
       aria-hidden="true"
       class="lane-above-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/addLaneAboveButton.vue
+++ b/src/components/crown/crownButtons/addLaneAboveButton.vue
@@ -2,10 +2,16 @@
   <crown-button
     id="lane-above-button"
     aria-label="Add lane above icon"
-    :src="laneAboveIcon"
     v-on="$listeners"
     :width="25"
-  />
+  >
+    <img
+      :src="laneAboveIcon"
+      aria-hidden="true"
+      class="lane-above-icon"
+      alt=""
+    >
+  </crown-button>
 </template>
 
 <script>
@@ -21,3 +27,8 @@ export default {
   },
 };
 </script>
+<style>
+  .lane-above-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/addLaneAboveButton.vue
+++ b/src/components/crown/crownButtons/addLaneAboveButton.vue
@@ -8,7 +8,6 @@
     <img
       :src="laneAboveIcon"
       aria-hidden="true"
-      class="lane-above-icon"
     >
   </crown-button>
 </template>
@@ -26,8 +25,3 @@ export default {
   },
 };
 </script>
-<style>
-  .lane-above-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/addLaneBelowButton.vue
+++ b/src/components/crown/crownButtons/addLaneBelowButton.vue
@@ -9,7 +9,6 @@
       :src="laneBelowIcon"
       aria-hidden="true"
       class="lane-below-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/addLaneBelowButton.vue
+++ b/src/components/crown/crownButtons/addLaneBelowButton.vue
@@ -8,7 +8,6 @@
     <img
       :src="laneBelowIcon"
       aria-hidden="true"
-      class="lane-below-icon"
     >
   </crown-button>
 </template>
@@ -26,8 +25,3 @@ export default {
   },
 };
 </script>
-<style>
-  .lane-below-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/addLaneBelowButton.vue
+++ b/src/components/crown/crownButtons/addLaneBelowButton.vue
@@ -2,10 +2,16 @@
   <crown-button
     id="lane-below-button"
     aria-label="Add lane below icon"
-    :src="laneBelowIcon"
     v-on="$listeners"
     :width="25"
-  />
+  >
+    <img
+      :src="laneBelowIcon"
+      aria-hidden="true"
+      class="lane-below-icon"
+      alt=""
+    >
+  </crown-button>
 </template>
 
 <script>
@@ -21,3 +27,8 @@ export default {
   },
 };
 </script>
+<style>
+  .lane-below-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/associationFlowButton.vue
+++ b/src/components/crown/crownButtons/associationFlowButton.vue
@@ -11,7 +11,6 @@
     <img
       :src="connectIcon"
       aria-hidden="true"
-      class="connect-icon"
     >
   </crown-button>
 </template>
@@ -48,8 +47,3 @@ export default {
   },
 };
 </script>
-<style>
-  .connect-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/associationFlowButton.vue
+++ b/src/components/crown/crownButtons/associationFlowButton.vue
@@ -5,10 +5,16 @@
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     id="association-flow-button"
     aria-label="Add association flow"
-    :src="connectIcon"
     role="menuitem"
     @click="addAssociation"
-  />
+  >
+    <img
+      :src="connectIcon"
+      aria-hidden="true"
+      class="connect-icon"
+      alt=""
+    >
+  </crown-button>
 </template>
 
 <script>
@@ -43,3 +49,8 @@ export default {
   },
 };
 </script>
+<style>
+  .connect-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/associationFlowButton.vue
+++ b/src/components/crown/crownButtons/associationFlowButton.vue
@@ -12,7 +12,6 @@
       :src="connectIcon"
       aria-hidden="true"
       class="connect-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/copyButton.vue
+++ b/src/components/crown/crownButtons/copyButton.vue
@@ -6,9 +6,16 @@
     aria-label="Copy Element"
     data-test="copy-button"
     role="menuitem"
-    :src="copyIcon"
     @click="copyElement"
-  />
+  >
+    <img
+      :src="copyIcon"
+      aria-hidden="true"
+      class="copy-icon"
+      alt=""
+    >
+  </crown-button>
+  
 </template>
 
 <script>
@@ -33,3 +40,8 @@ export default {
   },
 };
 </script>
+<style>
+  .copy-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/copyButton.vue
+++ b/src/components/crown/crownButtons/copyButton.vue
@@ -12,7 +12,6 @@
       :src="copyIcon"
       aria-hidden="true"
       class="copy-icon"
-      alt=""
     >
   </crown-button>
   

--- a/src/components/crown/crownButtons/copyButton.vue
+++ b/src/components/crown/crownButtons/copyButton.vue
@@ -11,7 +11,6 @@
     <img
       :src="copyIcon"
       aria-hidden="true"
-      class="copy-icon"
     >
   </crown-button>
   
@@ -39,8 +38,3 @@ export default {
   },
 };
 </script>
-<style>
-  .copy-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/crownButton.vue
+++ b/src/components/crown/crownButtons/crownButton.vue
@@ -40,8 +40,12 @@ export default {
   margin-top: 0;
   display: flex;
 }
-img, i {
+img {
   margin: 0px 10px;
   height: 15px;
+}
+i {
+  margin: 0px 10px;
+  font-size: 15px;
 }
 </style>

--- a/src/components/crown/crownButtons/crownButton.vue
+++ b/src/components/crown/crownButtons/crownButton.vue
@@ -8,7 +8,6 @@
     <slot>
       <img
         :src="src"
-        alt=""
         width="width"
         height="height"
       >

--- a/src/components/crown/crownButtons/crownButton.vue
+++ b/src/components/crown/crownButtons/crownButton.vue
@@ -41,7 +41,7 @@ export default {
   display: flex;
 }
 img, i {
-  margin: 5px 10px;
-  width: 15px;
+  margin: 0px 10px;
+  height: 15px;
 }
 </style>

--- a/src/components/crown/crownButtons/crownDropdown.scss
+++ b/src/components/crown/crownButtons/crownDropdown.scss
@@ -13,6 +13,7 @@ $crown-left-chevron: 0.3rem;
     background: none;
     border: none;
     color: $primary-white;
+    height: 15px;
   }
 }
 

--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -11,7 +11,6 @@
     <img
       :src="connectIcon"
       aria-hidden="true"
-      class="connect-icon"
     >
   </crown-button>
 </template>
@@ -65,8 +64,3 @@ export default {
   },
 };
 </script>
-<style>
-  .connect-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -12,7 +12,6 @@
       :src="connectIcon"
       aria-hidden="true"
       class="connect-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -5,10 +5,16 @@
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     id="association-flow-button"
     aria-label="Add association flow"
-    :src="connectIcon"
     role="menuitem"
     @click="addDataAssociation"
-  />
+  >
+    <img
+      :src="connectIcon"
+      aria-hidden="true"
+      class="connect-icon"
+      alt=""
+    >
+  </crown-button>
 </template>
 
 <script>
@@ -60,3 +66,8 @@ export default {
   },
 };
 </script>
+<style>
+  .connect-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/defaultFlowButton.vue
+++ b/src/components/crown/crownButtons/defaultFlowButton.vue
@@ -11,7 +11,6 @@
     <img
       :src="icon"
       aria-hidden="true"
-      class="default-flow-icon"
     >
   </crown-button>
 </template>
@@ -35,8 +34,3 @@ export default {
   },
 };
 </script>
-<style>
-  .default-flow-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/defaultFlowButton.vue
+++ b/src/components/crown/crownButtons/defaultFlowButton.vue
@@ -12,7 +12,6 @@
       :src="icon"
       aria-hidden="true"
       class="default-flow-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/defaultFlowButton.vue
+++ b/src/components/crown/crownButtons/defaultFlowButton.vue
@@ -6,9 +6,15 @@
     aria-label="Default Flow"
     data-test="default-flow"
     role="menuitem"
-    :src="icon"
     @click="click"
-  />
+  >
+    <img
+      :src="icon"
+      aria-hidden="true"
+      class="default-flow-icon"
+      alt=""
+    >
+  </crown-button>
 </template>
 
 <script>
@@ -30,3 +36,8 @@ export default {
   },
 };
 </script>
+<style>
+  .default-flow-icon {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -13,7 +13,6 @@
       data-prefix="fas"
       data-icon="trash-alt"
       class="fa-trash-alt trash-icon"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -65,8 +65,3 @@ export default {
   },
 };
 </script>
-<style>
-  .trash-icon {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -68,6 +68,6 @@ export default {
 </script>
 <style>
   .trash-icon {
-    height: 13.25px;
+    height: 15px;
   }
 </style>

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -11,7 +11,6 @@
     <img
       :src="sequenceFlow"
       aria-hidden="true"
-      class="sequence-flow"
     >
   </crown-button>
 </template>
@@ -77,8 +76,3 @@ export default {
   },
 };
 </script>
-<style>
-  .sequence-flow {
-    height: 15px;
-  }
-</style>

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -12,7 +12,6 @@
       :src="sequenceFlow"
       aria-hidden="true"
       class="sequence-flow"
-      alt=""
     >
   </crown-button>
 </template>

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -5,10 +5,16 @@
     :title="$t('Flow')"
     id="generic-flow-button"
     aria-label="Create a flow"
-    :src="sequenceFlow"
     role="menuitem"
     @click="addSequence"
-  />
+  >
+    <img
+      :src="sequenceFlow"
+      aria-hidden="true"
+      class="sequence-flow"
+      alt=""
+    >
+  </crown-button>
 </template>
 <script>
 import Flow from '@/assets/connect-elements.svg';
@@ -72,3 +78,8 @@ export default {
   },
 };
 </script>
+<style>
+  .sequence-flow {
+    height: 15px;
+  }
+</style>

--- a/src/components/crown/crownConfig/crownConfig.scss
+++ b/src/components/crown/crownConfig/crownConfig.scss
@@ -6,6 +6,7 @@ $crown-left-chevron: 0.3rem;
   position: absolute;
   z-index: 0;
   display: flex;
+  align-items: center;
   justify-content: center;
   width: auto;
   height: 1.85rem;


### PR DESCRIPTION
# Issue
Ticket: [FOUR-6606](https://processmaker.atlassian.net/browse/FOUR-6606)

Numerous icons in the Modeler crown-config menu have varying heights. This makes the icons noticeably smaller and inconsistent with their neighbors.

# Solution
Updated heights of all icons to 15px (if they were not already at that height).

# How to Test
1. Update Modeler branch to `bugfix/FOUR-6606`
2. Link Modeler to Core
3. Open local environment, create a new process
4. Add the following elements to your process: Start Event, Form Task, Exclusive Gateway (with a Default Flow), Text Annotation, Data Object. This will allow you to see all of the different crown icons.
5. Open your Inspector to see that heights of icons have been set to 15px. Note: some icons were already set to a height of 15px, although the height is not listed as a style attribute. Inspecting the element should still show a height of 15px:
![Screen Shot 2022-08-17 at 12 11 04 PM](https://user-images.githubusercontent.com/73713665/185190332-791557a2-beaf-4283-885f-cbcde99f4a44.png)

# Related Tickets & Packages
- [FOUR-5110](https://processmaker.atlassian.net/browse/FOUR-5110) | Design Bugs

# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.