### PR TITLE
FOUR-8152: Connectors flow are selected inside a pool with selection

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -356,9 +356,11 @@ export default {
           return shape.model.component.node.pool && !selectedPoolsIds.includes(shape.model.component.node.pool.component.node.id);
         }
         // remove from selection the selected flows that belongs to a selected pools
-        if (shape.model.component && shape.model.component.node && flowTypes.includes(shape.model.component.node.type)) {
+        if (shape.model.component  && flowTypes.includes(shape.model.component.node.type)) {
           const parent = shape.model.getParentCell();
-          return parent && parent.component.node.pool && !selectedPoolsIds.includes(parent.component.node.pool.component.node.id);
+          if (parent.component && parent.component.node.pool) {
+            return !selectedPoolsIds.includes(parent.component.node.pool.component.node.id);
+          }
         }
         return true;
       });

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -28,6 +28,13 @@ import CrownMultiselect from '@/components/crown/crownMultiselect/crownMultisele
 import { id as poolId } from '@/components/nodes/pool/config';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
+
+import { id as sequenceFlowId } from '@/components/nodes/sequenceFlow';
+import { id as associationId } from '@/components/nodes/association';
+import { id as messageFlowId } from '@/components/nodes/messageFlow/config';
+import { id as dataOutputAssociationFlowId } from '@/components/nodes/dataOutputAssociation/config';
+import { id as dataInputAssociationFlowId } from '@/components/nodes/dataInputAssociation/config';
+
 import { labelWidth, poolPadding } from '../nodes/pool/poolSizes';
 
 export default {
@@ -333,6 +340,13 @@ export default {
      * Filter the selected elements
      */
     filterSelected() {
+      const flowTypes = [
+        sequenceFlowId,
+        dataOutputAssociationFlowId,
+        dataInputAssociationFlowId,
+        associationId,
+        messageFlowId,
+      ];
       // Get the selected pools IDs
       const selectedPoolsIds = this.selected
         .filter(shape => shape.model.component)
@@ -342,6 +356,11 @@ export default {
       this.selected = this.selected.filter(shape => {
         if (shape.model.component && shape.model.component.node.pool) {
           return shape.model.component.node.pool && !selectedPoolsIds.includes(shape.model.component.node.pool.component.node.id);
+        }
+        // remove from selection the selected flows that belongs to a selected pools
+        if (shape.model.component && shape.model.component.node && flowTypes.includes(shape.model.component.node.type)) {
+          const parent = shape.model.getParentCell();
+          return parent && parent.component.node.pool && !selectedPoolsIds.includes(parent.component.node.pool.component.node.id);
         }
         return true;
       });

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -28,13 +28,11 @@ import CrownMultiselect from '@/components/crown/crownMultiselect/crownMultisele
 import { id as poolId } from '@/components/nodes/pool/config';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
-
 import { id as sequenceFlowId } from '@/components/nodes/sequenceFlow';
 import { id as associationId } from '@/components/nodes/association';
 import { id as messageFlowId } from '@/components/nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '@/components/nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '@/components/nodes/dataInputAssociation/config';
-
 import { labelWidth, poolPadding } from '../nodes/pool/poolSizes';
 
 export default {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The flow inside a pool must not be selected
Actual behavior: 
The pool is selected
## Solution
- Add a validation to avoid flow selection in pools

## How to Test
Test the steps above
- Select a pool that contains elements wit flows.
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8152

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
