### PR TITLE
FOUR-7833

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -785,11 +785,6 @@ export default {
 
       this.highlightNode(newNode);
       await this.addNode(newNode);
-      const point = {
-        clientX: clientX + 5,
-        clientY: clientY + 5,
-      };
-      this.$refs.selector.markSelectedByPoint(point);
       if (!nodeThatWillBeReplaced) {
         return;
       }

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1015,7 +1015,6 @@ export default {
       this.isDragging = false;
       this.isSelecting = false;
       this.isIntoTheSelection = false;
-      this.isPointerDown =
       this.dragStart = { x, y };
       // Verify if is in the selection box
       if (this.isPointInSelection(event)) {

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -143,8 +143,8 @@ export default {
       this.selectOrUnselectShape(view);
     },
     /**
-     * Select if there there is not this shape
-     * Unselect if there there is not thisshape
+     * Select an shape if it is not in the collection
+     * Unselect an shape if it is in the collection
      */
     selectOrUnselectShape(view){
       const element = this.selected.find( item => item.id === view.id);

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -257,6 +257,11 @@ export default {
         this.selectionBlackList.includes(elementView.model.component.node.type)) {
         return;
       }
+      // verify if the selected elements is not in dragable black list
+      if (elementView && elementView.model && elementView.model.component &&
+        this.draggableBlackList.includes(elementView.model.component.node.type)) {
+        this.selected = [];
+      }
       if (this.shiftKeyPressed) {
         const element = this.selected.find( item => item.id === elementView.id);
         if (element) {

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -113,11 +113,7 @@ export default {
      * @param {Object} view
      */
     shiftKeySelectionHandler(view){
-      if (view && view.model && view.model.component &&
-        this.draggableBlackList.includes(view.model.component.node.type)) {
-        return;
-      }
-      // validate if current shape is a lane
+      // validate if current shape is black listed
       if (view && view.model && view.model.component &&
         this.draggableBlackList.includes(view.model.component.node.type)) {
         return;

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -27,6 +27,7 @@ import store from '@/store';
 import CrownMultiselect from '@/components/crown/crownMultiselect/crownMultiselect';
 import { id as poolId } from '@/components/nodes/pool/config';
 import { id as laneId } from '@/components/nodes/poolLane/config';
+import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
 import { labelWidth, poolPadding } from '../nodes/pool/poolSizes';
 export default {
   name: 'Selection',
@@ -63,6 +64,12 @@ export default {
       shiftKeyPressed: false,
       isOutOfThePool: false,
       stopForceMove: false,
+      draggableBlackList: [
+        laneId,
+      ],
+      selectionBlackList:[
+        genericFlowId,
+      ],
     };
   },
   mounted(){
@@ -245,9 +252,9 @@ export default {
      * @param {Object} elementView
      */
     elementClickHandler(elementView) {
-      const shapesToNotSelect = [
-      ];
-      if (shapesToNotSelect.includes(elementView.model.get('type'))) {
+      // verify if element is not black listed 
+      if (elementView && elementView.model && elementView.model.component &&
+        this.selectionBlackList.includes(elementView.model.component.node.type)) {
         return;
       }
       if (this.shiftKeyPressed) {
@@ -276,6 +283,11 @@ export default {
       this.selected = this.selected.filter(shape => {
         if (shape.model.component && shape.model.component.node.pool) {
           return shape.model.component.node.pool && !selectedPoolsIds.includes(shape.model.component.node.pool.component.node.id);
+        }
+        return true;
+      }).filter(shape => {
+        if (shape.model.getParentCell() && shape.model.getParentCell().get('parent')){
+          return false;
         }
         return true;
       });

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -254,9 +254,23 @@ export default {
      * Get elements into a selected area
      * @param {Object} area
      */
-    getElementsInSelectedArea(area, options) {
+    getElementsInSelectedArea(area, options, addLinks=true) {
       const { paper } = this.paperManager;
-      return paper.findViewsInArea(area, options);
+      const elements =  paper.findViewsInArea(area, options);
+
+      if (!addLinks) {
+        return elements;
+      }
+      // get flows
+      this.graph.getLinks().forEach(function(link) {
+        // Check if the link is within the selected area
+        if (area.intersect(link.getBBox())) {
+          // The link is within the selected area
+          // Do something with the link, such as highlighting it
+          elements.push(paper.findViewByModel(link));
+        }
+      });
+      return elements;
     },
     /**
      * Return the bounding box of the selected elements,

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -134,18 +134,25 @@ export default {
       if (view.model.component && view.model.component.node.type === poolId) {
         //validate if previous selection are all pools
         if (this.hasOnlyPools(this.selected)) {
-          this.selected.push(view);
+          this.selectOrUnselectShape(view);
         } else {
           this.selected = [view];
         }
         return;
       }
+      this.selectOrUnselectShape(view);
+    },
+    /**
+     * Select if there there is not this shape
+     * Unselect if there there is not thisshape
+     */
+    selectOrUnselectShape(view){
       const element = this.selected.find( item => item.id === view.id);
       if (element) {
         this.selected = this.selected.filter(item => item.id !== view.id);
       } else {
         this.selected.push(view);
-      }      
+      }     
     },
     clearSelection() {
       this.initSelection();

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -302,6 +302,9 @@ export default {
     }
 
     this.updateRouter();
+    this.shape.on('change:vertices', function() {
+      this.component.$emit('shape-resize');
+    });
   },
   beforeDestroy() {
     document.removeEventListener('mouseup', this.emitSave);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Given the user selects a flow element (tasks, gateways, flows, etc)
When user try to Shift+Click on a Pool
Then only the Pool should be selected and can be copied

Given the user selects some flow elements (tasks, gateways, flows, etc)
When user try to Shift+Click on a Lane
Then the selection is kept not adding the Lane to the selection
Actual behavior: 

## Solution
- shift key allow select pool an lanes

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7833

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
