### PR TITLE
FOUR-8318 | Add ‘Save as Template’ Button to Modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -11,6 +11,7 @@
       @toggle-panels-compressed="panelsCompressed = !panelsCompressed"
       @toggle-mini-map-open="miniMapOpen = $event"
       @saveBpmn="saveBpmn"
+      @publishTemplate="publishTemplate"
       @close="close"
       @save-state="pushToUndoStack"
       @clearSelection="clearSelection"
@@ -337,6 +338,9 @@ export default {
       if (this.highlightedNodes.length === 1 && flows.includes(this.highlightedNodes[0].type)) return;
       store.commit('setCopiedElements', this.cloneNodesSelection());
       this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
+    },
+    publishTemplate() {
+      this.$emit('publishTemplate');
     },
     async pasteElements() {
       if (this.copiedElements.length > 0 && !this.pasteInProgress) {

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -227,6 +227,11 @@ export default {
           content: this.$t('Discard Draft'),
           icon: '',
         },
+        {
+          value: 'save-template',
+          content: this.$t('Save as Template'),
+          icon: '',
+        },
       ],
     };
   },
@@ -256,6 +261,9 @@ export default {
         case 'discard-draft':
           window.ProcessMaker.EventBus.$emit('open-versions-discard-modal');
           break;
+        case 'save-template':
+          this.$emit('publishTemplate');
+          break;
         default:
           break;
       }
@@ -272,6 +280,15 @@ export default {
         inspectorDiv.style.zIndex = '2';
       }
     },
+  },
+  mounted() {
+    if (this.$root.$children[0].process.is_template) {
+      const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
+        return object.value === 'save-template';
+      });
+
+      this.ellipsisMenuActions.splice(indexOfActions, 1);
+    }
   },
 };
 </script>


### PR DESCRIPTION
# Description
Ticket: [FOUR-8318](https://processmaker.atlassian.net/browse/FOUR-8318)

We need to add a ‘Save as Template’ button to Modeler so that users can save a Process as a Template from the Process Modeler.

# How to Test
1. Go to branch `feature/FOUR-8318` in Modeler.
2. Go to branch `feature/FOUR-8318` in Core. Link Modeler to Core.
3. In the UI, open up the Process Modeler. From the Ellipsis Menu, select 'Save as Template'.
	- The template should save successfully and show up in your Templates listing.
4. In the UI, open up the Template editor. In the Ellipsis Menu, there should be no option to 'Save as Template'.

# Related Tickets & Packages
- [FOUR-7955](https://processmaker.atlassian.net/browse/FOUR-7955) | Implement the New Ellipsis Menu for Specified Menus Across the Platform
- [FOUR-7878](https://processmaker.atlassian.net/browse/FOUR-7637) | Ellipsis Menu
- [FOUR-7375](https://processmaker.atlassian.net/browse/FOUR-7375) | Process Templates - Spring 2023

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-8318]: https://processmaker.atlassian.net/browse/FOUR-8318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7955]: https://processmaker.atlassian.net/browse/FOUR-7955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7878]: https://processmaker.atlassian.net/browse/FOUR-7878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7375]: https://processmaker.atlassian.net/browse/FOUR-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ