### PR TITLE
FOUR-8161: The boundary event is detached from the task

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -634,7 +634,7 @@ export default {
     /**
      * Rollback drag an element outside it's pool parent
      */
-    rollbackSelection(){
+    async rollbackSelection(){
       const deltaX = this.initialPosition.left  - this.left;
       const deltaY = this.initialPosition.top - this.top;
       this.style.left = `${this.initialPosition.left}px`;
@@ -643,14 +643,18 @@ export default {
       const shapesToNotTranslate = [
         'PoolLane',
         'standard.Link',
+        'processmaker.components.nodes.boundaryEvent.Shape',
       ];
       this.selected.filter(shape => !shapesToNotTranslate.includes(shape.model.get('type')))
         .forEach(shape => {
           shape.model.translate(deltaX/scale.sx, deltaY/scale.sy);
         });
       this.isOutOfThePool = false;
-      store.commit('allowSavingElementPosition');
+      await store.commit('allowSavingElementPosition');
       this.paperManager.setStateValid();
+      await this.$nextTick();
+      await this.paperManager.awaitScheduledUpdates();
+      this.updateSelectionBox(true);
     },
     /**
      * Expand and fit the pool container


### PR DESCRIPTION
## Issue & Reproduction Steps
The boundary event is detached from the task
Expected behavior: 

Actual behavior: 
The boundary event should not be detached from the task
## Solution
- rollback if the user move a shape over the pool will be preventing with the boundary event 

https://user-images.githubusercontent.com/1401911/234975845-a1e05d2d-fb01-4c3a-a4be-eda470ede040.mov

## How to Test
Test the steps above
- create a pool
- add a task the 
- attach a boundary event 
- select task and boundary event try to drag over the pool
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8161

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
