### PR TITLE
FOUR-8040-a - The screen does not focus on the cloned selection

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -366,7 +366,8 @@ export default {
       // Scroll to the cloned elements only when they are not visible on the screen.
       if (selectorRect.right > containerRect.right || selectorRect.bottom > containerRect.bottom || selectorRect.left < containerRect.left || selectorRect.top < containerRect.top) {
         const currentPosition = this.paper.translate();
-        this.paper.translate(currentPosition.tx, currentPosition.ty - selectorRect.height);
+        const newTy = currentPosition.ty - (selectorRect.top - containerRect.top - selectorRect.height);
+        this.paper.translate(currentPosition.tx, newTy);
         selector.updateSelectionBox(true);
       }
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

When you click on another element that is above, in that case the selection copied is no longer focused

1. Add task form -> End Event
2. Select the items
3. Press Copy (Ctrl +C)
4. Paste the selection
5. Change the first selection to see the start
6. Click on first selection
7. Paste the selection

Expected behavior: 
- Scroll should be enabled for cloned elements

Actual behavior:
- If the selection is very large, it is not possible to see that it has been cloned correctly

## Solution
- Improved the way to calculate the new y-axis position for the cloned element.

## How to Test
Test the steps above

## Related Tickets & Packages
- [Previous PR](https://github.com/ProcessMaker/modeler/pull/1510)
- [FOUR-8040](https://processmaker.atlassian.net/browse/FOUR-8040)