### PR TITLE
Fix Selection with Text Annotation is not cloned 

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -334,25 +334,13 @@ export default {
       }
     },
     cloneSelection() {
-      let clonedNodes = [], clonedFlows = [], originalFlows = [];
+      let clonedNodes = [], clonedFlows = [];
       const nodes = this.highlightedNodes;
       const selector = this.$refs.selector.$el;
       const { height: sheight } = selector.getBoundingClientRect();
       if (typeof selector.getBoundingClientRect === 'function') {
         // get selector height
         nodes.forEach(node => {
-          // Add flows described in the definitions property
-          if (node.definition.incoming || node.definition.outgoing) {
-            // Since both incoming and outgoing reference the same flow, any of them is copied
-            let flowsToCopy = [...(node.definition.incoming || node.definition.outgoing)];
-            // Check if flow is already in array before pushing
-            flowsToCopy.forEach(flow => {
-              if (!originalFlows.some(el => el.id === flow.id)) {
-                originalFlows.push(flow);
-              }
-            });
-          }
-
           // Check node type to clone
           if ([
             sequenceFlowId,
@@ -382,7 +370,7 @@ export default {
       // Connect flows
       clonedFlows.forEach(flow => {
         // Look up the original flow
-        const flowClonedFrom = { definition: originalFlows.find(el => el.id === flow.definition.cloneOf) };
+        const flowClonedFrom = this.nodes.find(node => node.definition.id === flow.definition.cloneOf);
         // Get the id's of the sourceRef and targetRef of original flow
         const src = flowClonedFrom.definition.sourceRef;
         const target = flowClonedFrom.definition.targetRef;
@@ -966,7 +954,12 @@ export default {
       await this.pushToUndoStack();
     },
     async removeNode(node, { removeRelationships = true } = {}) {
+      if (!node) {
+        // already removed
+        return;
+      }
       if (removeRelationships) {
+
         removeNodeFlows(node, this);
         removeNodeMessageFlows(node, this);
         removeNodeAssociations(node, this);

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -14,6 +14,9 @@ export default {
       associationDirection: `${direction.none}`,
     });
   },
+  diagram(moddle) {
+    return moddle.create('bpmndi:BPMNEdge');
+  },
   inspectorConfig: [
     {
       name: 'Data Association',


### PR DESCRIPTION
## Issue & Reproduction Steps
The selection that contains text annotation associated to a element is not cloned

Expected behavior: 
The selection that contains text annotation associated should be cloned

Actual behavior: 
JS Error thrown.

## Solution
- Fix missing association property required to clone
- Fix logic of cloning

## How to Test

1. Add task form 
2. Add Text Annotation 
3. Connect the Text Annotation with Task Form 
4. Select all elements 
5. Press “Duplicate Selection“

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
