### PR TITLE
FOUR-7785:  Deselection with shift key does not work with pools

### DIFF
--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -16,7 +16,7 @@ export default {
     keyupListener(event) {
       if (event.code === 'Space') {
         this.isGrabbing = false;
-        this.paperManager.removeEventHandler('blank:pointermove');
+        this.paperManager.paper.stopListening(this.paperManager.paper, 'blank:pointermove');
       }
     },
     keydownListener(event) {
@@ -38,7 +38,7 @@ export default {
 
       if (event.code === 'Space') {
         this.isGrabbing = true;
-        this.paperManager.addEventHandler('blank:pointermove', (event, x, y) => {
+        this.paperManager.paper.listenTo(this.paperManager.paper, 'blank:pointermove',  (event, x, y) => {
           if (!this.canvasDragPosition) {
             const scale = this.paperManager.scale;
             this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };

--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -38,7 +38,7 @@ export default {
 
       if (event.code === 'Space') {
         this.isGrabbing = true;
-        this.paperManager.paper.listenTo(this.paperManager.paper, 'blank:pointermove',  (event, x, y) => {
+        this.paperManager.paper.listenTo(this.paperManager.paper, 'blank:pointermove', (event, x, y) => {
           if (!this.canvasDragPosition) {
             const scale = this.paperManager.scale;
             this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -200,8 +200,6 @@ export default {
 
       let selectedArea = g.rect(f.x, f.y, width, height);
       this.selected = this.getElementsInSelectedArea(selectedArea, { strict: false });
-
-      
       this.filterSelected();
       if (this.selected && this.selected.length > 0) {
         this.updateSelectionBox();

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -172,6 +172,8 @@ export default {
 
       let selectedArea = g.rect(f.x, f.y, width, height);
       this.selected = this.getElementsInSelectedArea(selectedArea, { strict: false });
+
+      
       this.filterSelected();
       if (this.selected && this.selected.length > 0) {
         this.updateSelectionBox();
@@ -187,9 +189,27 @@ export default {
      * Get elements into a selected area
      * @param {Object} area
      */
-    getElementsInSelectedArea(area, options) {
+    getElementsInSelectedArea(area, options, addLinks=true) {
       const { paper } = this.paperManager;
-      return paper.findViewsInArea(area, options);
+      // get shapes
+      const elements =  paper.findViewsInArea(area, options);
+      
+      if (!addLinks) {
+        return elements;
+      }
+      // get flows
+      this.graph.getLinks().forEach(function(link) {
+        console.log(link);
+        // Check if the link is within the selected area
+        // if (selectedArea.containsRect(link.getBBox())) {
+        if (area.intersect(link.getBBox())) {
+          // The link is within the selected area
+          // Do something with the link, such as highlighting it
+          link.attr('line/stroke', 'red');
+          elements.push(paper.findViewByModel(link));
+        }
+      });
+      return elements;
     },
     /**
      * Return the bounding box of the selected elements,
@@ -371,6 +391,10 @@ export default {
           return;
         } 
       }
+
+      
+
+      
       this.overPoolStopDrag();
       this.$emit('save-state');
       this.dragging = false;

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -248,6 +248,9 @@ export default {
         this.setupLinkTools();
       });
     });
+    this.shape.on('change:vertices', function() {
+      this.component.$emit('shape-resize');
+    });
 
     const targetRef = this.getTargetRef
       ? this.getTargetRef()


### PR DESCRIPTION
## Issue & Reproduction Steps
  Deselection with shift key does not work with pools
Expected behavior: 
pool must be unselected if previously was selected with shift key
Actual behavior: 
does not work
## Solution
- event coalition was fixed and improved

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7785

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
