### PR TITLE
FOUR-7954 Added check if srcClone || targetClone are undefined to rem…

### DIFF
--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -82,6 +82,10 @@ export default {
         const target = originalFlow.definition.targetRef;
         const srcClone = clonedNodes.find(node => node.cloneOf === src.id);
         const targetClone = clonedNodes.find(node => node.cloneOf === target.id);
+        if (!srcClone || !targetClone) {
+          clonedNodes.splice(clonedNodes.indexOf(clonedFlow), 1);
+          return;
+        }
         clonedFlow.definition.set('sourceRef', [srcClone.definition]);
         clonedFlow.definition.set('targetRef', targetClone);
         clonedFlow.definition.sourceRef = srcClone.definition;

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -78,7 +78,7 @@ export default {
       });
     },
     setEndpoint(shape, endpoint, connectionOffset) {
-      if (isPoint(shape)) {
+      if (shape && isPoint(shape)) {
         return this.shape[endpoint](shape, {
           anchor: {
             name: 'modelCenter',
@@ -252,6 +252,9 @@ export default {
     const targetRef = this.getTargetRef
       ? this.getTargetRef()
       : this.node.definition.get('targetRef');
+
+    // if flow doesn't have a targetRef such as incomplete node, return
+    if (!targetRef) return;
 
     if (targetRef.id) {
       const targetShape = this.graph.getElements().find(element => {


### PR DESCRIPTION
…ove it from the node

## Issue & Reproduction Steps

Expected behavior: 
If we want to clone a Start -> Task -> without a end element, the last flow shouldn't be cloned so it would end as Start -> Task

Actual behavior: 
ALL SORTS OF ERRORS 😆 since we are not checking for the `sourceRef` or `targetRef` to be defined

## Solution
- Added an if statement to check if the srcClone or targetClone are defined since these determine where the flow is going or outgoing

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7954
- https://processmaker.atlassian.net/browse/FOUR-7975

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
