### PR TITLE
FOUR-8160 Added missing awaits to several methods to allow the Promis…

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -442,7 +442,7 @@ export default {
     async pushToUndoStack() {
       try {
         const xml = await this.getXmlFromDiagram();
-        undoRedoStore.dispatch('pushState', xml);
+        await undoRedoStore.dispatch('pushState', xml);
         window.ProcessMaker.EventBus.$emit('modeler-change');
       } catch (invalidXml) {
         // eslint-disable-next-line no-console
@@ -798,7 +798,7 @@ export default {
       this.xmlManager.definitions = this.definitions;
       this.nodeIdGenerator = getNodeIdGenerator(this.definitions);
       store.commit('clearNodes');
-      this.renderPaper();
+      await this.renderPaper();
     },
     getBoundaryEvents(process) {
       return process.get('flowElements').filter(({ $type }) => $type === 'bpmn:BoundaryEvent');
@@ -958,10 +958,10 @@ export default {
       store.commit('highlightNode', this.processNode);
       this.$refs.selector.clearSelection();
       await this.$nextTick();
-      this.pushToUndoStack();
+      await this.pushToUndoStack();
     },
     async removeNodes() {
-      this.performSingleUndoRedoTransaction(async() => {
+      await this.performSingleUndoRedoTransaction(async() => {
         await this.paperManager.performAtomicAction(async() => {
           const waitPromises = [];
           this.highlightedNodes.forEach((node) =>
@@ -1004,7 +1004,7 @@ export default {
       undoRedoStore.commit('disableSavingState');
       await cb();
       undoRedoStore.commit('enableSavingState');
-      this.pushToUndoStack();
+      await this.pushToUndoStack();
     },
     removeNodesFromLane(node) {
       const containingLane = node.pool && node.pool.component.laneSet &&
@@ -1283,9 +1283,9 @@ export default {
 
     /* Register custom nodes */
     window.ProcessMaker.EventBus.$emit('modeler-start', {
-      loadXML: xml => {
-        this.loadXML(xml);
-        undoRedoStore.dispatch('pushState', xml);
+      loadXML: async(xml) => {
+        await this.loadXML(xml);
+        await undoRedoStore.dispatch('pushState', xml);
       },
       addWarnings: warnings => this.$emit('warnings', warnings),
       addBreadcrumbs: breadcrumbs => this.breadcrumbData.push(breadcrumbs),

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -187,9 +187,17 @@ export default class Node {
     clonedFlow.id = null;
     clonedFlow.pool = this.pool;
     clonedFlow.cloneOf = this.id;
-    clonedFlow.diagram.waypoint = [];
+    clonedFlow.diagram = moddle.create('bpmndi:BPMNEdge', {
+      waypoint: [],
+    });
 
-    this.diagram.waypoint.forEach(point => clonedFlow.diagram.waypoint.push(point));
+    this.diagram.waypoint.forEach(point => {
+      const waypoint = moddle.create('dc:Point', {
+        x: point.x,
+        y: point.y,
+      });
+      clonedFlow.diagram.waypoint.push(waypoint);
+    });
 
     Object.keys(this.definition).filter(key => !Node.flowDefinitionPropertiesToNotCopy.includes(key)).forEach(key => {
       const definition = this.definition.get(key);

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -112,9 +112,11 @@ export default {
           targetClone.definition.set('incoming', [clonedFlow.definition]);
         }
 
+        const { height: selectorHeight } = this.$refs.selector.$el.getBoundingClientRect();
+        const { sy } = this.paper.scale();
+        const yOffset = selectorHeight / sy;
         clonedFlow.diagram.waypoint.forEach(point => {
-          const { height: selectorHeight } = this.$refs.selector.$el.getBoundingClientRect();
-          point.y += selectorHeight;
+          point.y += yOffset;
         });
       });
     },


### PR DESCRIPTION
…es to be completed

## Issue & Reproduction Steps

Expected behavior: 
Undo should work just fine when inside a pool

Actual behavior: 
Undo wasn't working as expected when inside a pool, causing the elements to redo themselves or sometimes in errors

## Solution
- Added missing `await` in several methods in `Modeler.vue` to finish the Promises expected from the Paper

## How to Test
Test the steps above

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-8160

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
