### PR TITLE
(Reopened) FOUR-8281: Text annotation new flows now snap to pointer

### DIFF
--- a/src/components/crown/crownButtons/associationFlowButton.vue
+++ b/src/components/crown/crownButtons/associationFlowButton.vue
@@ -20,6 +20,8 @@ import connectIcon from '@/assets/connect-artifacts.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import { direction } from '@/components/nodes/association/associationConfig';
 import Node from '@/components/nodes/node';
+import store from '@/store';
+import { V } from 'jointjs';
 
 export default {
   components: { CrownButton },
@@ -29,12 +31,23 @@ export default {
       connectIcon,
     };
   },
+  computed: {
+    paper: () => store.getters.paper,
+  },
   methods: {
     addAssociation(cellView, evt, x, y) {
       this.$emit('toggle-crown-state', false);
+      const { clientX, clientY } = cellView;
+      let point = null;
+      if (cellView){
+        point = V(this.paper.viewport).toLocalPoint(clientX, clientY);
+      }
       const associationLink = this.moddle.create('bpmn:Association', {
         sourceRef: this.shape.component.node.definition,
-        targetRef: { x, y },
+        targetRef: {
+          x: x ? x : point.x,
+          y: y ? y : point.y,
+        },
         associationDirection: direction.none,
       });
 


### PR DESCRIPTION
This PR fixes the observation made in [FOUR-8281](https://processmaker.atlassian.net/browse/FOUR-8281) for the Text Annotation

## Solution
- A file that handles the new flow button for Text Annotations was left out in the solution for 8281. This fix has been applied to this left out file.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8281

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8281]: https://processmaker.atlassian.net/browse/FOUR-8281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy