### PR TITLE
FIX FOUR-8055 Copy/Paste Hotkeys is not working with Bloq-Mayus

### DIFF
--- a/src/components/hotkeys/copyPaste.js
+++ b/src/components/hotkeys/copyPaste.js
@@ -1,8 +1,9 @@
 export default {
   methods: {
     copyPasteHandler(event, options) {
-      const isCopy = event.key === 'c';
-      const isPaste = event.key === 'v';
+      const key = event.key.toLowerCase();
+      const isCopy = key === 'c';
+      const isPaste = key === 'v';
 
       if (isCopy && options.mod) {
         this.copy(event);


### PR DESCRIPTION
## Issue & Reproduction Steps
Copy/Paste Hotkeys is not working with Bloq-Mayus.
- Drag a start Event
- enable Bloq-Mayus
- copy the element with hotkeys (CTRL+C) and paste the element with hotkeys (CTRL+V).

### Expected behavior: 
Hot keys should work if the Bloq Mayus is enabled.

### Actual behavior: 
Hot keys are not working if the Bloq Mayus is enabled.

## Solution
Fix the bug that prevents the host keys from working with the Bloq Mayus enabled.

This was tested in Mac/Linux/Windows

## How to Test
- Enable Bloq-Mayus and copy/paste the element with host keys.
- Disenable Bloq-Mayus and copy/paste the element with host keys.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8055