### PR TITLE
FOUR-8611 Add zoom reset functionality

### DIFF
--- a/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
+++ b/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
@@ -113,10 +113,6 @@ export default ({
     }
     &.active {
       background-color: #EBEEF2;
-
-      & > svg {
-        fill: peru;
-      }
     }
   }
   &-list {

--- a/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
+++ b/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
@@ -11,8 +11,6 @@
       <inline-svg :src="undoIcon" />
     </button>
 
-    <div class="ur-divider" />
-
     <button type="button"
       class="ur-button"
       data-cy="redo-control"

--- a/src/components/railBottom/undoRedoControl/undoRedoControl.scss
+++ b/src/components/railBottom/undoRedoControl/undoRedoControl.scss
@@ -42,24 +42,10 @@
       cursor: not-allowed;
     }
 
-    &:first-child {
-      margin-right: 4px;
-    }
-
-    &:last-child {
-      margin-left: 4px;
-    }
-
     & > svg {
       width: 24px;
       height: 24px;
       fill: #333344;
     }
-  }
-
-  &-divider {
-    width: 1px;
-    height: 28px;
-    border-right: thin solid #B6BFC6;
   }
 }

--- a/src/components/railBottom/zoomControl/ZoomControl.vue
+++ b/src/components/railBottom/zoomControl/ZoomControl.vue
@@ -17,7 +17,7 @@
       class="zoom-button zoom-reset"
       data-cy="zoom-reset-control"
     >
-      {{ Math.round(paperManager.scale.sx * 100) }}%
+      {{ percentageText }}
     </button>
 
     <button
@@ -51,6 +51,11 @@ export default ({
       minusIcon: require('@/assets/railBottom/minus.svg'),
       plusIcon: require('@/assets/railBottom/plus.svg'),
     };
+  },
+  computed: {
+    percentageText() {
+      return `${Math.round(this.$props.paperManager.scale.sx * 100)}%`;
+    },
   },
   methods: {
     onClickZoomOut() {

--- a/src/components/railBottom/zoomControl/ZoomControl.vue
+++ b/src/components/railBottom/zoomControl/ZoomControl.vue
@@ -11,9 +11,14 @@
       <inline-svg :src="minusIcon" />
     </button>
 
-    <div v-if="paperManager" class="zoom-text">
-      {{ Math.round(paperManager.scale.sx*100) }}%
-    </div>
+    <button
+      v-if="paperManager"
+      @click="onClickReset"
+      class="zoom-button zoom-reset"
+      data-cy="zoom-reset-control"
+    >
+      {{ Math.round(paperManager.scale.sx * 100) }}%
+    </button>
 
     <button
       type="button"
@@ -56,6 +61,9 @@ export default ({
     },
     onClickZoomIn() {
       this.paperManager.scale = this.paperManager.scale.sx + this.scaleStep;
+    },
+    onClickReset() {
+      this.paperManager.scale = this.initialScale;
     },
   },
 });

--- a/src/components/railBottom/zoomControl/zoomControl.scss
+++ b/src/components/railBottom/zoomControl/zoomControl.scss
@@ -10,8 +10,7 @@
     border-radius: 8px;
   }
 
-  &-button,
-  &-text {
+  &-button {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -51,20 +50,17 @@
     }
   }
 
-  &-text {
-    height: 28px;
-    margin-right: 0;
+  &-reset {
     padding: {
-      left: 30px;
-      right: 30px;
+      left: 24px;
+      right: 24px;
     };
-    border: {
-      left: thin solid #B6BFC6;
-      right: thin solid #B6BFC6;
-    };
-    border-radius: 0;
     font-size: 14px;
     font-weight: 700;
     user-select: none;
+
+    &:active {
+      color: #1264AA;
+    }
   }
 }

--- a/tests/e2e/specs/zoomControl/ZoomControl.spec.js
+++ b/tests/e2e/specs/zoomControl/ZoomControl.spec.js
@@ -1,6 +1,7 @@
 describe('Zoom control test', () => {
   const zoomOutSelector = '[data-cy="zoom-out-control"]';
   const zoomInSelector = '[data-cy="zoom-in-control"]';
+  const zoomResetSelector = '[data-cy="zoom-reset-control"]';
 
   const buttonBgColorDefault = 'rgb(255, 255, 255)';
   const iconFillColorDefault = 'rgb(51, 51, 68)';
@@ -71,6 +72,37 @@ describe('Zoom control test', () => {
 
         expect(expectedScale).eq(Math.round(paper.scale().sx * 10) / 10);
         expect(expectedScale).eq(Math.round(paper.scale().sy * 10) / 10);
+      });
+  });
+
+  it(`should reset modeler after (+) zoom-in (${numZoomInTimes}) times`, () => {
+    const numClicks = Array.from({length: numZoomInTimes}, (_, index) => index + 1);
+
+    numClicks.forEach(() => {
+      cy.get(zoomInSelector).click();
+    });
+
+    cy.window()
+      .its('store.state.paper')
+      .then(paper => {
+        const expectedScale = initialScale + (scaleStep * numZoomInTimes);
+
+        cy.wait(500);
+
+        expect(expectedScale).eq(Math.round(paper.scale().sx * 10) / 10);
+        expect(expectedScale).eq(Math.round(paper.scale().sy * 10) / 10);
+      });
+
+    cy.wait(500);
+    cy.get(zoomResetSelector).click();
+
+    cy.window()
+      .its('store.state.paper')
+      .then(paper => {
+        cy.wait(500);
+
+        cy.log(paper.scale().sx);
+        expect(paper.scale().sx).eq(initialScale);
       });
   });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The reset button should be present in the new design of the modeler 

Actual behavior: 
N/A

## Solution
The reset behavior is being moved to the View Percentage element. When the user clicks on the percentage button the view will be reset to 100%

## How to Test
1. Open a BPMN process
2. It should show the new zoom control at the bottom rail
3. Click on the zoom-in or zoom-out button
4. Then click on the View Percentage element

![image](https://github.com/ProcessMaker/modeler/assets/3604190/45b33d9e-12fb-4ecf-b06a-a116b404d006)


## Related Tickets & Packages
[FOUR-8611](https://processmaker.atlassian.net/browse/FOUR-8611)


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-8611]: https://processmaker.atlassian.net/browse/FOUR-8611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ