### PR TITLE
FOUR-8040 - The screen does not focus on the cloned selection

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -337,12 +337,12 @@ export default {
     },
     async pasteElements() {
       if (this.copiedElements) {
-        this.scrollToSelection();
         await this.addClonedNodes(this.copiedElements);
         await this.$nextTick();
         await this.paperManager.awaitScheduledUpdates();
         await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
         store.commit('setCopiedElements', this.cloneSelection());
+        this.scrollToSelection();
       }
     },
     async duplicateSelection() {
@@ -350,18 +350,23 @@ export default {
       if (clonedNodes && clonedNodes.length === 0) {
         return;
       }
-      this.scrollToSelection();
       this.$refs.selector.clearSelection();
       await this.addClonedNodes(clonedNodes);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
-      await this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes), true);
+      await this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
+      this.scrollToSelection();
     },
     scrollToSelection() {
-      const selector = this.$refs.selector.$el;
-      const { height } = selector.getBoundingClientRect();
-      const currentPosition = this.paper.translate();
-      this.paper.translate(currentPosition.tx, currentPosition.ty - height * 0.9);
+      const containerRect = this.$refs['paper-container'].getBoundingClientRect();
+      const selector = this.$refs.selector;
+      const selectorRect = selector.$el.getBoundingClientRect();
+      // Scroll to the cloned elements only when they are not visible on the screen.
+      if (selectorRect.right > containerRect.right || selectorRect.bottom > containerRect.bottom || selectorRect.left < containerRect.left || selectorRect.top < containerRect.top) {
+        const currentPosition = this.paper.translate();
+        this.paper.translate(currentPosition.tx, currentPosition.ty - selectorRect.height);
+        selector.updateSelectionBox(true);
+      }
     },
     findViewElementsFromNodes(nodes) {
       return nodes.map(node => {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -337,10 +337,11 @@ export default {
     },
     async pasteElements() {
       if (this.copiedElements) {
+        this.scrollToSelection();
         await this.addClonedNodes(this.copiedElements);
         await this.$nextTick();
         await this.paperManager.awaitScheduledUpdates();
-        this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements));
+        await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
         store.commit('setCopiedElements', this.cloneSelection());
       }
     },
@@ -349,11 +350,18 @@ export default {
       if (clonedNodes && clonedNodes.length === 0) {
         return;
       }
+      this.scrollToSelection();
       this.$refs.selector.clearSelection();
       await this.addClonedNodes(clonedNodes);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
-      this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
+      await this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes), true);
+    },
+    scrollToSelection() {
+      const selector = this.$refs.selector.$el;
+      const { height } = selector.getBoundingClientRect();
+      const currentPosition = this.paper.translate();
+      this.paper.translate(currentPosition.tx, currentPosition.ty - height * 0.9);
     },
     findViewElementsFromNodes(nodes) {
       return nodes.map(node => {


### PR DESCRIPTION
## Issue & Reproduction Steps

The screen does not focus on the cloned selection

- Drag a components like (Start Event → Task Form → End Event)
- Select the components 
- Duplicate the selection

Expected behavior: 
- Scroll should be enabled for cloned elements

Actual behavior:
- If the selection is very large, it is not possible to see that it has been cloned correctly

## Solution
- After duplicating or pasting, we'll perform a scroll to the cloned elements only if the cloned elements are outside the paperContainer.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-8040](https://processmaker.atlassian.net/browse/FOUR-8040)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8040]: https://processmaker.atlassian.net/browse/FOUR-8040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ