### PR TITLE
FOUR-7483 Copy and Paste

### DIFF
--- a/src/components/crown/crownButtons/copyButton.vue
+++ b/src/components/crown/crownButtons/copyButton.vue
@@ -13,7 +13,7 @@
       aria-hidden="true"
     >
   </crown-button>
-  
+
 </template>
 
 <script>
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     copyElement() {
-      this.$emit('copy-element', this.node);
+      this.$emit('copy-element');
     },
   },
 };

--- a/src/components/crown/crownButtons/copyButton.vue
+++ b/src/components/crown/crownButtons/copyButton.vue
@@ -33,7 +33,7 @@ export default {
   },
   methods: {
     copyElement() {
-      this.$emit('copy-element');
+      this.$emit('copy-element', this.node);
     },
   },
 };

--- a/src/components/hotkeys/copyPaste.js
+++ b/src/components/hotkeys/copyPaste.js
@@ -13,9 +13,11 @@ export default {
     },
     copy(event) {
       event.preventDefault();
+      window.ProcessMaker.$modeler.copyElement();
     },
     paste(event) {
       event.preventDefault();
+      window.ProcessMaker.$modeler.pasteElements();
     },
   },
 };

--- a/src/components/hotkeys/copyPaste.js
+++ b/src/components/hotkeys/copyPaste.js
@@ -1,0 +1,21 @@
+export default {
+  methods: {
+    copyPasteHandler(event, options) {
+      const isCopy = event.key === 'c';
+      const isPaste = event.key === 'v';
+
+      if (isCopy && options.mod) {
+        this.copy(event);
+      }
+      if (isPaste && options.mod) {
+        this.paste(event);
+      }
+    },
+    copy(event) {
+      event.preventDefault();
+    },
+    paste(event) {
+      event.preventDefault();
+    },
+  },
+};

--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -1,9 +1,10 @@
 import ZoomInOut from './zoomInOut';
+import CopyPaste from './copyPaste.js';
 import store from '@/store';
 import moveShapeByKeypress from './moveWithArrowKeys';
 
 export default {
-  mixins: [ZoomInOut],
+  mixins: [ZoomInOut, CopyPaste],
   mounted() {
     document.addEventListener('keydown', this.keydownListener);
     document.addEventListener('keyup', this.keyupListener);
@@ -12,6 +13,7 @@ export default {
     handleHotkeys(event, options) {
       // Pass event to all handlers
       this.zoomInOutHandler(event, options);
+      this.copyPasteHandler(event, options);
     },
     keyupListener(event) {
       if (event.code === 'Space') {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1198,7 +1198,13 @@ export default {
     }, this);
 
     this.$el.addEventListener('mousemove', event => {
+      const { clientX, clientY } = event;
       this.pointerMoveHandler(event);
+      store.commit('setClientMousePosition', { clientX, clientY });
+    });
+
+    this.$el.addEventListener('mouseleave', () => {
+      store.commit('clientLeftPaper');
     });
 
     this.paperManager.addEventHandler('cell:pointerclick', (cellView, evt, x, y) => {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -326,7 +326,6 @@ export default {
       // Serialize node(s)
       // Copy to clipboard
       store.commit('setCopiedElements', this.cloneSelection());
-      console.log('copied');
       // TODO add message that the element was succesfully copied
     },
     async pasteElements() {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -323,7 +323,13 @@ export default {
     },
     copyElement() {
       // Checking if User selected a single flow and tries to copy it, to deny it.
-      if (this.highlightedNodes.length === 1 && this.highlightedNodes[0].type === 'processmaker-modeler-sequence-flow') return;
+      const flows = [
+        sequenceFlowId,
+        dataOutputAssociationFlowId,
+        dataInputAssociationFlowId,
+        genericFlowId,
+      ];
+      if (this.highlightedNodes.length === 1 && flows.includes(this.highlightedNodes[0].type)) return;
       store.commit('setCopiedElements', this.cloneSelection());
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -322,6 +322,8 @@ export default {
       this.addNode(clonedNode);
     },
     copyElement() {
+      // Checking if User selected a single flow and tries to copy it, to deny it.
+      if (this.highlightedNodes.length === 1 && this.highlightedNodes[0].type === 'processmaker-modeler-sequence-flow') return;
       store.commit('setCopiedElements', this.cloneSelection());
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -322,11 +322,8 @@ export default {
       this.addNode(clonedNode);
     },
     copyElement() {
-      // This is the true copy, where a node or selection (nodes passed as argument) will be copied to clipboard
-      // Serialize node(s)
-      // Copy to clipboard
       store.commit('setCopiedElements', this.cloneSelection());
-      // TODO add message that the element was succesfully copied
+      this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },
     async pasteElements() {
       if (this.copiedElements) {

--- a/src/store.js
+++ b/src/store.js
@@ -35,6 +35,7 @@ export default new Vuex.Store({
     autoValidate: false,
     globalProcesses: [],
     allowSavingElementPosition: true,
+    copiedElements: [],
     clientX: null,
     clientY: null,
   },
@@ -54,6 +55,7 @@ export default new Vuex.Store({
     globalProcesses: state => state.globalProcesses,
     globalProcessEvents: (state, getters) => flatten(getters.globalProcesses.map(process => process.events)),
     allowSavingElementPosition: state => state.allowSavingElementPosition,
+    copiedElements: state => state.copiedElements,
     clientX: state => state.clientX,
     clientY: state => state.clientY,
   },
@@ -141,6 +143,10 @@ export default new Vuex.Store({
     },
     setGlobalProcesses(state, globalProcesses) {
       state.globalProcesses = globalProcesses;
+    },
+    // Copy Nodes to the clipboard or in this case, to the state
+    setCopiedElements(state, elements) {
+      state.copiedElements = elements;
     },
     setClientMousePosition(state, position) {
       const { clientX, clientY } = position;

--- a/src/store.js
+++ b/src/store.js
@@ -35,6 +35,8 @@ export default new Vuex.Store({
     autoValidate: false,
     globalProcesses: [],
     allowSavingElementPosition: true,
+    clientX: null,
+    clientY: null,
   },
   getters: {
     nodes: state => state.nodes,
@@ -52,6 +54,8 @@ export default new Vuex.Store({
     globalProcesses: state => state.globalProcesses,
     globalProcessEvents: (state, getters) => flatten(getters.globalProcesses.map(process => process.events)),
     allowSavingElementPosition: state => state.allowSavingElementPosition,
+    clientX: state => state.clientX,
+    clientY: state => state.clientY,
   },
   mutations: {
     preventSavingElementPosition(state) {
@@ -137,6 +141,14 @@ export default new Vuex.Store({
     },
     setGlobalProcesses(state, globalProcesses) {
       state.globalProcesses = globalProcesses;
+    },
+    setClientMousePosition(state, position) {
+      const { clientX, clientY } = position;
+      state = { clientX, clientY };
+    },
+    clientLeftPaper(state) {
+      state.clientX = null;
+      state.clientY = null;
     },
   },
   actions: {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
A user would be able to copy using Command + C (on Mac) or Control + C (Windows)
AND
Pasting using Command + V (on Mac) or Control + V (Windows)

Actual behavior: 
User cannot copy elements with key binds

## Solution
- Added logic to watch for event handlers for the keyboard con Command/Control pressed and/or {C,V} 
- Added logic to add the elements into the state 
- Getting the elements from a getter and pasting them

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7483

### This ticket depends heavily on `feature/FOUR-7498`

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
