### PR TITLE
FOUR-8304 It is not possible to manipulate the operations with the mouse, keyboard in Modeler

### DIFF
--- a/src/components/nodes/pool/poolEventHandlers.js
+++ b/src/components/nodes/pool/poolEventHandlers.js
@@ -46,14 +46,6 @@ export default class PoolEventHandlers {
       return;
     }
 
-    if (this.previousValidPosition) {
-      this.draggingElement.position(this.previousValidPosition.x, this.previousValidPosition.y, { deep: true });
-      store.commit('updateNodeBounds', {
-        node: this.draggingElement.component.node,
-        bounds: this.previousValidPosition,
-      });
-    }
-
     if (this.invalidPool) {
       this.invalidPool.attr('body/fill', poolColor);
       this.invalidPool = null;
@@ -64,7 +56,6 @@ export default class PoolEventHandlers {
       this.component.moveElement(this.draggingElement, this.newPool);
       this.newPool = null;
     } else {
-      this.component.expandToFitElement(this.draggingElement, this.shape);
       this.component.laneSet && this.component.updateLaneChildren();
     }
 

--- a/src/store.js
+++ b/src/store.js
@@ -71,6 +71,9 @@ export default new Vuex.Store({
       state.rootElements = rootElements;
     },
     updateNodeBounds(state, { node, bounds }) {
+      if (!bounds) {
+        return;
+      }
       Object.entries(bounds).forEach(([key, val]) => {
         if (key === '$type') {
           return;


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Open modeler
2. drag a pool
3. add Start Event → Task Form → Task Form → End Event
4. select all elements inside the pool
5. copy the selection with (Ctrl+C) and paste the selection with (Ctrl+V), move the selection cloned outside the pool.

### Expected behavior: 
It should not appear any error in the console if the elements copied are dragged outside the pool.

### Actual behavior: 
The following errors appear in the console: `TypeError: Cannot convert undefined or null to object` and it is not possible to manipulate the mouse or keyboard.

## Solution
The solution is to update the code that manages the drag and drop outside of a pool.

## How to Test
To test the solution, open the modeler and drag a pool. Add Start Event → Task Form → Task Form → End Event, select all elements inside the pool, copy the selection with (Ctrl+C) and paste the selection with (Ctrl+V). Move the selection cloned outside the pool and verify that no errors appear in the console and that the elements can be manipulated with the mouse and keyboard.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8304

https://user-images.githubusercontent.com/8028650/235241867-9fd3b84b-28e0-4f16-9aaf-22249bf350f3.mov

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
