### PR TITLE
FOUR-8538 - Highlight request's path on Process Map

### DIFF
--- a/src/components/modeler/ModelerReadonly.vue
+++ b/src/components/modeler/ModelerReadonly.vue
@@ -1,6 +1,6 @@
 <template>
   <span data-test="body-container">
-    <b-row class="modeler h-100">
+    <div class="modeler h-100">
       <controls
         v-if="showControls"
         class="controls h-100 rounded-0 border-top-0 border-bottom-0 border-left-0"
@@ -71,7 +71,7 @@
         :useModelGeometry="false"
         :processNode="processNode"
       />
-    </b-row>
+    </div>
   </span>
 </template>
 
@@ -979,10 +979,8 @@ svg {
 .rail {
   &-container {
     position: relative;
-    bottom: 70px;
-    display: flex;
-    align-items: center;
-    width: 100%;
+    bottom: 60px;
+    display: inline-block;
     height: 48px;
     max-height: 48px;
     z-index: 2;
@@ -990,17 +988,9 @@ svg {
 
   &-left {
     position: absolute;
-    display: flex;
+    display: inline;
     width: auto;
-    padding: 0 35px;
-  }
-
-  &-center {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    column-gap: 22px;
-    width: 100%;
+    padding: 0 12px;
   }
 }
 </style>

--- a/src/components/modeler/ModelerReadonly.vue
+++ b/src/components/modeler/ModelerReadonly.vue
@@ -31,7 +31,6 @@
         :paper="paper"
         :node="node"
         :id="node.id"
-        :highlighted="highlightedNodes.includes(node)"
         :border-outline="borderOutline(node.id)"
         :collaboration="collaboration"
         :process-node="processNode"
@@ -40,11 +39,14 @@
         :moddle="moddle"
         :nodeRegistry="nodeRegistry"
         :root-elements="definitions.get('rootElements')"
-        :isRendering="isRendering"
         :paperManager="paperManager"
         :auto-validate="autoValidate"
-        :is-active="node === activeNode"
         :node-id-generator="nodeIdGenerator"
+        :highlighted="highlightedNodes.includes(node)"
+        :is-active="node === activeNode"
+        :is-rendering="isRendering"
+        :is-completed="requestCompletedNodes.includes(node.definition.id)"
+        :is-in-progress="requestInProgressNodes.includes(node.definition.id)"
         @add-node="addNode"
         @set-cursor="cursor = $event"
         @set-pool-target="poolTarget = $event"
@@ -131,6 +133,14 @@ export default {
     readOnly: {
       type: Boolean,
       default: true,
+    },
+    requestCompletedNodes: {
+      type: Array,
+      default: () => [],
+    },
+    requestInProgressNodes: {
+      type: Array,
+      default: () => [],
     },
   },
   data() {

--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -35,8 +35,7 @@ const completedHighlighter = {
     options: {
       attrs: {
         stroke: '#1572C2',
-        'stroke-width': 2,
-        'data-cy': 'completed',
+        'stroke-width': 3,
       },
     },
   },
@@ -48,9 +47,8 @@ const inProgressHighlighter = {
     options: {
       attrs: {
         stroke: '#00875A',
-        'stroke-width': 2,
+        'stroke-width': 3,
         'stroke-dasharray': '4 4',
-        'data-cy': 'in-progress',
       },
     },
   },

--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -1,4 +1,6 @@
+/* eslint-disable no-unused-vars */
 import cloneDeep from 'lodash/cloneDeep';
+import store from '@/store';
 
 const errorHighlighter = {
   highlighter: {
@@ -22,6 +24,33 @@ const defaultHighlighter = {
         stroke: '#5096db',
         'stroke-width': 3,
         'data-cy': 'selected',
+      },
+    },
+  },
+};
+
+const completedHighlighter = {
+  highlighter: {
+    name: 'stroke',
+    options: {
+      attrs: {
+        stroke: '#1572C2',
+        'stroke-width': 2,
+        'data-cy': 'completed',
+      },
+    },
+  },
+};
+
+const inProgressHighlighter = {
+  highlighter: {
+    name: 'stroke',
+    options: {
+      attrs: {
+        stroke: '#00875A',
+        'stroke-width': 2,
+        'stroke-dasharray': '4 4',
+        'data-cy': 'in-progress',
       },
     },
   },
@@ -68,6 +97,10 @@ export default {
   },
   methods: {
     setShapeHighlight() {
+      if (store.getters.isReadOnly) {
+        return;
+      }
+
       if (!this.shapeView) {
         return;
       }
@@ -84,7 +117,9 @@ export default {
       if (this.currentBorderOutline) {
         this.shapeView.unhighlight(this.shapeBody, this.currentBorderOutline);
       }
-      this.currentBorderOutline = borderOutline ? cloneDeep(borderOutline) : null;
+      this.currentBorderOutline = borderOutline
+        ? cloneDeep(borderOutline)
+        : null;
       if (this.currentBorderOutline) {
         this.shapeView.highlight(this.shapeBody, this.currentBorderOutline);
       }
@@ -92,14 +127,15 @@ export default {
   },
   mounted() {
     this.$nextTick(() => {
-      this.paperManager.awaitScheduledUpdates()
-        .then(() => {
-          this.setShapeHighlight();
-          this.shape.on('change:size', () => {
-            this.paperManager.awaitScheduledUpdates().then(this.setShapeHighlight);
-            this.$emit('shape-resize', this.shape);
-          });
+      this.paperManager.awaitScheduledUpdates().then(() => {
+        this.setShapeHighlight();
+        this.shape.on('change:size', () => {
+          this.paperManager
+            .awaitScheduledUpdates()
+            .then(this.setShapeHighlight);
+          this.$emit('shape-resize', this.shape);
         });
+      });
     });
   },
 };

--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -63,6 +63,8 @@ export default {
     'hasError',
     'autoValidate',
     'borderOutline',
+    'isCompleted',
+    'isInProgress',
   ],
   data() {
     return {
@@ -98,6 +100,14 @@ export default {
   methods: {
     setShapeHighlight() {
       if (store.getters.isReadOnly) {
+        this.shapeView.unhighlight(this.shapeBody, completedHighlighter);
+        if (this.isCompleted) {
+          this.shapeView.highlight(this.shapeBody, completedHighlighter);
+        }
+        this.shapeView.unhighlight(this.shapeBody, inProgressHighlighter);
+        if (this.isInProgress) {
+          this.shapeView.highlight(this.shapeBody, inProgressHighlighter);
+        }
         return;
       }
 

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -40,6 +40,9 @@ export default {
       }
     },
     highlighted(highlighted) {
+      if (store.getters.isReadOnly) {
+        return;
+      }
       if (highlighted) {
         this.shape.attr({
           line: { stroke: '#5096db' },
@@ -246,9 +249,10 @@ export default {
 
     this.$once('click', () => {
       this.$nextTick(() => {
-        if (store.getters.isReadOnly === false) {
-          this.setupLinkTools();
+        if (store.getters.isReadOnly) {
+          return;
         }
+        this.setupLinkTools();
       });
     });
 

--- a/src/mixins/resizeConfig.js
+++ b/src/mixins/resizeConfig.js
@@ -28,7 +28,9 @@ export default {
       }
 
       if (highlighted) {
-        this.addResizeAnchors();
+        if (store.getters.isReadOnly === false) {
+          this.addResizeAnchors();
+        }
         this.calculateElementLimits();
         this.updateAnchorPointPosition();
       } else {


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR is part of [Core's PR](https://github.com/ProcessMaker/processmaker/pull/4831).

Expected behavior: 
- The user can see clear visual indicators differentiating completed, in-progress, and unused BPMN elements for the request.

Actual behavior: 
- The user cannot see the highlighted path.

## Solution
- Created new highlighters for when the nodes are in completed and in-progress status.
  - These are applied if the node is within the new props lists of `requestCompletedNodes` and `requestInProgressNodes`.

## How to Test
- Please link modeler and core or use the provided QA test server.

## Related Tickets & Packages
- [Core's PR](https://github.com/ProcessMaker/processmaker/pull/4831)