### PR TITLE
FOUR-8194 Renamed mostly everything to cloneButton except Modeler sin…

### DIFF
--- a/src/components/crown/crownButtons/cloneButton.vue
+++ b/src/components/crown/crownButtons/cloneButton.vue
@@ -34,7 +34,7 @@ export default {
   },
   methods: {
     cloneElement() {
-      this.$emit('duplicate-element', this.node, ++this.copyCount);
+      this.$emit('clone-element', this.node, ++this.copyCount);
     },
   },
 };

--- a/src/components/crown/crownButtons/cloneButton.vue
+++ b/src/components/crown/crownButtons/cloneButton.vue
@@ -1,9 +1,9 @@
 <template>
   <crown-button
     v-if="node.isBpmnType(...validCopyElements)"
-    :title="$t('Clone element')"
+    :title="$t('Clone Element')"
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
-    aria-label="Clone element"
+    aria-label="Clone Element"
     data-test="clone-button"
     role="menuitem"
     @click="cloneElement"

--- a/src/components/crown/crownButtons/cloneButton.vue
+++ b/src/components/crown/crownButtons/cloneButton.vue
@@ -1,16 +1,17 @@
 <template>
   <crown-button
     v-if="node.isBpmnType(...validCopyElements)"
-    :title="$t('Duplicate Element')"
+    :title="$t('Clone element')"
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
-    aria-label="Duplicate Element"
-    data-test="duplicate-button"
+    aria-label="Clone element"
+    data-test="clone-button"
     role="menuitem"
-    @click="duplicateElement"
+    @click="cloneElement"
   >
     <img
-      :src="duplicateIcon"
+      :src="cloneIcon"
       aria-hidden="true"
+      alt="Clone element icon"
     >
   </crown-button>
   
@@ -18,7 +19,7 @@
 
 <script>
 import CrownButton from '@/components/crown/crownButtons/crownButton';
-import duplicateIcon from '@/assets/copy-regular.svg';
+import cloneIcon from '@/assets/copy-regular.svg';
 import validCopyElements from '@/components/crown/crownButtons/validCopyElements';
 
 export default {
@@ -27,12 +28,12 @@ export default {
   data() {
     return {
       copyCount: 0,
-      duplicateIcon,
+      cloneIcon,
       validCopyElements,
     };
   },
   methods: {
-    duplicateElement() {
+    cloneElement() {
       this.$emit('duplicate-element', this.node, ++this.copyCount);
     },
   },

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -50,7 +50,7 @@
       v-on="$listeners"
     />
 
-    <duplicate-button
+    <clone-button
       :node="node"
       v-on="$listeners"
     />
@@ -84,7 +84,7 @@ import GenericFlowButton from '@/components/crown/crownButtons/genericFlowButton
 import AssociationFlowButton from '@/components/crown/crownButtons/associationFlowButton';
 import DataAssociationFlowButton from '@/components/crown/crownButtons/dataAssociationFlowButton';
 import CopyButton from '@/components/crown/crownButtons/copyButton.vue';
-import DuplicateButton from '@/components/crown/crownButtons/duplicateButton.vue';
+import CloneButton from '@/components/crown/crownButtons/cloneButton.vue';
 import CrownDropdowns from '@/components/crown/crownButtons/crownDropdowns';
 import DefaultFlow from '@/components/crown/crownButtons/defaultFlowButton.vue';
 import poolLaneCrownConfig from '@/mixins/poolLaneCrownConfig';
@@ -101,7 +101,7 @@ export default {
     GenericFlowButton,
     AssociationFlowButton,
     CopyButton,
-    DuplicateButton,
+    CloneButton,
     DefaultFlow,
     DataAssociationFlowButton,
   },

--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -42,7 +42,7 @@ export default {
       nodeToReplace: null,
       buttons: [
         {
-          label: 'Copy Seletion',
+          label: 'Copy Selection',
           icon: 'clipboard',
           testId: 'copy-button',
           role: 'menuitem',

--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -49,11 +49,11 @@ export default {
           action: this.copySelection,
         },
         {
-          label: 'Duplicate Selection',
+          label: 'Clone Selection',
           icon: 'copy',
           testId: 'clone-button',
           role: 'menuitem',
-          action: this.duplicateSelection,
+          action: this.cloneSelection,
         },
         {
           label: 'Delete Element',
@@ -80,8 +80,8 @@ export default {
     copySelection() {
       this.$emit('copy-selection');
     },
-    duplicateSelection() {
-      this.$emit('duplicate-selection');
+    cloneSelection() {
+      this.$emit('clone-selection');
     },
     deleteElement() {
       this.$emit('remove-nodes');

--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -51,7 +51,7 @@ export default {
         {
           label: 'Duplicate Selection',
           icon: 'copy',
-          testId: 'duplicate-button',
+          testId: 'clone-button',
           role: 'menuitem',
           action: this.duplicateSelection,
         },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -105,8 +105,8 @@
         @copy-element="copyElement"
         @copy-selection="copyElement"
         @paste-element="pasteElements"
-        @duplicate-element="duplicateElement"
-        @duplicate-selection="duplicateSelection"
+        @clone-element="cloneElement"
+        @clone-selection="cloneSelection"
         @default-flow="toggleDefaultFlow"
         @shape-resize="shapeResize"
       />
@@ -116,7 +116,7 @@
         :graph="graph"
         :paperManager="paperManager"
         :useModelGeometry="false"
-        @duplicate-selection="duplicateSelection"
+        @clone-selection="cloneSelection"
         @remove-nodes="removeNodes"
         :processNode="processNode"
         @save-state="pushToUndoStack"
@@ -318,7 +318,7 @@ export default {
       }
       source.set('default', flow);
     },
-    duplicateElement(node, copyCount) {
+    cloneElement(node, copyCount) {
       const clonedNode = node.clone(this.nodeRegistry, this.moddle, this.$t);
       const yOffset = (node.diagram.bounds.height + 30) * copyCount;
 
@@ -335,7 +335,7 @@ export default {
         processId,
       ];
       if (this.highlightedNodes.length === 1 && flows.includes(this.highlightedNodes[0].type)) return;
-      store.commit('setCopiedElements', this.cloneSelection());
+      store.commit('setCopiedElements', this.cloneNodesSelection());
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },
     async pasteElements() {
@@ -347,15 +347,15 @@ export default {
           await this.paperManager.awaitScheduledUpdates();
           await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
           await this.$nextTick();
-          await store.commit('setCopiedElements', this.cloneSelection());
+          await store.commit('setCopiedElements', this.cloneNodesSelection());
           this.scrollToSelection();
         } finally {
           this.pasteInProgress = false;
         }
       }
     },
-    async duplicateSelection() {
-      const clonedNodes = this.cloneSelection();
+    async cloneSelection() {
+      const clonedNodes = this.cloneNodesSelection();
       if (clonedNodes && clonedNodes.length === 0) {
         return;
       }

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -9,7 +9,7 @@ import { getOrFindDataInput, findIOSpecificationOwner } from '../components/crow
 
 export default {
   methods: {
-    cloneSelection() {
+    cloneNodesSelection() {
       let clonedNodes = [], clonedFlows = [], clonedDataInputAssociations = [], clonedDataOutputAssociations = [];
       const nodes = this.highlightedNodes;
       const selector = this.$refs.selector.$el;

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfEndEvent.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfEndEvent.spec.js
@@ -29,7 +29,7 @@ describe('Clone Improvement', () => {
     getIframeDocumnetation().find('p').should('exist').click().type('Documentation to End Event');
 
     //Step 5: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that End event was cloned
     cy.get(selectorEndEvent).eq(1).should('be.visible');
@@ -57,7 +57,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorEndEvent,'switch-to-message-end-event');
 
     //Step 4: Clone the End Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Message End Event was cloned
     cy.get(selectorEndEvent).eq(1).should('be.visible');
@@ -68,7 +68,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorEndEvent,'switch-to-error-end-event');
 
     //Step 6: Clone the Error End Event
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 2: Verify that Error End Event was cloned
     cy.get(selectorEndEvent).eq(1).should('be.visible');
@@ -79,7 +79,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorEndEvent,'switch-to-signal-end-event');
 
     //Step 8: Clone the End Event
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 3: Verify that Signal End Event was cloned
     cy.get(selectorEndEvent).eq(1).should('be.visible');
@@ -90,7 +90,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorEndEvent,'switch-to-terminate-end-event');
 
     //Step 8: Clone the End Event
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 3: Verify that Terminate End Event was cloned
     cy.get(selectorEndEvent).eq(1).should('be.visible');

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfExclusiveGateway.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfExclusiveGateway.spec.js
@@ -31,7 +31,7 @@ describe('Clone Improvement', () => {
     getIframeDocumnetation().find('p').should('exist').click().type('Documentation to Gateway');
 
     //Step 5: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that gateway was cloned
     cy.get(selectorExclusiveGateway).eq(1).should('be.visible');
@@ -58,7 +58,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorExclusiveGateway,'switch-to-inclusive-gateway');
 
     //Step 4: Clone the Gateway
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Inclusive Gateway was cloned
     cy.get(selectorExclusiveGateway).eq(1).should('be.visible');
@@ -69,7 +69,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorExclusiveGateway,'switch-to-parallel-gateway');
 
     //Step 6: Clone the Gateway
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 2: Verify that Parallel Gateway was cloned
     cy.get(selectorExclusiveGateway).eq(1).should('be.visible');
@@ -80,7 +80,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorExclusiveGateway,'switch-to-event-based-gateway');
 
     //Step 8: Clone the Gateway
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 3: Verify that Event Based in Gateway was cloned
     cy.get(selectorExclusiveGateway).eq(1).should('be.visible');

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
@@ -27,7 +27,7 @@ describe('Clone Improvement', () => {
     getIframeDocumnetation().find('p').should('exist').click().type('Documentation to Form Task');
 
     //Step 5: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Task event was cloned
     cy.get(selectorFormTask).eq(1).should('be.visible');
@@ -55,7 +55,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorFormTask,'switch-to-manual-task');
 
     //Step 4: Clone the Manual Task
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Manual was cloned
     cy.get(selectorFormTask).eq(1).should('be.visible');
@@ -66,7 +66,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorFormTask,'switch-to-script-task');
 
     //Step 6: Clone the Script Task
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 2: Verify that Script Task was cloned
     cy.get(selectorFormTask).eq(1).should('be.visible');
@@ -77,7 +77,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorFormTask,'switch-to-sub-process');
 
     //Step 8: Clone the Sub-process
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 3: Verify that Sub-process was cloned
     cy.get(selectorFormTask).eq(1).should('be.visible');

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfIntermediateEvent.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfIntermediateEvent.spec.js
@@ -27,7 +27,7 @@ describe('Clone Improvement', () => {
     getIframeDocumnetation().find('p').should('exist').click().type('Documentation to Intermediate Event');
 
     //Step 5: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Intermediate event was cloned
     cy.get(selectorIntermediateEvent).eq(1).should('be.visible');
@@ -54,7 +54,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorIntermediateEvent,'switch-to-intermediate-signal-catch-event');
 
     //Step 4: Clone the Intermediate Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Intermediate Event was cloned
     cy.get(selectorIntermediateEvent).eq(1).should('be.visible');
@@ -65,7 +65,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorIntermediateEvent,'switch-to-intermediate-message-catch-event');
 
     //Step 6: Clone the Intermediate Event
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 2: Verify that Intermediate Message Event was cloned
     cy.get(selectorIntermediateEvent).eq(1).should('be.visible');
@@ -76,7 +76,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorIntermediateEvent,'switch-to-intermediate-conditional-catch-event');
 
     //Step 8: Clone the Intermediate Event
-    cy.get('[data-test="duplicate-button"]').click({force: true});
+    cy.get('[data-test="clone-button"]').click({force: true});
 
     //Validation 3: Verify that Intermediate Conditional Event was cloned
     cy.get(selectorIntermediateEvent).eq(1).should('be.visible');

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfStartEvent.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfStartEvent.spec.js
@@ -23,7 +23,7 @@ describe('Clone Improvement', () => {
     getIframeDocumnetation().find('p').should('exist').click().type('Documentation to Start Event');
 
     //Step 4: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Start Event was cloned successfully
     cy.get(selectorStartEvent).eq(1).should('be.visible');
@@ -46,7 +46,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorStartEvent,'switch-to-start-timer-event');
 
     //Step 3: Clone Start Timer Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Start Timer Event was cloned
     cy.get(selectorStartEvent).eq(1).should('be.visible');
@@ -57,7 +57,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorStartEvent,'switch-to-signal-start-event');
 
     //Step 5: Clone the Signal Start Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 2: Verify that Signal Start Event was cloned
     cy.get(selectorStartEvent).eq(1).should('be.visible');
@@ -68,7 +68,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorStartEvent,'switch-to-message-start-event');
 
     //Step 7: Clone the Message Start Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 3: Verify that Message Start Event was cloned
     cy.get(selectorStartEvent).eq(1).should('be.visible');
@@ -79,7 +79,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorStartEvent,'switch-to-conditional-start-event');
 
     //Step 9: Clone the Conditional Start Event
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 4: Verify that Conditional Start Event was cloned
     cy.get(selectorStartEvent).eq(1).should('be.visible');

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfTextAnnotation.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfTextAnnotation.spec.js
@@ -34,7 +34,7 @@ describe('Clone Improvement', () => {
     cy.get('[class="element-list color-list"]>button:nth-child(1)').click();
 
     //Step 6: Clone the element
-    cy.get('[data-test="duplicate-button"]').click();
+    cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Start Event was cloned successfully
     cy.get(selectorTextAnnotation).eq(1).should('be.visible');


### PR DESCRIPTION
…ce I wanted to avoid big changes with the other team members

* Changed the label to Clone element

## Issue & Reproduction Steps

Expected behavior: 
Label should be `Clone Element`

Actual behavior: 
Label is `Duplicate Element`

## Solution
- Did a rename on the label
- Changed the filename to cloneButton and did several renaming in functions to be more targetted to clone

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8194

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
