### PR TITLE
FOUR-8301: The mouse does double focus in modeler

### DIFF
--- a/src/components/hotkeys/copyPaste.js
+++ b/src/components/hotkeys/copyPaste.js
@@ -1,17 +1,19 @@
 export default {
   methods: {
     copyPasteHandler(event, options) {
-      const node = event.target.nodeName.toLowerCase();
-      const isBody = node === 'body';
-      const key = event.key.toLowerCase();
-      const isCopy = key === 'c';
-      const isPaste = key === 'v';
-
-      if (isBody && isCopy && options.mod) {
-        this.copy(event);
-      }
-      if (isBody && isPaste && options.mod) {
-        this.paste(event);
+      const selectedText = window.getSelection().toString();
+      if (!selectedText) {
+        const node = event.target.nodeName.toLowerCase();
+        const isBody = node === 'body';
+        const key = event.key.toLowerCase();
+        const isCopy = key === 'c';
+        const isPaste = key === 'v';
+        if (isBody && isCopy && options.mod) {
+          this.copy(event);
+        }
+        if (isBody && isPaste && options.mod) {
+          this.paste(event);
+        }
       }
     },
     copy(event) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
select the html page text must work as expected
Actual behavior: 
(Ctrl + c) and (Crt + v ) is preventing the default browser copy paste  functionality
## Solution
- a validation was if the user has a selected text must work as the default behaviour

https://user-images.githubusercontent.com/1401911/234966120-c1183b53-b85c-4cc9-9015-d6a06a42ea0d.mov


## How to Test
Test the steps above
- select a html text un the modeler 
- press Ctrl + v 
- try to copy this selected text in other input field
- does not work

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8301

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
