### PR TITLE
FOUR-8393: Elements are moved out of the Pool container

### DIFF
--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -222,8 +222,6 @@ export default {
       if (!store.getters.allowSavingElementPosition) {
         return;
       }
-
-      this.$emit('save-state');
     },
     repositionCrown() {
       const shapeView = this.shape.findView(this.paper);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1175,7 +1175,6 @@ export default {
       if (!this.isDragging && this.dragStart) {
         // is clicked over the shape
         if (cellView) {
-          this.$refs.selector.stopDrag(event);
           this.$refs.selector.selectElement(cellView, event.shiftKey);
         } else {
           this.clearSelection();

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -503,20 +503,17 @@ export default {
       this.updateFlowsWaypoint();
       this.overPoolStopDrag();
     },
+    /**
+     * Selector will update the waypoints of the related flows
+     */
     updateFlowsWaypoint(){
       this.conectedLinks.forEach((link)=> {
         if (link.model.component && link.model.get('type') === 'standard.Link'){
-          // console.log('old: shape.model.component.node.diagram.waypoint');
-          // console.log(link.model.component.node.diagram.waypoint);
           const start = link.sourceAnchor;
           const end = link.targetAnchor;
-
           link.model.component.node.diagram.waypoint = [start,
             ...link.model.component.shape.vertices(),
             end].map(point => link.model.component.moddle.create('dc:Point', point));
-          
-          // console.log('new: shape.model.component.node.diagram.waypoint');
-          // console.log(link.model.component.node.diagram.waypoint);
         }
       });
     },

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -698,6 +698,7 @@ export default {
           shape.model.translate(deltaX/scale.sx, deltaY/scale.sy);
         });
       this.isOutOfThePool = false;
+      this.updateFlowsWaypoint();
       await store.commit('allowSavingElementPosition');
       this.paperManager.setStateValid();
       await this.$nextTick();

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -771,7 +771,6 @@ export default {
             node: pool.component.node,
             bounds: pool.getBBox(),
           });
-          // this.$emit('save-state');
         }
       }
     },

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -218,7 +218,6 @@ export default {
     this.updateShapePosition(task);
 
     this.shape.on('change:position', this.turnInvalidTargetRed);
-    this.shape.listenTo(this.paper, 'element:pointerdown', this.attachToValidTarget);
   },
 };
 </script>

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -118,13 +118,25 @@ export default {
       const targetShape = this.shape.getTargetElement();
       resetShapeColor(targetShape);
 
-      this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
-      this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
-      this.shape.on('change:vertices change:source change:target', this.updateWaypoints);
+      // this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
+      // this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
+      // this.shape.on('change:source change:target', this.updateWaypoints);
+      this.shape.on('change:vertices', this.onChangeVertices);
 
       const sourceShape = this.shape.getSourceElement();
       sourceShape.embed(this.shape);
       this.$emit('set-shape-stacking', sourceShape);
+    },
+    /**
+     * On Change vertices handler
+     * @param {Object} link 
+     * @param {Array} vertices 
+     * @param {Object} options 
+     */
+    onChangeVertices(link, vertices, options){
+      if (options && options.ui) {
+        this.updateWaypoints();
+      }
     },
     updateWaypoints() {
       const linkView = this.shape.findView(this.paper);

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -118,9 +118,6 @@ export default {
       const targetShape = this.shape.getTargetElement();
       resetShapeColor(targetShape);
 
-      // this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
-      // this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
-      // this.shape.on('change:source change:target', this.updateWaypoints);
       this.shape.on('change:vertices', this.onChangeVertices);
 
       const sourceShape = this.shape.getSourceElement();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The elements should not be moved out of the Pool container.

Actual behavior: 
The elements copied are moved  out of the Pool container  after undo
## Solution
- Link Waypoints event was improved, and some was removed


https://user-images.githubusercontent.com/1401911/236048159-6736d65b-05b7-4467-b117-42ae58c8beb2.mov





## How to Test
Test the steps above

1. Drag a pool
3. Add Task Form| sub-process with boundary event
5. Add End Event
7. Connect the boundary event with the end event
9. Select all elements inside the pool
11. Copy the elements with (Ctr+C)
13. Paste the elements with (Ctrl+V)
15. Move the element outside the pool
17. Press UNDO more than once 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8393

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
