### PR TITLE
Bugfix/four 7959 a

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -114,6 +114,7 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
       inputSets: [],
       outputSets: [],
     });
+    task.definition.ioSpecification.$parent = task.definition;
   }
   // Check if dataInput exists
   if (!task.definition.ioSpecification.dataInputs) {
@@ -126,6 +127,7 @@ export function getOrFindDataInput(moddle, task, sourceNode) {
       isCollection: 'false',
       name: sourceNode.name,
     }));
+    task.definition.ioSpecification.dataInputs[task.definition.ioSpecification.dataInputs.length - 1].$parent = task.definition.ioSpecification;
     task.definition.ioSpecification.set('dataInputs', task.definition.ioSpecification.dataInputs);
   }
   dataInput = task.definition.ioSpecification.dataInputs.find(input => input.id === dataInputId);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -439,8 +439,8 @@ export default {
           // is a Task, UserTask, ManualTask, CallActivity...
           clonedElement = clonedNodes.find(node => node.definition.cloneOf === originalElement.id);
           clonedDataInput = getOrFindDataInput(this.moddle, clonedElement, srcClone.definition);
-          console.log('originalAssociation', originalAssociation);
-          console.log('clonedAssociation', clonedAssociation);
+          // console.log('originalAssociation', originalAssociation);
+          // console.log('clonedAssociation', clonedAssociation);
 
           clonedAssociation.definition.sourceRef = [srcClone.definition];
           clonedAssociation.definition.targetRef = clonedDataInput;

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -57,7 +57,7 @@ export default {
       }
 
       /* A data input association can be connected to anything that isn't a data store or object or a start event */
-      const invalidTarget = this.targetNode.isBpmnType('bpmn:DataObjectReference', 'bpmn:DataStoreReference', 'bpmn:StartEvent');
+      const invalidTarget = !this.targetNode.isBpmnType('bpmn:Task', 'bpmn:SubProcess', 'bpmn:CallActivity', 'bpmn:ManualTask', 'bpmn:ScriptTask', 'bpmn:ServiceTask');
 
       if (invalidTarget) {
         return false;

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -102,7 +102,8 @@ export default {
       const targetShape = this.shape.getTargetElement();
       const dataInput = getOrFindDataInput(this.moddle, targetShape.component.node, this.sourceNode.definition);
       this.node.definition.set('targetRef', dataInput);
-      this.node.definition.set('sourceRef', this.sourceNode.definition);
+      // @todo Review why this needs to be and array. When saving the BPMN, if this is not an array the sourceRef is not stored
+      this.node.definition.set('sourceRef', [this.sourceNode.definition]);
       targetShape.component.node.definition.set('dataInputAssociations', [this.node.definition]);
     },
   },

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -72,16 +72,16 @@ export default {
         return this.node.dataAssociationProps.sourceShape;
       }
 
-      const taskWithInputAssociation = this.graph.getElements().find(element => {
-        return element.component && element.component.node.definition.get('dataInputAssociations') &&
-            element.component.node.definition.get('dataInputAssociations')[0] === this.node.definition;
+      const taskWithInputAssociation = this.$parent.nodes.find(element => {
+        return element.definition.get('dataInputAssociations') &&
+            element.definition.get('dataInputAssociations')[0].definition === this.node.definition;
       });
 
-      const dataObjectDefinition = taskWithInputAssociation.component.node.definition.get('dataInputAssociations')[0].sourceRef[0];
-
-      return this.graph.getElements().find(element => {
-        return element.component && element.component.node.definition === dataObjectDefinition;
-      });
+      const dataObjectDefinition = taskWithInputAssociation.definition.get('dataInputAssociations')[0].definition.sourceRef[0];
+      return dataObjectDefinition;
+      // return this.$parent.nodes.find(element => {
+      //   return element.definition === dataObjectDefinition;
+      // });
     },
     getTargetRef() {
       if (this.node.dataAssociationProps) {

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -71,17 +71,10 @@ export default {
       if (this.node.dataAssociationProps) {
         return this.node.dataAssociationProps.sourceShape;
       }
-
-      const taskWithInputAssociation = this.$parent.nodes.find(element => {
-        return element.definition.get('dataInputAssociations') &&
-            element.definition.get('dataInputAssociations')[0].definition === this.node.definition;
-      });
-
-      const dataObjectDefinition = taskWithInputAssociation.definition.get('dataInputAssociations')[0].definition.sourceRef[0];
-      return dataObjectDefinition;
-      // return this.$parent.nodes.find(element => {
-      //   return element.definition === dataObjectDefinition;
-      // });
+      const source = this.node.definition.sourceRef[0];
+      // find shape
+      const shape = this.graph.getElements().find(e=>e.component.node.definition === source);
+      return shape;
     },
     getTargetRef() {
       if (this.node.dataAssociationProps) {

--- a/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
+++ b/src/components/nodes/dataInputAssociation/dataInputAssociation.vue
@@ -102,7 +102,7 @@ export default {
       const targetShape = this.shape.getTargetElement();
       const dataInput = getOrFindDataInput(this.moddle, targetShape.component.node, this.sourceNode.definition);
       this.node.definition.set('targetRef', dataInput);
-      this.node.definition.set('sourceRef', [this.sourceNode.definition]);
+      this.node.definition.set('sourceRef', this.sourceNode.definition);
       targetShape.component.node.definition.set('dataInputAssociations', [this.node.definition]);
     },
   },

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -138,7 +138,7 @@ export default class Node {
         }
       }
       clonedFlow.definition.set(key, clonedDefinition);
-      clonedFlow.definition.sourceRef = clonedFlow.definition.targetRef  = null;
+      clonedFlow.definition.sourceRef = clonedFlow.definition.targetRef = null;
     });
 
     Node.eventDefinitionPropertiesToNotCopy.forEach(

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -10,7 +10,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export default class Node {
   static diagramPropertiesToCopy = ['x', 'y', 'width', 'height'];
-  static definitionPropertiesToNotCopy = ['$type', 'id'];
+  static definitionPropertiesToNotCopy = ['$type', 'id', 'ioSpecification'];
   static flowDefinitionPropertiesToNotCopy = ['$type', 'id', 'sourceRef', 'targetRef'];
   static eventDefinitionPropertiesToNotCopy = ['errorRef', 'messageRef'];
 

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -10,7 +10,7 @@ import cloneDeep from 'lodash/cloneDeep';
 
 export default class Node {
   static diagramPropertiesToCopy = ['x', 'y', 'width', 'height'];
-  static definitionPropertiesToNotCopy = ['$type', 'id', 'ioSpecification'];
+  static definitionPropertiesToNotCopy = ['$type', 'id', 'ioSpecification', 'dataOutputAssociations'];
   static flowDefinitionPropertiesToNotCopy = ['$type', 'id', 'sourceRef', 'targetRef'];
   static eventDefinitionPropertiesToNotCopy = ['errorRef', 'messageRef'];
 
@@ -90,7 +90,7 @@ export default class Node {
 
     clonedNode.id = null;
     clonedNode.pool = this.pool;
-    clonedNode.definition.cloneOf = this.id;
+    clonedNode.cloneOf = this.id;
 
     Node.diagramPropertiesToCopy.forEach(prop => clonedNode.diagram.bounds[prop] = this.diagram.bounds[prop]);
     Object.keys(this.definition).filter(key => !Node.definitionPropertiesToNotCopy.includes(key)).forEach(key => {
@@ -122,7 +122,7 @@ export default class Node {
 
     clonedFlow.id = null;
     clonedFlow.pool = this.pool;
-    clonedFlow.definition.cloneOf = this.id;
+    clonedFlow.cloneOf = this.id;
     clonedFlow.diagram.waypoint = [];
 
     this.diagram.waypoint.forEach(point => clonedFlow.diagram.waypoint.push(point));

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -1,0 +1,138 @@
+import { id as laneId } from '../components/nodes/poolLane/config';
+import { id as sequenceFlowId } from '../components/nodes/sequenceFlow';
+import { id as associationId } from '../components/nodes/association';
+import { id as messageFlowId } from '../components/nodes/messageFlow/config';
+import { id as dataOutputAssociationFlowId } from '../components/nodes/dataOutputAssociation/config';
+import { id as dataInputAssociationFlowId } from '../components/nodes/dataInputAssociation/config';
+import { id as genericFlowId } from '../components/nodes/genericFlow/config';
+import { getOrFindDataInput } from '../components/crown/utils';
+
+export default {
+  methods: {
+    cloneSelection() {
+      let clonedNodes = [], clonedFlows = [], clonedDataInputAssociations = [], clonedDataOutputAssociations = [];
+      const nodes = this.highlightedNodes;
+      const selector = this.$refs.selector.$el;
+      const flowNodeTypes = [
+        sequenceFlowId,
+        laneId,
+        associationId,
+        messageFlowId,
+        genericFlowId,
+      ];
+      const dataInputAssociationNodeTypes = [
+        dataInputAssociationFlowId,
+      ];
+      const dataOutputAssociationNodeTypes = [
+        dataOutputAssociationFlowId,
+      ];
+
+      if (typeof selector.getBoundingClientRect === 'function') {
+        nodes.forEach(node => {
+          if (flowNodeTypes.includes(node.type)) {
+            const clonedFlow = this.cloneFlowAndSetNewId(node);
+            clonedFlows.push(clonedFlow);
+            clonedNodes.push(clonedFlow);
+          } else if (dataInputAssociationNodeTypes.includes(node.type)) {
+            const clonedFlow = this.cloneFlowAndSetNewId(node);
+            clonedDataInputAssociations.push(clonedFlow);
+            clonedNodes.push(clonedFlow);
+          } else if (dataOutputAssociationNodeTypes.includes(node.type)) {
+            const clonedFlow = this.cloneFlowAndSetNewId(node);
+            clonedDataOutputAssociations.push(clonedFlow);
+            clonedNodes.push(clonedFlow);
+          } else {
+            const clonedElement = this.cloneElementAndCalculateOffset(node);
+            clonedNodes.push(clonedElement);
+          }
+        });
+      }
+
+      this.connectClonedFlows(clonedFlows, clonedNodes);
+      this.connectClonedDataInputAssociations(clonedDataInputAssociations, clonedNodes);
+      this.connectClonedDataOutputAssociations(clonedDataOutputAssociations, clonedNodes);
+
+      return clonedNodes;
+    },
+    // Returns the Flow Element (Task| DataStore| DataObject)  that is the target of the association
+    getDataInputOutputAssociationTargetRef(association) {
+      if (association.targetRef.$type === 'bpmn:DataInput') {
+        return association.targetRef.$parent.$parent;
+      }
+      return association.targetRef;
+    },
+    cloneFlowAndSetNewId(node) {
+      const clonedFlow = node.cloneFlow(this.nodeRegistry, this.moddle, this.$t);
+      clonedFlow.setIds(this.nodeIdGenerator);
+      return clonedFlow;
+    },
+    cloneElementAndCalculateOffset(node) {
+      const clonedElement = node.clone(this.nodeRegistry, this.moddle, this.$t);
+      const { height: selectorHeight } = this.$refs.selector.$el.getBoundingClientRect();
+      const { sy } = this.paper.scale();
+      const yOffset = selectorHeight / sy;
+      clonedElement.diagram.bounds.y += yOffset;
+      clonedElement.setIds(this.nodeIdGenerator);
+      return clonedElement;
+    },
+    connectClonedFlows(clonedFlows, clonedNodes) {
+      clonedFlows.forEach(clonedFlow => {
+        const originalFlow = this.nodes.find(node => node.definition.id === clonedFlow.cloneOf);
+        const src = originalFlow.definition.sourceRef;
+        const target = originalFlow.definition.targetRef;
+        const srcClone = clonedNodes.find(node => node.cloneOf === src.id);
+        const targetClone = clonedNodes.find(node => node.cloneOf === target.id);
+        clonedFlow.definition.set('sourceRef', [srcClone.definition]);
+        clonedFlow.definition.set('targetRef', targetClone);
+        clonedFlow.definition.sourceRef = srcClone.definition;
+        clonedFlow.definition.targetRef = targetClone.definition;
+
+        if (srcClone.definition.outgoing) {
+          srcClone.definition.outgoing.push(clonedFlow.definition);
+        } else {
+          srcClone.definition.outgoing = [clonedFlow.definition];
+        }
+
+        if (targetClone.definition.incoming) {
+          targetClone.definition.incoming.push(clonedFlow.definition);
+        } else {
+          targetClone.definition.incoming = [clonedFlow.definition];
+        }
+
+        clonedFlow.diagram.waypoint.forEach(point => {
+          const { height: selectorHeight } = this.$refs.selector.$el.getBoundingClientRect();
+          point.y += selectorHeight;
+        });
+      });
+    },
+    connectClonedDataInputAssociations(clonedDataInputAssociations, clonedNodes) {
+      clonedDataInputAssociations.forEach(clonedAssociation => {
+        const originalAssociation = this.nodes.find(node => node.definition.id === clonedAssociation.cloneOf);
+        const src = originalAssociation.definition.sourceRef[0];
+        const srcClone = clonedNodes.find(node => node.cloneOf === src.id);
+        const originalTargetElement = this.getDataInputOutputAssociationTargetRef(originalAssociation.definition);
+        const clonedElement = clonedNodes.find(node => node.cloneOf === originalTargetElement.id);
+        const clonedDataInput = getOrFindDataInput(this.moddle, clonedElement, srcClone.definition);
+
+        clonedAssociation.definition.sourceRef = [srcClone.definition];
+        clonedAssociation.definition.targetRef = clonedDataInput;
+        clonedElement.definition.set('dataInputAssociations', [clonedAssociation.definition]);
+      });
+    },
+    connectClonedDataOutputAssociations(clonedDataOutputAssociations, clonedNodes) {
+      clonedDataOutputAssociations.forEach(clonedAssociation => {
+        const originalAssociation = this.nodes.find(node => node.definition.id === clonedAssociation.cloneOf);
+        const src = originalAssociation.definition.sourceRef;
+        const target = originalAssociation.definition.targetRef;
+        const srcClone = clonedNodes.find(node => node.cloneOf === src.id);
+        const targetClone = clonedNodes.find(node => node.cloneOf === target.id);
+
+        clonedAssociation.definition.set('targetRef', targetClone.definition);
+        clonedAssociation.definition.set('sourceRef', srcClone.definition);
+
+        const existingOutputAssociations = srcClone.definition.get('dataOutputAssociations') || [];
+        srcClone.definition.set('dataOutputAssociations', [...existingOutputAssociations, clonedAssociation.definition]);
+      });
+    },
+  },
+};


### PR DESCRIPTION
## Fix merged PR to point IT3-spring

Original PR: https://github.com/ProcessMaker/modeler/pull/1503

## Issue & Reproduction Steps
Selection with Data Store is not cloned. Steps to Reproduce: 

- Add Task form 
- Add Data Store
- Connect the Task Form with Data store 
- Select the elements 
- Press “Duplicate Selection“

### Expected behavior: 
The selection with data store should be cloned.

### Actual behavior: 
The selection with data store could not be cloned.

## Solution
The solution is to add a custom clone logic that handles properly the data store and dat object to be cloned.

## How to Test
To test the solution:
- add a Task form
- add a Data Store
- connect the Task Form with Data store
- select the elements
- and press “Duplicate Selection” to check if the selection with data store has been successfully cloned.

[CloneDataStoreDataObject.webm](https://user-images.githubusercontent.com/8028650/233383881-f1656bec-10c2-4538-893d-192405b0f2f7.webm)

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7958
- https://processmaker.atlassian.net/browse/FOUR-7959

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
