### PR TITLE
FOUR-8312: Ctrl + V with an empty clipboard does nothing

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -339,7 +339,7 @@ export default {
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
     },
     async pasteElements() {
-      if (this.copiedElements && !this.pasteInProgress) {
+      if (this.copiedElements.length > 0 && !this.pasteInProgress) {
         this.pasteInProgress = true;
         try {
           await this.addClonedNodes(this.copiedElements);


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Open modeler 
2. Drag elements
3. Paste with (Ctrl + V)

Expected behavior: 
There should be no errors when pressing Ctrl+V

Actual behavior: 
The following error appears when I made Ctrl+V without Ctrl +C before 

## Solution
- Validation for the variable copiedElements was fixed.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8312

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
