### PR TITLE
Fix blur when typing a process ID or name

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -63,7 +63,7 @@
         :parent-height="parentHeight"
         :canvas-drag-position="canvasDragPosition"
         :compressed="panelsCompressed && noElementsSelected"
-        @shape-resize="shapeResize"
+        @shape-resize="shapeResize(false)"
       />
 
       <component
@@ -306,10 +306,10 @@ export default {
     isAppleOS() {
       return typeof navigator !== 'undefined' && /Mac|iPad|iPhone/.test(navigator.platform);
     },
-    async shapeResize() {
+    async shapeResize(clearIfEmpty=true) {
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
-      this.$refs.selector.updateSelectionBox(true);
+      this.$refs.selector.updateSelectionBox(true, clearIfEmpty);
     },
     toggleDefaultFlow(flow) {
       const source = flow.definition.sourceRef;

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -312,7 +312,7 @@ export default {
     /**
      * Update the selection Box
      */
-    updateSelectionBox(force=false) {
+    updateSelectionBox(force=false, clearIfEmpty=true) {
       if (force || this.isSelecting && this.style) {
         if (this.selected.length > 0) {
           const box = this.getSelectionVertex(this.selected, false, true);
@@ -324,7 +324,7 @@ export default {
           // Set the dimensions of the element
           this.style.width = `${box.maxX - box.minX}px`;
           this.style.height = `${box.maxY - box.minY}px`;
-        } else {
+        } else if (clearIfEmpty) {
           this.clearSelection();
         }
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Go to Designer
2. Create a Process
3. Write a word in the Node Identifier field
4. Write a word in the Name field

https://user-images.githubusercontent.com/8028650/234890598-406f80f4-ec26-4ea2-bfdf-bdb1b3c38bcf.mov


# Current Behavior:
When a User wants to write fluidly in the Node Identifier or Name fields only one letter is wrote but not all letters. 

# Expected Behavior: 
User should write letters fluidly in the Node Identifier or Name fields.

## Solution
Behind the scene, the modeler was clearing the selection and reselecting the process causing the lost of focus on the Inspector.
The solution is to prevent deselect and reselect the process when typing on the Inspector.

## How to Test
The testing should include entering a variety of text into the Node Identifier and Name fields to ensure that all text is correctly entered.

## Related tickets
- https://processmaker.atlassian.net/browse/FOUR-8162

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
