### PR TITLE
FOUR-7942: The selection box does not contain the entire cloned selection

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -963,7 +963,12 @@ export default {
         this.poolTarget = null;
       });
 
-      await this.pushToUndoStack();
+      return new Promise(resolve => {
+        setTimeout(() => {
+          this.pushToUndoStack();
+          resolve();
+        });
+      });
     },
     async removeNode(node, { removeRelationships = true } = {}) {
       if (removeRelationships) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -404,6 +404,9 @@ export default {
     async duplicateSelection() {
       const clonedNodes = this.cloneSelection();
       await this.addClonedNodes(clonedNodes);
+      // await this.$nextTick();
+      await this.$nextTick();
+      await this.paperManager.awaitScheduledUpdates();
       this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
     },
     findViewElementsFromNodes(nodes) {
@@ -962,13 +965,7 @@ export default {
         store.commit('addNode', node);
         this.poolTarget = null;
       });
-
-      return new Promise(resolve => {
-        setTimeout(() => {
-          this.pushToUndoStack();
-          resolve();
-        });
-      });
+      this.pushToUndoStack();
     },
     async removeNode(node, { removeRelationships = true } = {}) {
       if (removeRelationships) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -404,7 +404,6 @@ export default {
     async duplicateSelection() {
       const clonedNodes = this.cloneSelection();
       await this.addClonedNodes(clonedNodes);
-      // await this.$nextTick();
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
       this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
@@ -965,7 +964,8 @@ export default {
         store.commit('addNode', node);
         this.poolTarget = null;
       });
-      this.pushToUndoStack();
+
+      await this.pushToUndoStack();
     },
     async removeNode(node, { removeRelationships = true } = {}) {
       if (removeRelationships) {


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
The selection box must contain all new cloned elements
Actual behavior: 
The selection box does not contain the entire cloned selection
## Solution
- promise was added

## How to Test
Test the steps above

1. Add two single events 
2. Select the elements 
3. Click on “Duplicate selection“6. 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7942

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
