### PR TITLE
Bugfix/four 8041

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -399,6 +399,7 @@ export default {
     },
     async duplicateSelection() {
       const clonedNodes = this.cloneSelection();
+      this.$refs.selector.clearSelection();
       await this.addClonedNodes(clonedNodes);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -399,6 +399,9 @@ export default {
     },
     async duplicateSelection() {
       const clonedNodes = this.cloneSelection();
+      if (clonedNodes && clonedNodes.length === 0) {
+        return;
+      }
       this.$refs.selector.clearSelection();
       await this.addClonedNodes(clonedNodes);
       await this.$nextTick();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The screen should not freeze  with any selection
Actual behavior: 
Screen freeze with "Duplicated selection" if user click many time the duplicate button
## Solution
- After the user click in the duplicated button the selection box was cleaned

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8041

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
