### PR TITLE
Bugfix/FOUR-6905: The required mark is shown when clicking on sub process

### DIFF
--- a/src/components/nodes/subProcess/SubProcessFormSelect.vue
+++ b/src/components/nodes/subProcess/SubProcessFormSelect.vue
@@ -6,12 +6,12 @@
       :helper="$t('Select which Process this element calls')"
       v-model="selectedProcess"
       :showLabels="false"
-      :allow-empty="true"
+      :allow-empty="false"
       :options="processList"
       :loading="loading"
       optionContent="name"
       class="p-0 mb-2"
-      validation="required"
+      :validation="validation"
       @search-change="searchChange"
       :searchable="true"
       :internal-search="false"
@@ -58,6 +58,7 @@ export default {
       loading: false ,
       processes: [],
       selectedProcessInfo: null,
+      validation: '',
     };
   },
   inheritAttrs: false,
@@ -146,6 +147,9 @@ export default {
       this.selectedProcess = this.processList.find(p => p.id === this.config.processId);
       this.selectedStartEvent = this.startEventList.find(se => se.id === this.config.startEvent);
       this.$nextTick(() => {
+        if (!this.selectedProcess) {
+          this.validation = 'required';
+        }
         this.loading = false;
       });
     },
@@ -206,6 +210,7 @@ export default {
     },
   },
   created() {
+    this.validation = !this.config.processId ? 'required' : '';
     this.loadProcessesDebounced = debounce((filter) => {
       this.loadProcesses(filter);
     }, 500);


### PR DESCRIPTION
## Issue & Reproduction Steps

- Log in 4.3.30RC2 version  
- have a process that contains thread in its layout
- click on the subprocess task 

Expected behavior: 
When clicking on the thread type task, the required mark should not be displayed temporarily

Actual behavior: 
As we see in the attached video, when we click on the task of the sub process type.
The required mark is temporarily displayed, as if it had no configuration of a process.  

## Solution
- Hide required when some process is selected before list load

**Working video**

https://user-images.githubusercontent.com/90727999/197853473-27c9ab08-33f5-4f6d-8ca5-90af669b2f05.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-6905](https://processmaker.atlassian.net/browse/FOUR-6905)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
