### PR TITLE
FOUR-7173: Change URL of helper for expression in gateway outgoing connection in modeler

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -155,7 +155,7 @@ export default {
 
       if (this.isSequenceFlow(type) && this.isConnectedToGateway(definition)) {
         let helper = this.$t('Enter the expression that describes the workflow condition');
-        helper += ' <a href="https://processmaker.gitbook.io/processmaker/v/processmaker/designing-processes/process-design/model-your-process/flow-indicator-elements/the-quick-toolbar#expression-syntax-components-to-specify-request-conditions-that-trigger-an-outgoing-sequence-flow-element" target="_blank"><i class="far fa-question-circle mr-1"></a>';
+        helper += ' <a href="https://processmaker.gitbook.io/processmaker/v/processmaker-4.3/designing-processes/expression-syntax-components" target="_blank"><i class="far fa-question-circle mr-1"></a>';
         const expressionConfig = {
           component: 'FormInput',
           config: {


### PR DESCRIPTION
## Issue & Reproduction Steps

* Create a process
* add a task, a exclusive gateway and 2 additional Tasks
* Connect the process as in this diagram
![image](https://user-images.githubusercontent.com/14875032/205096220-84336635-13ff-4694-a566-a42900f08015.png)

* Click over one of the outgoing flows from the exclusive gateway
* Click over the question mark icon ?
![image](https://user-images.githubusercontent.com/14875032/205096306-660d7ccd-af2b-4b29-87ba-ed5afd090f61.png)

Expected behavior: 
An new tab with the documentation must be opened

Actual behavior: 
A new tab with a 404 error is displayed

## Solution
The link has been updated


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-7173](https://processmaker.atlassian.net/browse/FOUR-7173)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
