### PR TITLE
FOUR-8326

### DIFF
--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -42,7 +42,7 @@ export default {
             clonedDataOutputAssociations.push(clonedFlow);
             clonedNodes.push(clonedFlow);
           } else {
-            //validate boundary events and collect in clonedBoundaryEvents array
+            // Validate boundary events and collect in clonedBoundaryEvents array
             const clonedElement = this.cloneElementAndCalculateOffset(node);
             if (node.definition && node.definition.$type !== 'bpmn:BoundaryEvent') {
               clonedNodes.push(clonedElement);
@@ -52,7 +52,7 @@ export default {
           }
         });
       }
-      //attach the cloned boundary events alway at the end off the cloned nodes
+      // Sets the clonedBoundaryEvents at the end of the array
       clonedNodes = [...clonedNodes, ...clonedBoundaryEvents];
       this.connectClonedFlows(clonedFlows, clonedNodes);
       this.connectClonedDataInputAssociations(clonedDataInputAssociations, clonedNodes);

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -10,7 +10,7 @@ import { getOrFindDataInput, findIOSpecificationOwner } from '../components/crow
 export default {
   methods: {
     cloneNodesSelection() {
-      let clonedNodes = [], clonedFlows = [], clonedDataInputAssociations = [], clonedDataOutputAssociations = [];
+      let clonedNodes = [], clonedFlows = [], clonedBoundaryEvents = [], clonedDataInputAssociations = [], clonedDataOutputAssociations = [];
       const nodes = this.highlightedNodes;
       const selector = this.$refs.selector.$el;
       const flowNodeTypes = [
@@ -42,12 +42,18 @@ export default {
             clonedDataOutputAssociations.push(clonedFlow);
             clonedNodes.push(clonedFlow);
           } else {
+            //validate boundary events and collect in clonedBoundaryEvents array
             const clonedElement = this.cloneElementAndCalculateOffset(node);
-            clonedNodes.push(clonedElement);
+            if (node.definition && node.definition.$type !== 'bpmn:BoundaryEvent') {
+              clonedNodes.push(clonedElement);
+            }  else {
+              clonedBoundaryEvents.push(clonedElement);
+            }
           }
         });
       }
-
+      //attach the cloned boundary events alway at the end off the cloned nodes
+      clonedNodes = [...clonedNodes, ...clonedBoundaryEvents];
       this.connectClonedFlows(clonedFlows, clonedNodes);
       this.connectClonedDataInputAssociations(clonedDataInputAssociations, clonedNodes);
       this.connectClonedDataOutputAssociations(clonedDataOutputAssociations, clonedNodes);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 

Actual behavior: 

## Solution
- the boundary events will be cloned in the final process to avoid this js issue

## How to Test

1. create a process
3. add  a task
5. attach a boundary 
7. select the boludary with shift key
9. select the task with shift key 
10. open the developer tools
11. clone or duplicate the selected shapes

https://user-images.githubusercontent.com/1401911/235174954-dae20aa1-1ea7-4801-9953-fa9e5da9a67a.mov

teds shapes

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8326

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
