### PR TITLE
FOUR-8137: Data Object selection can now be cloned again after undo

### DIFF
--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -122,7 +122,7 @@ export default {
     connectClonedDataOutputAssociations(clonedDataOutputAssociations, clonedNodes) {
       clonedDataOutputAssociations.forEach(clonedAssociation => {
         const originalAssociation = this.nodes.find(node => node.definition.id === clonedAssociation.cloneOf);
-        const src = originalAssociation.definition.sourceRef;
+        const src = originalAssociation.definition.sourceRef || originalAssociation.definition.$parent;
         const target = originalAssociation.definition.targetRef;
         const srcClone = clonedNodes.find(node => node.cloneOf === src.id);
         const targetClone = clonedNodes.find(node => node.cloneOf === target.id);


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Drag Data Object
2. Drag Start Event
3. Connect the elements  (Start Event -> Data Object)
4. Select the elements
5. Clone the selection
6. Click on UNDO button
7. Try to clone again the first selection

Expected behavior: 
It should be possible to clone the selection with data object.

Actual behavior: 
It is not possible to clone the data object after making UNDO.

## Solution
- A reference for the `sourceRef ` of the Data Association was missing for a reason that needs to be analyzed, in this case to the Start Event. This reference was found to be the `$parent` attribute of the original Data Association in case the `sourceRef ` disappears.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8137

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
