### PR TITLE
FIX FOUR7977 Connectors of Boundary Events are not cloned

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -29,13 +29,7 @@ import { id as poolId } from '@/components/nodes/pool/config';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
 import { labelWidth, poolPadding } from '../nodes/pool/poolSizes';
-const boundaryElements = [
-  'processmaker-modeler-boundary-timer-event',
-  'processmaker-modeler-boundary-error-event',
-  'processmaker-modeler-boundary-signal-event',
-  'processmaker-modeler-boundary-conditional-event',
-  'processmaker-modeler-boundary-message-event',
-];
+
 export default {
   name: 'Selection',
   components: {
@@ -351,24 +345,6 @@ export default {
         }
         return true;
       });
-      // A boundary event could only be selected alone
-      const firstSelectedBoundary = this.selected.find(shape => {
-        return shape.model.component &&
-          boundaryElements.includes(shape.model.component.node.type);
-      });
-      const firstSelectedElement = this.selected[0];
-      if (firstSelectedBoundary) {
-        this.selected = this.selected.filter(shape => {
-          if (firstSelectedElement === firstSelectedBoundary) {
-            // boundary event selected alone
-            return shape.model.component &&
-              shape === firstSelectedBoundary;
-          }
-          // do not allow to select a boundary event with another element
-          return shape.model.component &&
-            !boundaryElements.includes(shape.model.component.node.type);
-        });
-      }
     },
     /**
      * Pan paper handler
@@ -475,6 +451,9 @@ export default {
       this.$emit('save-state');
       this.dragging = false;
       this.stopForceMove = false;
+      // Readjusts the selection box, taking into consideration elements
+      // that are anchored and did not move, such as boundary events. 
+      this.updateSelectionBox();
     },
     /**
      * Translate the Selected shapes adding some custom validations


### PR DESCRIPTION
## Issue & Reproduction Steps

### Expected behavior: 

When duplicating a selection that includes a boundary event with a connector, the connector of the boundary event should be cloned.

### Actual behavior: 
When duplicating a selection that includes a boundary event with a connector, the connector of the boundary event is not cloned.

## Solution
The issue has been resolved by enabling to select boundary events so they can be cloned =within a selection. The fix has been tested and verified to work as expected.

[CloneWithBoundaryEvents.webm](https://user-images.githubusercontent.com/8028650/233140610-50234cc8-9525-4404-a663-97f9e74fcb9a.webm)

## How to Test
- Create a task with a boundary event
- Connect the boundary to a second task
- Select the created elements
- Click on the duplicate option con clone the selection

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7977

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
