### PR TITLE
feature/FOUR-8530 add pop up to UNDO and REDO controls  when not enabled

### DIFF
--- a/src/components/railBottom/undoRedoControl/undoRedoControl.scss
+++ b/src/components/railBottom/undoRedoControl/undoRedoControl.scss
@@ -39,7 +39,6 @@
       background-color: #ffffff;
       color: #7e7e92;
       cursor: not-allowed;
-      pointer-events: none;
     }
 
     &:first-child {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Pop up menu should be visible when the UNDO & REDO button is disabled as the original button 

Actual behavior: 
When the UNDO & REDO options are disabled the pop-up menu is not visible

## Solution
- Update the undo/redo controls style in order to add the tooltip when the button is disabled

## How to Test
Test the steps above 
1. Open a BPMN process
2. It should show the new undo/redo controls at the bottom of the screen
3. Move the mouse over these controls when are disabled and It should show the tooltip 

## Related Tickets & Packages
[FOUR-8530](https://processmaker.atlassian.net/browse/FOUR-8530)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-8530]: https://processmaker.atlassian.net/browse/FOUR-8530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ