### PR TITLE
FOUR-7920 - Modeler Toolbar Improvements

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -2,6 +2,7 @@
   <transition name="inspector">
     <b-col
       v-show="!compressed"
+      id="inspector"
       class="pl-0 h-100 overflow-hidden inspector-column"
       :class="[{ 'ignore-pointer': canvasDragPosition, 'inspector-column-compressed' : compressed }]"
       data-test="inspector-column"

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -101,7 +101,7 @@
               </span>
             </div>
             <a
-              class="btn btn-sm btn-primary mini-map-btn text-uppercase mx-2"
+              class="btn btn-sm btn-primary autosave-btn text-uppercase mx-2"
               data-test="publish-btn"
               :title="$t('Publish')"
               @click="$emit('saveBpmn')"
@@ -109,7 +109,7 @@
               {{ $t('Publish') }}
             </a>
             <a
-              class="btn btn-sm btn-link toolbar-item mini-map-btn text-black text-uppercase"
+              class="btn btn-sm btn-link toolbar-item autosave-btn text-black text-uppercase"
               data-test="close-btn"
               :title="$t('Close')"
               @click="$emit('close')"

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -117,9 +117,11 @@
               {{ $t('Close') }}
             </a>
             <EllipsisMenu
-              @navigate="onNavigate"
               :actions="ellipsisMenuActions"
               :divider="false"
+              @navigate="onNavigate"
+              @show="onShow"
+              @hide="onHide"
             />
           </template>
           <b-button
@@ -256,6 +258,18 @@ export default {
           break;
         default:
           break;
+      }
+    },
+    onShow() {
+      const inspectorDiv = document.getElementById('inspector');
+      if (inspectorDiv) {
+        inspectorDiv.style.zIndex = '1';
+      }
+    },
+    onHide() {
+      const inspectorDiv = document.getElementById('inspector');
+      if (inspectorDiv) {
+        inspectorDiv.style.zIndex = '2';
       }
     },
   },

--- a/src/components/toolbar/breadcrumb/Breadcrumb.vue
+++ b/src/components/toolbar/breadcrumb/Breadcrumb.vue
@@ -19,3 +19,10 @@ export default {
   },
 };
 </script>
+<style lang="css" scoped>
+@media screen and (max-width: 1365px) {
+  #breadcrumbs {
+    width: 290px;
+  }
+}
+</style>

--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -27,3 +27,14 @@ $toolbar-background-color: #fff;
 .cursor-default {
   cursor: default !important;
 }
+
+.autosave-btn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.btn-ellipsis {
+  border-top-left-radius: 4px !important;
+  border-bottom-left-radius: 4px !important;
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
When the screen gets smaller, the Alignment Button Group and the Autosave Button Group are shown in two rows.

Expected behavior: 
- The Alignment Button Group and the Autosave Button Group will continue to occupy a single line, until the browser's minimum width of 1275px is reached.

Actual behavior: 
- Breadcrumbs' width section is undefined and uses additional space.

## Solution
- A CSS media query was added to reduce the width of the breadcrumbs section so that the button groups are on a single row up to a screen width of 1275 pixels.
- Additionally, some issues with the border radius of the ellipsis menu button and centering the content of the autosave buttons were fixed.
- Additionally, added a Fix to drop-down menu content overlapping in Modeler.

## How to Test
- run `npm run build-bundle`
- copy dist folder to `node_modules/@processmaker/modeler/`
- run `npm run dev` in core.
- manually test Modeler.

## Related Tickets & Packages
- [FOUR-7920](https://processmaker.atlassian.net/browse/FOUR-7920)
- [FOUR-7973](https://processmaker.atlassian.net/browse/FOUR-7973)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-7920]: https://processmaker.atlassian.net/browse/FOUR-7920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ