### PR TITLE
FOUR-8173: Remove cloneOf attribute from cloned nodes

### DIFF
--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -52,6 +52,12 @@ export default {
       this.connectClonedDataInputAssociations(clonedDataInputAssociations, clonedNodes);
       this.connectClonedDataOutputAssociations(clonedDataOutputAssociations, clonedNodes);
 
+      clonedNodes.forEach(node => {
+        if (node.cloneOf) {
+          delete node.cloneOf;
+        }
+      });
+
       return clonedNodes;
     },
     // Returns the Flow Element (Task| DataStore| DataObject)  that is the target of the association


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Drag (Start Event → Task Form → End Event)
2. Assign Screen in Task Form 
3. Clone the start Event 
4. Publish the changes 
5. Try to start request

Expected behavior: 
It should be possible to start a request with elements cloned

Actual behavior: 
It is not possible to start a request if the elements inside the modeler are cloned 

## Solution
- Attribute used for cloning `cloneOf` was removed so that the XML valdiation is valid

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8173

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
