### PR TITLE
FOUR-8281: Fixed position for flow to be created

### DIFF
--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -22,6 +22,7 @@ import Node from '@/components/nodes/node';
 import * as dataOutputConfig from '@/components/nodes/dataOutputAssociation/config';
 import * as dataInputConfig from '@/components/nodes/dataInputAssociation/config';
 import DataAssociation from '@/components/nodes/genericFlow/DataAssociation';
+import store from '@/store';
 
 export default {
   components: { CrownButton },
@@ -32,6 +33,7 @@ export default {
     };
   },
   computed: {
+    paper: () => store.getters.paper,
     allowOutgoingDataAssociationFlow() {
       return DataAssociation.isADataNode(this.node);
     },
@@ -40,6 +42,7 @@ export default {
     addDataAssociation() {
       this.$emit('toggle-crown-state', false);
 
+      const { sx } = this.paper.scale();
       const comingFromDataStoreOrDataObject = this.node.isBpmnType('bpmn:DataStoreReference', 'bpmn:DataObjectReference');
 
       const dataAssociationConfig = comingFromDataStoreOrDataObject
@@ -56,7 +59,10 @@ export default {
 
       node.dataAssociationProps = {
         sourceShape: this.shape,
-        targetCoords: { x: undefined, y: undefined },
+        targetCoords: {
+          x: this.node.diagram.bounds.x + (this.node.diagram.bounds.width + (50 * sx)),
+          y: this.node.diagram.bounds.y + (this.node.diagram.bounds.height / 2),
+        },
       };
 
       this.$emit('add-node', node);

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -19,6 +19,7 @@ import Flow from '@/assets/connect-elements.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import Node from '@/components/nodes/node';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
+import store from '@/store';
 
 // Don't show the magic flow button on:
 const dontShowOn = [
@@ -42,6 +43,7 @@ export default {
     };
   },
   computed: {
+    paper: () => store.getters.paper,
     sequenceFlowConfig() {
       return this.nodeRegistry[genericFlowId];
     },
@@ -58,11 +60,12 @@ export default {
   methods: {
     addSequence(cellView, evt, x, y) {
       this.$emit('toggle-crown-state', false);
+      const { sx } = this.paper.scale();
       const flowPlaceholderDefinition = this.moddle.create('bpmn:SequenceFlow', {
         name: '',
         sourceRef: this.node.definition,
         targetRef: {
-          x: x ? x : this.node.diagram.bounds.x + this.node.diagram.bounds.width + 50,
+          x: x ? x : this.node.diagram.bounds.x + (this.node.diagram.bounds.width + (50 * sx)),
           y: y ? y : this.node.diagram.bounds.y + (this.node.diagram.bounds.height / 2),
         },
       });

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -61,7 +61,10 @@ export default {
       const flowPlaceholderDefinition = this.moddle.create('bpmn:SequenceFlow', {
         name: '',
         sourceRef: this.node.definition,
-        targetRef: { x, y },
+        targetRef: {
+          x: x ? x : this.node.diagram.bounds.x + this.node.diagram.bounds.width + 50,
+          y: y ? y : this.node.diagram.bounds.y + (this.node.diagram.bounds.height / 2),
+        },
       });
 
       this.$emit('add-node', new Node(

--- a/src/store.js
+++ b/src/store.js
@@ -40,6 +40,7 @@ export default new Vuex.Store({
   },
   getters: {
     nodes: state => state.nodes,
+    paper: state => state.paper,
     highlightedNodes: state => state.highlightedNodes,
     nodeShape: state => node => {
       return state.graph.getCells().find(cell => cell.component && cell.component.node === node);


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Open modeler
2. Drag elements like start event 
3. Click on the element 
4. Select the flow option

Expected behavior: 
flow should start in the middle of the element like this:
![image](https://user-images.githubusercontent.com/37810239/235674859-913acd14-825c-48b0-9c31-1a40d01aaf97.png)

Actual behavior: 
Flow always starts out to the extreme upper left

## Solution
- Temporary fix has been implemented where the flow to-be-created always starts at the right of the selected element.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8281

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
