### PR TITLE
Add undoRedoTransaction

### DIFF
--- a/src/ModelerApp.vue
+++ b/src/ModelerApp.vue
@@ -85,7 +85,7 @@ export default {
   methods: {
     loadXmlIntoModeler() {
       this.$refs.modeler.loadXML(this.uploadedXml);
-      undoRedoStore.dispatch('pushState', this.uploadedXml);
+      undoRedoStore.dispatch('loadXML', this.uploadedXml);
     },
     clearUpload() {
       this.uploadedXml = null;

--- a/src/components/controls/controls.vue
+++ b/src/components/controls/controls.vue
@@ -33,6 +33,7 @@
 
 <script>
 import { BOTTOM } from '@/components/controls/rankConstants';
+import undoRedoStore from '@/undoRedoStore';
 
 export default {
   props: ['allowDrop', 'compressed', 'canvasDragPosition', 'parentHeight', 'nodeTypes'],
@@ -97,9 +98,11 @@ export default {
       this.draggingElement = null;
       this.draggingControl = null;
     },
-    dropElement({ clientX, clientY }) {
-      this.$emit('handleDrop', { clientX, clientY, control: this.draggingControl });
-      this.stopDrag();
+    async dropElement({ clientX, clientY }) {
+      undoRedoStore.dispatch('undoRedoTransaction', () => {
+        this.$emit('handleDrop', { clientX, clientY, control: this.draggingControl });
+        this.stopDrag();
+      });
     },
     setDraggingPosition({ pageX, pageY, clientX, clientY }) {
       this.draggingElement.style.left = pageX - this.xOffset + 'px';

--- a/src/components/crown/crownButtons/deleteButton.vue
+++ b/src/components/crown/crownButtons/deleteButton.vue
@@ -21,6 +21,7 @@
 import trashIcon from '@/assets/trash-alt-solid.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import { removeFlows } from '@/components/crown/utils.js';
+import undoRedoStore from '@/undoRedoStore';
 
 export default {
   components: { CrownButton },
@@ -37,10 +38,11 @@ export default {
   },
   methods: {
     removeFlows,
-    removeShape() {
-      // @todo this should be handled by the Modeler.vue
-      this.removeFlows(this.graph, this.shape);
-      this.$emit('remove-node', this.node);
+    async removeShape() {
+      undoRedoStore.dispatch('undoRedoTransaction', () => {
+        this.removeFlows(this.graph, this.shape);
+        this.$emit('remove-node', this.node);
+      });
     },
     removePoolLaneShape() {
       this.$emit('remove-node', this.node);

--- a/src/components/crown/crownConfig/crownConfig.vue
+++ b/src/components/crown/crownConfig/crownConfig.vue
@@ -93,6 +93,7 @@ import store from '@/store';
 import isEqual from 'lodash/isEqual';
 import { getDefaultNodeColors, setShapeColor } from '@/components/nodeColors';
 import runningInCypressTest from '@/runningInCypressTest';
+import undoRedoStore from '@/undoRedoStore';
 
 export default {
   components: {
@@ -216,14 +217,14 @@ export default {
       this.$emit('replace-node', this.nodeToReplace);
     },
     setNodePosition() {
-      this.shape.stopListening(this.paper, 'element:pointerup', this.setNodePosition);
-      this.savePositionOnPointerupEventSet = false;
+      undoRedoStore.dispatch('undoRedoTransaction', () => {
+        this.shape.stopListening(this.paper, 'element:pointerup', this.setNodePosition);
+        this.savePositionOnPointerupEventSet = false;
 
-      if (!store.getters.allowSavingElementPosition) {
-        return;
-      }
-
-      this.$emit('save-state');
+        if (!store.getters.allowSavingElementPosition) {
+          return;
+        }
+      });
     },
     repositionCrown() {
       const shapeView = this.shape.findView(this.paper);

--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -26,6 +26,7 @@
 <script>
 import store from '@/store';
 import runningInCypressTest from '@/runningInCypressTest';
+import undoRedoStore from '@/undoRedoStore';
 
 export default {
   props: {
@@ -103,18 +104,18 @@ export default {
       return !this.isRendering;
     },
     setNodePosition() {
-      this.shape.stopListening(
-        this.paper,
-        'element:pointerup',
-        this.setNodePosition
-      );
-      this.savePositionOnPointerupEventSet = false;
+      undoRedoStore.dispatch('undoRedoTransaction', () => {
+        this.shape.stopListening(
+          this.paper,
+          'element:pointerup',
+          this.setNodePosition
+        );
+        this.savePositionOnPointerupEventSet = false;
 
-      if (!store.getters.allowSavingElementPosition) {
-        return;
-      }
-
-      this.$emit('save-state');
+        if (!store.getters.allowSavingElementPosition) {
+          return;
+        }
+      });
     },
     paperDoneRendering() {
       if (!this.isRendering) {

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -51,6 +51,7 @@ import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import Process from './process';
 import isString from 'lodash/isString';
+import undoRedoStore from '@/undoRedoStore';
 
 Vue.component('FormText', renderer.FormText);
 Vue.component('FormInput', FormInput);
@@ -225,7 +226,9 @@ export default {
       }
     },
     updateState() {
-      this.$emit('save-state');
+      undoRedoStore.dispatch('undoRedoTransaction', async() => {
+        this.$emit('save-state');
+      });
     },
   },
 };

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -469,14 +469,15 @@ export default {
       if (this.pasteInProgress || this.cloneInProgress) {
         return;
       }
-      try {
-        const xml = await this.getXmlFromDiagram();
-        await undoRedoStore.dispatch('pushState', xml);
-        window.ProcessMaker.EventBus.$emit('modeler-change');
-      } catch (invalidXml) {
-        // eslint-disable-next-line no-console
-        console.warn(invalidXml.message);
-      }
+      await undoRedoStore.dispatch('pushState', async() => {
+        try {
+          return await this.getXmlFromDiagram();
+        } catch (invalidXml) {
+          // eslint-disable-next-line no-console
+          console.warn(invalidXml.message);
+        }
+      });
+      window.ProcessMaker.EventBus.$emit('modeler-change');
     },
     getXmlFromDiagram() {
       return new Promise((resolve, reject) => {
@@ -1353,7 +1354,7 @@ export default {
     window.ProcessMaker.EventBus.$emit('modeler-start', {
       loadXML: async(xml) => {
         await this.loadXML(xml);
-        await undoRedoStore.dispatch('pushState', xml);
+        await undoRedoStore.dispatch('loadXML', xml);
       },
       addWarnings: warnings => this.$emit('warnings', warnings),
       addBreadcrumbs: breadcrumbs => this.breadcrumbData.push(breadcrumbs),

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -277,7 +277,7 @@ export default {
     },
   },
   mounted() {
-    if (this.$root.$children[0].process.is_template) {
+    if (this.$root.$children[0].process && this.$root.$children[0].process.is_template) {
       const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
         return object.value === 'save-template';
       });


### PR DESCRIPTION
## Issue & Reproduction Steps
Intermediate states are stored while a diagram is moved or changed.

Expected behavior: 
Only one state of the diagram should be stored by User action.

Actual behavior: 
In some cases more than one state is stored by one User action like moving sequence flow with waypoints

## Solution
- Implement a `start transaction -> updates -> commit` to handle the updates of the modeler.

## How to Test
Test all the ways a diagram can be changed by the user.

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy