### PR TITLE
FOUR-7998: A small box is inside the selection box with copy/paste hotkeys

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -337,6 +337,8 @@ export default {
     async pasteElements() {
       if (this.copiedElements) {
         await this.addClonedNodes(this.copiedElements);
+        await this.$nextTick();
+        await this.paperManager.awaitScheduledUpdates();
         this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements));
         store.commit('setCopiedElements', this.cloneSelection());
       }


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
after use the copy/paste hotkeys selection must contains all pasted elements 
Actual behavior: 
A small box is inside the selection box with copy/paste hotkeys
## Solution
- synchronization issue was fixed

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7998

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
