### PR TITLE
FOUR-8445: Data Store/Object flow error fixed

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -387,7 +387,7 @@ export default {
         // remove from selection the selected flows that belongs to a selected pools
         if (shape.model.component  && flowTypes.includes(shape.model.component.node.type)) {
           const parent = shape.model.getParentCell();
-          if (parent.component && parent.component.node.pool) {
+          if (parent && parent.component && parent.component.node.pool) {
             return !selectedPoolsIds.includes(parent.component.node.pool.component.node.id);
           }
         }


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a process 
2. Add Text Annotation | Data Object | Data Store
3. Click on the element 
4. Drag the connector flow
5. Drop the flow connector on an empty space 

Expected behavior: 
It should not appear error if the connector flow is released 

Actual behavior: 
Cannot read properties of null (reading 'component')>> Error appears when the connector flow is released 

## Solution
- If condition was missing a check on `parent` variable before accessing `parent.component`. This was due to `parent` being `null` if the target for the new flow was blank or you clicked on the canvas instead of a valid BPMN element.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8445

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy