### PR TITLE
FOUR-8777: Cannot set properties of undefined (setting 'bpmnElement')…

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -121,10 +121,10 @@ export default {
     moveEmbeddedElements(currentElement, toPool) {
       this.getElementsUnderArea(currentElement, this.graph)
         .filter(element => element.isEmbeddedIn(currentElement))
-        .map(element => element.component.node.definition)
-        .forEach((elementDefinition) => {
-          pull(this.containingProcess.get('flowElements'), elementDefinition);
-          toPool.component.containingProcess.get('flowElements').push(elementDefinition);
+        .forEach((child) => {
+          child.component.node.pool = toPool;
+          pull(this.containingProcess.get('flowElements'), child.component.node.definition);
+          toPool.component.containingProcess.get('flowElements').push(child.component.node.definition);
         });
     },
     moveElement(element, toPool) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 

Actual behavior: 
Cannot set properties of undefined (setting 'bpmnElement')>> Error appears on the pools and it is not possible to recover the process 

## Solution
- the pool references was missed for the embedded objects (boundary events), so the solution is to update the new pool reference 
## How to Test
Test the steps above

1. Go to modeler 
3. Add two pools
5. First pool
7. Add a task with a boundary event
9. Add End Event
11. Select the elements inside the loop
13. Copy the selection
15. Paste the selection
17. Move the selection to the second pool
19. Move the selection to the first  pool
21. Delete two pools 
23. Add a third pool
25. Publish the changes
27. Reload the page 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8777

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
