### PR TITLE
FOUR-7834 Modified the behavior of client entering / leaving the paper

### DIFF
--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -46,7 +46,6 @@ export default {
       if (event.code === 'Space') {
         this.isGrabbing = true;
         this.paperManager.addEventHandler('blank:pointermove', (event, x, y) => {
-          // console.log({ x: event.clientX, y: event.clientY });
           if (!this.canvasDragPosition) {
             const scale = this.paperManager.scale;
             this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };

--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -5,6 +5,11 @@ import moveShapeByKeypress from './moveWithArrowKeys';
 
 export default {
   mixins: [ZoomInOut, CopyPaste],
+  computed: {
+    clientLeftPaper() {
+      return store.getters.clientLeftPaper;
+    },
+  },
   mounted() {
     document.addEventListener('keydown', this.keydownListener);
     document.addEventListener('keyup', this.keyupListener);
@@ -41,11 +46,12 @@ export default {
       if (event.code === 'Space') {
         this.isGrabbing = true;
         this.paperManager.addEventHandler('blank:pointermove', (event, x, y) => {
+          // console.log({ x: event.clientX, y: event.clientY });
           if (!this.canvasDragPosition) {
             const scale = this.paperManager.scale;
             this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };
           }
-          if (this.canvasDragPosition) {
+          if (this.canvasDragPosition && !this.clientLeftPaper) {
             this.paperManager.translate(
               event.offsetX - this.canvasDragPosition.x,
               event.offsetY - this.canvasDragPosition.y

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1222,14 +1222,17 @@ export default {
       this.pointerUpHandler(event, cellView);
     }, this);
 
+    this.$el.addEventListener('mouseenter', () => {
+      store.commit('setClientLeftPaper', false);
+    });
+
     this.$el.addEventListener('mousemove', event => {
-      const { clientX, clientY } = event;
       this.pointerMoveHandler(event);
-      store.commit('setClientMousePosition', { clientX, clientY });
     });
 
     this.$el.addEventListener('mouseleave', () => {
-      store.commit('clientLeftPaper');
+      this.paperManager.removeEventHandler('blank:pointermove');
+      store.commit('setClientLeftPaper', true);
     });
 
     this.paperManager.addEventHandler('cell:pointerclick', (cellView, evt, x, y) => {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -342,7 +342,7 @@ export default {
         await this.addClonedNodes(this.copiedElements);
         await this.$nextTick();
         await this.paperManager.awaitScheduledUpdates();
-        this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements));
+        await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements));
         store.commit('setCopiedElements', this.cloneSelection());
       }
     },
@@ -355,7 +355,7 @@ export default {
       await this.addClonedNodes(clonedNodes);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
-      this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
+      await this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
     },
     findViewElementsFromNodes(nodes) {
       return nodes.map(node => {

--- a/src/store.js
+++ b/src/store.js
@@ -36,8 +36,7 @@ export default new Vuex.Store({
     globalProcesses: [],
     allowSavingElementPosition: true,
     copiedElements: [],
-    clientX: null,
-    clientY: null,
+    clientLeftPaper: false,
   },
   getters: {
     nodes: state => state.nodes,
@@ -56,8 +55,7 @@ export default new Vuex.Store({
     globalProcessEvents: (state, getters) => flatten(getters.globalProcesses.map(process => process.events)),
     allowSavingElementPosition: state => state.allowSavingElementPosition,
     copiedElements: state => state.copiedElements,
-    clientX: state => state.clientX,
-    clientY: state => state.clientY,
+    clientLeftPaper: state => state.clientLeftPaper,
   },
   mutations: {
     preventSavingElementPosition(state) {
@@ -148,13 +146,8 @@ export default new Vuex.Store({
     setCopiedElements(state, elements) {
       state.copiedElements = elements;
     },
-    setClientMousePosition(state, position) {
-      const { clientX, clientY } = position;
-      state = { clientX, clientY };
-    },
-    clientLeftPaper(state) {
-      state.clientX = null;
-      state.clientY = null;
+    setClientLeftPaper(state, status) {
+      state.clientLeftPaper = status;
     },
   },
   actions: {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Paper panning should be stopped when Client tries to move the paper outside of it

Actual behavior: 
Paper panning is not stopped when client moves outside of the paper causing the cells to be moved to 0

## Solution
- Added a new Boolean state to set if the client has left the paper or not.
- Removed the setting the client {X,Y} from the mouse on every iteration since I noticed was causing a lot of delay and creating a long pool of Vue Changes

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7834

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
