### PR TITLE
Fix invalid connection of DataInput

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -173,6 +173,15 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
   return dataInput;
 }
 
+export function findIOSpecificationOwner(ioSpec, modeler) {
+  const owner = ioSpec.$parent;
+  if (!owner) {
+    return modeler.nodes.find(node => node.definition.ioSpecification === ioSpec ||
+      node.definition.ioSpecification?.id === ioSpec.id
+    )?.definition;
+  }
+  return owner;
+}
 
 export function removeDataInput(task, sourceNode) {
   if (sourceNode.$type !== 'bpmn:DataObjectReference' && sourceNode.$type !== 'bpmn:DataStoreReference') {

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -81,10 +81,7 @@ export default {
       if (sourceIsDataStore && dataStoreValidTargets.includes(targetType)) {
         return true;
       }
-      if (sourceIsDataObject && dataObjectValidTargets.includes(targetType)) {
-        return true;
-      }
-      return false;
+      return (sourceIsDataObject && dataObjectValidTargets.includes(targetType));
     },
   },
   methods: {

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -21,7 +21,7 @@ import linkConfig from '@/mixins/linkConfig';
 import get from 'lodash/get';
 import associationHead from '!!url-loader!@/assets/association-head.svg';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
-import { getOrFindDataInput, removeDataInput } from '@/components/crown/utils';
+import { getOrFindDataInput, removeDataInput, findIOSpecificationOwner } from '@/components/crown/utils';
 import { pull } from 'lodash';
 
 export default {
@@ -98,13 +98,7 @@ export default {
       if (this.node.dataAssociationProps) {
         return this.node.dataAssociationProps.targetCoords;
       }
-
-      const taskWithInputAssociation = this.graph.getElements().find(element => {
-        return element.component && element.component.node.definition.get('dataInputAssociations') &&
-            element.component.node.definition.get('dataInputAssociations')[0] === this.node.definition;
-      });
-
-      return taskWithInputAssociation.component.node.definition;
+      return findIOSpecificationOwner(this.node.definition.targetRef.$parent, this.$parent);
     },
     updateRouter() {
       this.shape.router('normal', { elementPadding: this.elementPadding });

--- a/src/components/nodes/genericFlow/DataOutputAssociation.js
+++ b/src/components/nodes/genericFlow/DataOutputAssociation.js
@@ -12,8 +12,64 @@ export default class DataOutputAssociation extends DataAssociation {
       return false;
     }
 
-    return DataAssociation.isADataNode(targetNode) &&
-      DataOutputAssociation.isValidSourceNode(sourceNode);
+    const dataStoreValidSources = [
+      'bpmn:Task',
+      'bpmn:SubProcess',
+      'bpmn:CallActivity',
+      'bpmn:ManualTask',
+      'bpmn:ScriptTask',
+      'bpmn:ServiceTask',
+    ];
+    const dataStoreValidTargets = [
+      'bpmn:Task',
+      'bpmn:SubProcess',
+      'bpmn:CallActivity',
+      'bpmn:ManualTask',
+      'bpmn:ScriptTask',
+      'bpmn:ServiceTask',
+    ];
+    const dataObjectValidSources = [
+      'bpmn:Task',
+      'bpmn:SubProcess',
+      'bpmn:CallActivity',
+      'bpmn:ManualTask',
+      'bpmn:ScriptTask',
+      'bpmn:ServiceTask',
+      'bpmn:IntermediateCatchEvent',
+      'bpmn:StartEvent',
+    ];
+    const dataObjectValidTargets = [
+      'bpmn:Task',
+      'bpmn:SubProcess',
+      'bpmn:CallActivity',
+      'bpmn:ManualTask',
+      'bpmn:ScriptTask',
+      'bpmn:ServiceTask',
+      'bpmn:IntermediateThrowEvent',
+      'bpmn:EndEvent',
+    ];
+
+    const sourceType = sourceNode.definition.$type;
+    const targetType = targetNode.definition.$type;
+    const sourceIsDataStore = sourceNode.definition.$type === 'bpmn:DataStoreReference';
+    const sourceIsDataObject = sourceNode.definition.$type === 'bpmn:DataObjectReference';
+    const targetIsDataStore = targetNode.definition.$type === 'bpmn:DataStoreReference';
+    const targetIsDataObject = targetNode.definition.$type === 'bpmn:DataObjectReference';
+    
+    if (sourceIsDataStore && dataStoreValidTargets.includes(targetType)) {
+      return true;
+    }
+    if (sourceIsDataObject && dataObjectValidTargets.includes(targetType)) {
+      return true;
+    }
+    if (targetIsDataStore && dataStoreValidSources.includes(sourceType)) {
+      return true;
+    }
+    if (targetIsDataObject && dataObjectValidSources.includes(sourceType)) {
+      return true;
+    }
+
+    return false;
   }
 
   makeFlowNode(sourceShape, targetShape, genericLink) {

--- a/src/components/nodes/genericFlow/DataOutputAssociation.js
+++ b/src/components/nodes/genericFlow/DataOutputAssociation.js
@@ -65,11 +65,7 @@ export default class DataOutputAssociation extends DataAssociation {
     if (targetIsDataStore && dataStoreValidSources.includes(sourceType)) {
       return true;
     }
-    if (targetIsDataObject && dataObjectValidSources.includes(sourceType)) {
-      return true;
-    }
-
-    return false;
+    return (targetIsDataObject && dataObjectValidSources.includes(sourceType));
   }
 
   makeFlowNode(sourceShape, targetShape, genericLink) {

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -5,7 +5,7 @@ import { id as messageFlowId } from '../components/nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '../components/nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '../components/nodes/dataInputAssociation/config';
 import { id as genericFlowId } from '../components/nodes/genericFlow/config';
-import { getOrFindDataInput } from '../components/crown/utils';
+import { getOrFindDataInput, findIOSpecificationOwner } from '../components/crown/utils';
 
 export default {
   methods: {
@@ -57,7 +57,12 @@ export default {
     // Returns the Flow Element (Task| DataStore| DataObject)  that is the target of the association
     getDataInputOutputAssociationTargetRef(association) {
       if (association.targetRef.$type === 'bpmn:DataInput') {
-        return association.targetRef.$parent.$parent;
+        const ioSpec = association.targetRef.$parent;
+        return findIOSpecificationOwner(ioSpec, this);
+      }
+      if (association.targetRef.$type === 'bpmn:DataInputAssociation') {
+        const ioSpec = association.targetRef.$parent;
+        return findIOSpecificationOwner(ioSpec, this);
       }
       return association.targetRef;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
Invalid connections from DataStore/DataObject to EndEvents

Expected behavior: 
Do not allow invalid connections from DataStore/DataObject to EndEvents

Actual behavior: 
User can create invalid connections from DataStore/DataObject to EndEvents

## Solution
- Validate connections from DataStore/DataObject to EndEvents
- Register properly the $parent property of the association

## How to Test
- Create a process
- Add a DataStore and an EndEvent
- Try to connect them in any direction

![image](https://user-images.githubusercontent.com/8028650/233092712-871fbf40-1f0c-4726-b3ce-8c26443827c5.png)
It should not be allowed.

These are all the valid combinatios:
![Screenshot from 2023-04-20 09-09-15](https://user-images.githubusercontent.com/8028650/233378379-d4783158-ecd9-4566-889e-47cb447674d8.png)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7996

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
