### PR TITLE
FOUR-8499 add tooltip in some elements in the bottom controls

### DIFF
--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -6,7 +6,7 @@
     </li>
 
     <li class="control-item">
-      <div class="control-add">
+      <div class="control-add" :title="$t('Add')" v-b-tooltip.hover>
         <img :src="plusIcon" :alt="$t('Add')">
       </div>
     </li>
@@ -29,27 +29,27 @@ export default ({
           items: [
             {
               iconSrc: require('@/assets/toolpanel/start-event.svg'),
-              label: this.$t('Start Event'),    
+              label: this.$t('Start Event'),
               id: 'genericStartEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/message-start-event.svg'),
-              label: this.$t('Message Start Event'),    
+              label: this.$t('Message Start Event'),
               id: 'messageStartEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/conditional-start-event.svg'),
-              label: this.$t('Conditional Start Event'),    
+              label: this.$t('Conditional Start Event'),
               id: 'conditionalStartEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/signal-start-event.svg'),
-              label: this.$t('Signal Start Event'),    
+              label: this.$t('Signal Start Event'),
               id: 'signalStartEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/timer-start-event.svg'),
-              label: this.$t('Start Timer Event'),    
+              label: this.$t('Start Timer Event'),
               id: 'timerStartEvent',
             },
           ],
@@ -61,32 +61,32 @@ export default ({
           items: [
             {
               iconSrc: require('@/assets/toolpanel/intermediate-timer-event.svg'),
-              label: this.$t('Intermediate Timer Event'),    
+              label: this.$t('Intermediate Timer Event'),
               id: 'intermediateTimerEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/intermediate-signal-catch-event.svg'),
-              label: this.$t('Intermediate Signal Catch Event'),    
+              label: this.$t('Intermediate Signal Catch Event'),
               id: 'intermediateSignalCatchEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/intermediate-signal-throw-event.svg'),
-              label: this.$t('Intermediate Signal Throw Event'),    
+              label: this.$t('Intermediate Signal Throw Event'),
               id: 'intermediateSignalThrowEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/intermediate-message-catch-event.svg'),
-              label: this.$t('Intermediate Message Catch Event'),    
+              label: this.$t('Intermediate Message Catch Event'),
               id: 'intermediateMessageCatchEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/intermediate-message-throw-event.svg'),
-              label: this.$t('Intermediate Message Throw Event'),    
+              label: this.$t('Intermediate Message Throw Event'),
               id: 'intermediateMessageThrowEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/intermediate-conditional-catch-event.svg'),
-              label: this.$t('Intermediate Conditional Catch Event'),    
+              label: this.$t('Intermediate Conditional Catch Event'),
               id: 'intermediateConditionalCatchEvent',
             },
           ],
@@ -98,27 +98,27 @@ export default ({
           items: [
             {
               iconSrc: require('@/assets/toolpanel/end-event.svg'),
-              label: this.$t('End Event'),    
+              label: this.$t('End Event'),
               id: 'genericEndEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/message-end-event.svg'),
-              label: this.$t('Message End Event'),    
+              label: this.$t('Message End Event'),
               id: 'messageEndEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/end-event.svg'),
-              label: this.$t('Error End Event'),    
+              label: this.$t('Error End Event'),
               id: 'errorEndEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/signal-end-event.svg'),
-              label: this.$t('Signal End Event'),    
+              label: this.$t('Signal End Event'),
               id: 'signalEndEvent',
             },
             {
               iconSrc: require('@/assets/toolpanel/terminate-end-event.svg'),
-              label: this.$t('Terminate End Event'),    
+              label: this.$t('Terminate End Event'),
               id: 'terminateEndEvent',
             },
           ],
@@ -130,22 +130,22 @@ export default ({
           items: [
             {
               iconSrc: require('@/assets/toolpanel/task.svg'),
-              label: this.$t('Form Task'),    
+              label: this.$t('Form Task'),
               id: 'formTask',
             },
             {
               iconSrc: require('@/assets/toolpanel/manual-task.svg'),
-              label: this.$t('Manual Task'),    
+              label: this.$t('Manual Task'),
               id: 'manualTask',
             },
             {
               iconSrc: require('@/assets/toolpanel/script-task.svg'),
-              label: this.$t('Script Task'),    
+              label: this.$t('Script Task'),
               id: 'script',
             },
             {
               iconSrc: require('@/assets/toolpanel/task.svg'),
-              label: this.$t('Sub Process'),    
+              label: this.$t('Sub Process'),
               id: 'subProcess',
             },
           ],
@@ -157,28 +157,28 @@ export default ({
           items: [
             {
               iconSrc: require('@/assets/toolpanel/exclusive-gateway.svg'),
-              label: this.$t('Exclusive Gateway'),    
+              label: this.$t('Exclusive Gateway'),
               id: 'exclusiveGateway',
             },
             {
               iconSrc: require('@/assets/toolpanel/inclusive-gateway.svg'),
-              label: this.$t('Inclusive Gateway'),    
+              label: this.$t('Inclusive Gateway'),
               id: 'inclusiveGateway',
             },
             {
               iconSrc: require('@/assets/toolpanel/parallel-gateway.svg'),
-              label: this.$t('Parallel Gateway'),    
+              label: this.$t('Parallel Gateway'),
               id: 'parallelGateway',
             },
             {
               iconSrc: require('@/assets/toolpanel/generic-gateway.svg'),
-              label: this.$t('Event Based Gateway'),    
+              label: this.$t('Event Based Gateway'),
               id: 'eventBasedGateway',
             },
-            
+
           ],
         },
-        
+
         {
           iconSrc: require('@/assets/toolpanel/pool.svg'),
           label: this.$t('Pool'),

--- a/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
+++ b/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
@@ -21,11 +21,16 @@
       <div class="control-submenu-options">
         <span />
       </div>
-      <img :src=data.iconSrc :alt=data.label>
+      <img
+        :src=data.iconSrc
+        :alt=data.label
+        :title="$t(data.label)"
+        v-b-tooltip.hover
+      >
     </div>
   </popper>
 </template>
-  
+
 <script>
 import Popper from 'vue-popperjs';
 import 'vue-popperjs/dist/vue-popper.css';
@@ -39,7 +44,7 @@ export default ({
 });
 
 </script>
-  
+
 <style lang="scss" scoped>
 .control-submenu {
   display: flex;
@@ -67,7 +72,7 @@ export default ({
     &:hover {
       background: #EBEEF2;
     }
-   
+
     & > img {
       width: 24px;
       height: 24px;
@@ -89,9 +94,8 @@ export default ({
       clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
       clip-path: padding-box;
     }
-    
+
   }
 }
 
 </style>
-  

--- a/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
+++ b/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
@@ -3,6 +3,8 @@
     <button type="button"
       class="ur-button"
       data-test="undo"
+      v-b-tooltip.hover
+      :title="$t('Undo')"
     >
       <img :src="undoIcon" :alt="$t('Undo')" >
     </button>
@@ -12,6 +14,8 @@
     <button type="button"
       class="ur-button"
       data-test="redo"
+      v-b-tooltip.hover
+      :title="$t('Redo')"
     >
       <img :src="redoIcon" :alt="$t('Redo')" >
     </button>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior:
Pop-up  info should appears in all controls in the bottom rail  

Actual behavior: 
Some controls are not pop-up info like:

Undo 

Redo

Start Event

Intermediate Event

End Event

Task

Gateway

Pool

+ button “More Options“ 

## Solution
- Add a tooltip in the bottom controls

## How to Test
Test the steps above

1. Open a BPMN process
2. It should show the new undo/redo and BPMN controls at the bottom of the screen
3. Move the mouse over the controls 

## Related Tickets & Packages

[FOUR-8499](https://processmaker.atlassian.net/browse/FOUR-8499)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-8499]: https://processmaker.atlassian.net/browse/FOUR-8499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ