### PR TITLE
FOUR-8316: Clone or Copy options removed from pools

### DIFF
--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -8,7 +8,7 @@
     <slot />
 
     <button
-      v-for="button in buttons"
+      v-for="button in availableButtons"
       :key="button.label"
       :aria-label="button.label"
       class="btn"
@@ -30,6 +30,7 @@ import runningInCypressTest from '@/runningInCypressTest';
 export default {
   props: {
     paper: Object,
+    hasPools: Boolean,
   },
   data() {
     return {
@@ -75,6 +76,18 @@ export default {
       return countSelected > 1;
     },
     highlightedShapes: () => store.getters.highlightedShapes,
+    availableButtons() {
+      const hasPoolsSelected = this.hasPools;
+      return this.buttons.filter(button => {
+        if (button.testId === 'copy-button') {
+          return !hasPoolsSelected;
+        }
+        if (button.testId === 'clone-button') {
+          return !hasPoolsSelected;
+        }
+        return true;
+      });
+    },
   },
   methods: {
     copySelection() {

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -16,6 +16,7 @@
       :plane-elements="$parent.planeElements"
       :is-rendering="$parent.isRendering"
       :dropdown-data="[]"
+      :has-pools="hasPoolsOrLanesSelected"
       v-on="$listeners"
     />
   </div>
@@ -83,6 +84,14 @@ export default {
   mounted(){
     this.paperManager.paper.on('scale:changed ', this.updateSelectionBox);
     this.paperManager.paper.on('translate:changed ', this.translateChanged);
+  },
+  computed: {
+    hasPoolsOrLanesSelected() {
+      return this.selected.some((view) => {
+        return view.model.component.node.type === poolId ||
+        view.model.component.node.type === laneId;
+      });
+    },
   },
   watch: {
     // whenever selected changes


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Open the modeler
2. Drag two elements
3. Select the pools

Expected behavior: 
According to the acceptance criteria to Copy and Clone improvements. We don’t support these operations with pools. So we need to remove these options for pools selections

Actual behavior: 
Copy and Clone selection  appears in the selection of pools 

## Solution
- Temporary fix to detect if selection has pools or lanes in it and if so, change the buttons available in the crownMultiselect to avoid the behavior described above.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8316

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
