### PR TITLE
Nodes can now be pasted quickly without issue

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -346,6 +346,7 @@ export default {
           await this.$nextTick();
           await this.paperManager.awaitScheduledUpdates();
           await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
+          await this.$nextTick();
           await store.commit('setCopiedElements', this.cloneSelection());
           this.scrollToSelection();
         } finally {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -195,6 +195,7 @@ export default {
   mixins: [hotkeys, cloneSelection],
   data() {
     return {
+      pasteInProgress: false,
       internalClipboard: [],
       tooltipTarget: null,
 
@@ -338,13 +339,18 @@ export default {
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },
     async pasteElements() {
-      if (this.copiedElements) {
-        await this.addClonedNodes(this.copiedElements);
-        await this.$nextTick();
-        await this.paperManager.awaitScheduledUpdates();
-        await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
-        store.commit('setCopiedElements', this.cloneSelection());
-        this.scrollToSelection();
+      if (this.copiedElements && !this.pasteInProgress) {
+        this.pasteInProgress = true;
+        try {
+          await this.addClonedNodes(this.copiedElements);
+          await this.$nextTick();
+          await this.paperManager.awaitScheduledUpdates();
+          await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
+          await store.commit('setCopiedElements', this.cloneSelection());
+          this.scrollToSelection();
+        } finally {
+          this.pasteInProgress = false;
+        }
       }
     },
     async duplicateSelection() {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Drag a Start Event or Task into canvas.
2. Press Ctrl + C while the element is selected.
3. Quickly press Ctrl + V multiple times in quick succession.

Expected behavior: 
Many copies will be pasted onto canvas with different ID's
Actual behavior: 
Many copies with the same ID's are being pasted onto canvas.

## Solution
- Using a similar approach as [PR: 1502](https://github.com/ProcessMaker/modeler/pull/1502) the paste action has been locked when too many paste events are made.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8057

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
