### PR TITLE
Implement PM Block Registration and Explorer Rail Enhancement

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ module.exports = {
 
   rules: {
     semi: ['error', 'always'],
+    "no-console": "off",
     'comma-dangle': ['error', 'always-multiline'],
     indent: ['error', 2, { SwitchCase: 1 }],
     quotes: ['error', 'single'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,7 +12,7 @@ module.exports = {
 
   rules: {
     semi: ['error', 'always'],
-    "no-console": "off",
+    'no-console': 'off',
     'comma-dangle': ['error', 'always-multiline'],
     indent: ['error', 2, { SwitchCase: 1 }],
     quotes: ['error', 'single'],

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -12,6 +12,7 @@
       @toggle-mini-map-open="miniMapOpen = $event"
       @saveBpmn="saveBpmn"
       @publishTemplate="publishTemplate"
+      @publishPmBlock="publishPmBlock"
       @close="close"
       @save-state="pushToUndoStack"
       @clearSelection="clearSelection"
@@ -356,6 +357,9 @@ export default {
     },
     publishTemplate() {
       this.$emit('publishTemplate');
+    },
+    publishPmBlock() {
+      this.$emit('publishPmBlock');
     },
     async pasteElements() {
       if (this.copiedElements.length > 0 && !this.pasteInProgress) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -25,6 +25,7 @@
       />
       <explorer-rail
         :node-types="nodeTypes"
+        :pm-block-nodes="pmBlockNodes"
         @set-cursor="cursor = $event"
         @onCreateElement="onCreateElementHandler"
       />

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -241,6 +241,7 @@ export default {
       isRendering: false,
       allWarnings: [],
       nodeTypes: [],
+      pmBlockNodes: [],
       breadcrumbData: [],
       activeNode: null,
       xmlManager: null,
@@ -612,6 +613,26 @@ export default {
           return;
         }
 
+        this.parsers[bpmnType].default.push(defaultParser);
+      });
+    },
+    registerPmBlock(pmBlockNode) {
+      console.log('REGISTER PM BLOCK NODE', pmBlockNode);
+      const defaultParser = () => pmBlockNode.id;
+
+      this.translateConfig(pmBlockNode.inspectorConfig[0]);
+      addLoopCharacteristics(pmBlockNode);
+      this.nodeRegistry[pmBlockNode.id] = pmBlockNode;
+
+      Vue.component(pmBlockNode.id, pmBlockNode.component);
+      this.pmBlockNodes.push(pmBlockNode);
+      console.log('PM BLOCK NODES REGISTER', this.pmBlockNodes);
+
+      const types = Array.isArray(pmBlockNode.bpmnType)
+        ? pmBlockNode.bpmnType
+        : [pmBlockNode.bpmnType];
+
+      types.forEach(bpmnType => {
         this.parsers[bpmnType].default.push(defaultParser);
       });
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1258,6 +1258,7 @@ export default {
       registerBpmnExtension: this.registerBpmnExtension,
       registerNode: this.registerNode,
       registerStatusBar: this.registerStatusBar,
+      registerPmBlock: this.registerPmBlock,
     });
 
     this.moddle = new BpmnModdle(this.extensions);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -11,11 +11,8 @@
       @toggle-panels-compressed="panelsCompressed = !panelsCompressed"
       @toggle-mini-map-open="miniMapOpen = $event"
       @saveBpmn="saveBpmn"
-      @publishTemplate="publishTemplate"
-      @publishPmBlock="publishPmBlock"
       @close="close"
       @save-state="pushToUndoStack"
-      @clearSelection="clearSelection"
     />
     <b-row class="modeler h-100">
       <b-tooltip
@@ -26,6 +23,7 @@
       />
       <explorer-rail
         :node-types="nodeTypes"
+        :pm-block-nodes="pmBlockNodes"
         @set-cursor="cursor = $event"
         @onCreateElement="onCreateElementHandler"
       />
@@ -39,9 +37,15 @@
         <div ref="paper" data-test="paper" class="main-paper" />
       </b-col>
 
+      <mini-paper
+        :isOpen="miniMapOpen"
+        :paperManager="paperManager"
+        :graph="graph"
+        :class="{ 'expanded' : panelsCompressed }"
+      />
+
       <InspectorPanel
         ref="inspector-panel"
-        v-show="!(highlightedNodes.length > 1)"
         :style="{ height: parentHeight }"
         :nodeRegistry="nodeRegistry"
         :moddle="moddle"
@@ -52,14 +56,12 @@
         :parent-height="parentHeight"
         :canvas-drag-position="canvasDragPosition"
         :compressed="panelsCompressed && noElementsSelected"
-        @shape-resize="shapeResize(false)"
       />
 
       <component
         v-for="node in nodes"
         :is="node.type"
         :key="node._modelerId"
-        ref="nodeComponent"
         :graph="graph"
         :paper="paper"
         :node="node"
@@ -83,8 +85,8 @@
         @remove-node="removeNode"
         @set-cursor="cursor = $event"
         @set-pool-target="poolTarget = $event"
+        @click="highlightNode(node, $event)"
         @unset-pools="unsetPools"
-        @clearSelection="clearSelection"
         @set-pools="setPools"
         @save-state="pushToUndoStack"
         @set-shape-stacking="setShapeStacking"
@@ -92,35 +94,7 @@
         @replace-node="replaceNode"
         @replace-generic-flow="replaceGenericFlow"
         @copy-element="copyElement"
-        @copy-selection="copyElement"
-        @paste-element="pasteElements"
-        @clone-element="cloneElement"
-        @clone-selection="cloneSelection"
         @default-flow="toggleDefaultFlow"
-        @shape-resize="shapeResize"
-      />
-
-      <RailBottom
-        :nodeTypes="nodeTypes"
-        :paper-manager="paperManager"
-        :graph="graph"
-        :is-rendering="isRendering"
-        @load-xml="loadXML"
-        @clearSelection="clearSelection"
-        @set-cursor="cursor = $event"
-        @onCreateElement="onCreateElementHandler"
-      />
-
-      <selection
-        v-if="paper"
-        ref="selector"
-        :graph="graph"
-        :paperManager="paperManager"
-        :useModelGeometry="false"
-        @clone-selection="cloneSelection"
-        @remove-nodes="removeNodes"
-        :processNode="processNode"
-        @save-state="pushToUndoStack"
       />
     </b-row>
   </span>
@@ -132,7 +106,7 @@ import _ from 'lodash';
 import { dia } from 'jointjs';
 import boundaryEventConfig from '../nodes/boundaryEvent';
 import BpmnModdle from 'bpmn-moddle';
-import ExplorerRail from '../rails/explorer-rail/explorer';
+import controls from '../controls/controls';
 import pull from 'lodash/pull';
 import remove from 'lodash/remove';
 import store from '@/store';
@@ -140,24 +114,18 @@ import InspectorPanel from '@/components/inspectors/InspectorPanel';
 import undoRedoStore from '@/undoRedoStore';
 import { Linter } from 'bpmnlint';
 import linterConfig from '../../../.bpmnlintrc';
-import { getNodeIdGenerator } from '../../NodeIdGenerator';
+import NodeIdGenerator from '../../NodeIdGenerator';
 import Process from '../inspectors/process';
 import runningInCypressTest from '@/runningInCypressTest';
 import getValidationProperties from '@/targetValidationUtils';
+import MiniPaper from '@/components/miniPaper/MiniPaper';
 import { id as laneId } from '@/components/nodes/poolLane/config';
-import { id as processId } from '@/components/inspectors/process';
 import { id as sequenceFlowId } from '../nodes/sequenceFlow';
 import { id as associationId } from '../nodes/association';
 import { id as messageFlowId } from '../nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '../nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '../nodes/dataInputAssociation/config';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
-import { id as boundaryErrorEventId } from '@/components/nodes/boundaryErrorEvent';
-import { id as boundaryConditionalEventId } from '@/components/nodes/boundaryConditionalEvent';
-import { id as boundaryEscalationEventId } from '@/components/nodes/boundaryEscalationEvent';
-import { id as boundaryMessageEventId } from '@/components/nodes/boundaryMessageEvent';
-import { id as boundarySignalEventId } from '@/components/nodes/boundarySignalEvent';
-import { id as boundaryTimerEventId } from '@/components/nodes/boundaryTimerEvent';
 
 import PaperManager from '../paperManager';
 import registerInspectorExtension from '@/components/InspectorExtensionManager';
@@ -166,7 +134,8 @@ import ensureShapeIsNotCovered from '@/components/shapeStackUtils';
 import ToolBar from '@/components/toolbar/ToolBar';
 import Node from '@/components/nodes/node';
 import { addNodeToProcess } from '@/components/nodeManager';
-import hotkeys from '@/components/hotkeys/main';
+import moveShapeByKeypress from '@/components/modeler/moveWithArrowKeys';
+import setUpSelectionBox from '@/components/modeler/setUpSelectionBox';
 import TimerEventNode from '@/components/nodes/timerEventNode';
 import focusNameInputAndHighlightLabel from '@/components/modeler/focusNameInputAndHighlightLabel';
 import XMLManager from '@/components/modeler/XMLManager';
@@ -174,22 +143,16 @@ import { removeNodeFlows, removeNodeMessageFlows, removeNodeAssociations, remove
 import { getInvalidNodes } from '@/components/modeler/modelerUtils';
 import { NodeMigrator } from '@/components/modeler/NodeMigrator';
 import addLoopCharacteristics from '@/setup/addLoopCharacteristics';
-import cloneSelection from '../../mixins/cloneSelection';
-import RailBottom from '@/components/railBottom/RailBottom.vue';
 
 import ProcessmakerModelerGenericFlow from '@/components/nodes/genericFlow/genericFlow';
-
-import Selection from './Selection';
-
 
 export default {
   components: {
     ToolBar,
-    ExplorerRail,
+    controls,
     InspectorPanel,
+    MiniPaper,
     ProcessmakerModelerGenericFlow,
-    Selection,
-    RailBottom,
   },
   props: {
     owner: Object,
@@ -200,12 +163,8 @@ export default {
       },
     },
   },
-  mixins: [hotkeys, cloneSelection],
   data() {
     return {
-      pasteInProgress: false,
-      cloneInProgress: false,
-      internalClipboard: [],
       tooltipTarget: null,
 
       /* Custom parsers for handling certain bpmn node types */
@@ -242,19 +201,11 @@ export default {
       isRendering: false,
       allWarnings: [],
       nodeTypes: [],
+      pmBlockNodes: [],
       breadcrumbData: [],
       activeNode: null,
       xmlManager: null,
       previouslyStackedShape: null,
-      keyMod: this.isAppleOS() ? 'Command' : 'Control',
-      canvasScale: 1,
-      initialScale: 1,
-      minimumScale: 0.2,
-      scaleStep: 0.1,
-      isDragging: false,
-      isSelecting: false,
-      isIntoTheSelection: false,
-      dragStart: null,
     };
   },
   watch: {
@@ -283,10 +234,6 @@ export default {
     autoValidate() {
       this.validateIfAutoValidateIsOn();
     },
-    canvasScale(canvasScale) {
-      this.paperManager.scale = canvasScale;
-    },
-
   },
   computed: {
     noElementsSelected() {
@@ -303,7 +250,6 @@ export default {
     currentXML() {
       return undoRedoStore.getters.currentState;
     },
-    copiedElements: () => store.getters.copiedElements,
     /* connectors expect a highlightedNode property */
     highlightedNode: () => store.getters.highlightedNodes[0],
     highlightedNodes: () => store.getters.highlightedNodes,
@@ -312,14 +258,6 @@ export default {
     },
   },
   methods: {
-    isAppleOS() {
-      return typeof navigator !== 'undefined' && /Mac|iPad|iPhone/.test(navigator.platform);
-    },
-    async shapeResize(clearIfEmpty=true) {
-      await this.$nextTick();
-      await this.paperManager.awaitScheduledUpdates();
-      this.$refs.selector.updateSelectionBox(true, clearIfEmpty);
-    },
     toggleDefaultFlow(flow) {
       const source = flow.definition.sourceRef;
       if (source.default && source.default.id === flow.id) {
@@ -327,93 +265,12 @@ export default {
       }
       source.set('default', flow);
     },
-    cloneElement(node, copyCount) {
+    copyElement(node, copyCount) {
       const clonedNode = node.clone(this.nodeRegistry, this.moddle, this.$t);
       const yOffset = (node.diagram.bounds.height + 30) * copyCount;
 
       clonedNode.diagram.bounds.y += yOffset;
       this.addNode(clonedNode);
-    },
-    copyElement() {
-      // Checking if User selected a single flow and tries to copy it, to deny it.
-      const flows = [
-        sequenceFlowId,
-        dataOutputAssociationFlowId,
-        dataInputAssociationFlowId,
-        genericFlowId,
-        processId,
-      ];
-      const boundaryEvents = [
-        boundaryErrorEventId,
-        boundaryConditionalEventId,
-        boundaryEscalationEventId,
-        boundaryMessageEventId,
-        boundarySignalEventId,
-        boundaryTimerEventId,
-      ];
-      if (this.highlightedNodes.length === 1 && (flows.includes(this.highlightedNodes[0].type) || boundaryEvents.includes(this.highlightedNodes[0].type))) return;
-      store.commit('setCopiedElements', this.cloneNodesSelection());
-      this.$bvToast.toast(this.$t('Object(s) have been copied'), { noCloseButton:true, variant: 'success', solid: true, toaster: 'b-toaster-top-center' });
-    },
-    publishTemplate() {
-      this.$emit('publishTemplate');
-    },
-    publishPmBlock() {
-      this.$emit('publishPmBlock');
-    },
-    async pasteElements() {
-      if (this.copiedElements.length > 0 && !this.pasteInProgress) {
-        this.pasteInProgress = true;
-        try {
-          await this.addClonedNodes(this.copiedElements);
-          await this.$nextTick();
-          await this.paperManager.awaitScheduledUpdates();
-          await this.$refs.selector.selectElements(this.findViewElementsFromNodes(this.copiedElements), true);
-          await this.$nextTick();
-          await store.commit('setCopiedElements', this.cloneNodesSelection());
-          this.scrollToSelection();
-        } finally {
-          this.pasteInProgress = false;
-          await this.pushToUndoStack();
-        }
-      }
-    },
-    async cloneSelection() {
-      const clonedNodes = this.cloneNodesSelection();
-      if (clonedNodes && clonedNodes.length === 0) {
-        return;
-      }
-      try {
-        this.cloneInProgress = true;
-        this.$refs.selector.clearSelection();
-        await this.addClonedNodes(clonedNodes);
-        await this.$nextTick();
-        await this.paperManager.awaitScheduledUpdates();
-        await this.$refs.selector.selectElements(this.findViewElementsFromNodes(clonedNodes));
-        this.scrollToSelection();
-      } finally {
-        this.cloneInProgress = false;
-        await this.pushToUndoStack();
-      }
-    },
-    scrollToSelection() {
-      const containerRect = this.$refs['paper-container'].getBoundingClientRect();
-      const selector = this.$refs.selector;
-      const selectorRect = selector.$el.getBoundingClientRect();
-      // Scroll to the cloned elements only when they are not visible on the screen.
-      if (selectorRect.right > containerRect.right || selectorRect.bottom > containerRect.bottom || selectorRect.left < containerRect.left || selectorRect.top < containerRect.top) {
-        const currentPosition = this.paper.translate();
-        const newTy = currentPosition.ty - (selectorRect.top - containerRect.top - selectorRect.height);
-        this.paper.translate(currentPosition.tx, newTy);
-        selector.updateSelectionBox(true);
-      }
-    },
-    findViewElementsFromNodes(nodes) {
-      return nodes.map(node => {
-        const component = this.$refs.nodeComponent.find(cmp => cmp.node === node);
-        const shape = component.shape;
-        return this.paper.findViewByModel(shape);
-      });
     },
     async close() {
       this.$emit('close');
@@ -470,12 +327,10 @@ export default {
       }
     },
     async pushToUndoStack() {
-      if (this.pasteInProgress || this.cloneInProgress) {
-        return;
-      }
       try {
         const xml = await this.getXmlFromDiagram();
-        await undoRedoStore.dispatch('pushState', xml);
+        undoRedoStore.dispatch('pushState', xml);
+
         window.ProcessMaker.EventBus.$emit('modeler-change');
       } catch (invalidXml) {
         // eslint-disable-next-line no-console
@@ -616,6 +471,26 @@ export default {
           return;
         }
 
+        this.parsers[bpmnType].default.push(defaultParser);
+      });
+    },
+    registerPmBlock(pmBlockNode) {
+      console.log('REGISTER PM BLOCK NODE', pmBlockNode);
+      const defaultParser = () => pmBlockNode.id;
+
+      this.translateConfig(pmBlockNode.inspectorConfig[0]);
+      addLoopCharacteristics(pmBlockNode);
+      this.nodeRegistry[pmBlockNode.id] = pmBlockNode;
+
+      Vue.component(pmBlockNode.id, pmBlockNode.component);
+      this.pmBlockNodes.push(pmBlockNode);
+      console.log('PM BLOCK NODES REGISTER', this.pmBlockNodes);
+
+      const types = Array.isArray(pmBlockNode.bpmnType)
+        ? pmBlockNode.bpmnType
+        : [pmBlockNode.bpmnType];
+
+      types.forEach(bpmnType => {
         this.parsers[bpmnType].default.push(defaultParser);
       });
     },
@@ -826,20 +701,12 @@ export default {
       this.isRendering = false;
       this.$emit('parsed');
     },
-    async loadXML(xml = null) {
-      let emitChangeEvent = false;
-      if (xml === null) {
-        xml = this.currentXML;
-        emitChangeEvent = true;
-      }
+    async loadXML(xml = this.currentXML) {
       this.definitions = await this.xmlManager.getDefinitionsFromXml(xml);
       this.xmlManager.definitions = this.definitions;
-      this.nodeIdGenerator = getNodeIdGenerator(this.definitions);
+      this.nodeIdGenerator = new NodeIdGenerator(this.definitions);
       store.commit('clearNodes');
-      await this.renderPaper();
-      if (emitChangeEvent) {
-        window.ProcessMaker.EventBus.$emit('modeler-change');
-      }
+      this.renderPaper();
     },
     getBoundaryEvents(process) {
       return process.get('flowElements').filter(({ $type }) => $type === 'bpmn:BoundaryEvent');
@@ -876,15 +743,9 @@ export default {
     toXML(cb) {
       this.moddle.toXML(this.definitions, { format: true }, cb);
     },
-    onCreateElementHandler({ event, control }) {
-      this.handleDrop({
-        clientX: event.clientX,
-        clientY: event.clientY,
-        control,
-      });
-    },
     async handleDrop({ clientX, clientY, control, nodeThatWillBeReplaced }) {
       this.validateDropTarget({ clientX, clientY, control });
+
       if (!this.allowDrop) {
         return;
       }
@@ -905,6 +766,7 @@ export default {
 
       this.highlightNode(newNode);
       await this.addNode(newNode);
+
       if (!nodeThatWillBeReplaced) {
         return;
       }
@@ -925,14 +787,7 @@ export default {
       diagram.bounds.x -= (diagram.bounds.width / 2);
       diagram.bounds.y -= (diagram.bounds.height / 2);
     },
-    async selectNewNode(node) {
-      await this.$nextTick();
-      await this.paperManager.awaitScheduledUpdates();
-      const newNodeComponent = this.$refs.nodeComponent.find(component => component.node === node);
-      const view = newNodeComponent.shapeView;
-      await this.$refs.selector.selectElement(view);
-    },
-    async addNode(node) {
+    addNode(node) {
       if (!node.pool) {
         node.pool = this.poolTarget;
       }
@@ -958,9 +813,6 @@ export default {
         return;
       }
 
-      // Select the node after it has been added to the store (does not apply to flows)
-      this.selectNewNode(node);
-
       return new Promise(resolve => {
         setTimeout(() => {
           this.pushToUndoStack();
@@ -968,27 +820,8 @@ export default {
         });
       });
     },
-    async addClonedNodes(nodes) {
-      nodes.forEach(node => {
-        if (!node.pool) {
-          node.pool = this.poolTarget;
-        }
-
-        const targetProcess = node.getTargetProcess(this.processes, this.processNode);
-        addNodeToProcess(node, targetProcess);
-
-        this.planeElements.push(node.diagram);
-        store.commit('addNode', node);
-        this.poolTarget = null;
-      });
-    },
     async removeNode(node, { removeRelationships = true } = {}) {
-      if (!node) {
-        // already removed
-        return;
-      }
       if (removeRelationships) {
-
         removeNodeFlows(node, this);
         removeNodeMessageFlows(node, this);
         removeNodeAssociations(node, this);
@@ -1001,21 +834,8 @@ export default {
       this.removeNodesFromPool(node);
       store.commit('removeNode', node);
       store.commit('highlightNode', this.processNode);
-      this.$refs.selector.clearSelection();
       await this.$nextTick();
-      await this.pushToUndoStack();
-    },
-    async removeNodes() {
-      await this.performSingleUndoRedoTransaction(async() => {
-        await this.paperManager.performAtomicAction(async() => {
-          const waitPromises = [];
-          this.highlightedNodes.forEach((node) =>
-            waitPromises.push(this.removeNode(node, { removeRelationships: true }))
-          );
-          await Promise.all(waitPromises);
-          store.commit('highlightNode');
-        });
-      });
+      this.pushToUndoStack();
     },
     replaceNode({ node, typeToReplaceWith }) {
       this.performSingleUndoRedoTransaction(async() => {
@@ -1029,7 +849,6 @@ export default {
 
           await this.removeNode(node, { removeRelationships: false });
           this.highlightNode(newNode);
-          this.selectNewNode(newNode);
         });
       });
     },
@@ -1049,7 +868,7 @@ export default {
       undoRedoStore.commit('disableSavingState');
       await cb();
       undoRedoStore.commit('enableSavingState');
-      await this.pushToUndoStack();
+      this.pushToUndoStack();
     },
     removeNodesFromLane(node) {
       const containingLane = node.pool && node.pool.component.laneSet &&
@@ -1099,6 +918,18 @@ export default {
 
       this.paperManager.setPaperDimensions(clientWidth, clientHeight);
     },
+    keydownListener(event) {
+      const focusIsOutsideDiagram = !event.target.toString().toLowerCase().includes('body');
+      if (focusIsOutsideDiagram) {
+        return;
+      }
+
+      moveShapeByKeypress(
+        event.key,
+        store.getters.highlightedShapes,
+        this.pushToUndoStack,
+      );
+    },
     validateDropTarget({ clientX, clientY, control }) {
       const { allowDrop, poolTarget } = getValidationProperties(clientX, clientY, control, this.paperManager.paper, this.graph, this.collaboration, this.$refs['paper-container']);
       this.allowDrop = allowDrop;
@@ -1121,101 +952,6 @@ export default {
     enableVersions() {
       undoRedoStore.dispatch('enableVersions');
     },
-    setVersionIndicator(isDraft) {
-      undoRedoStore.dispatch('setVersionIndicator', isDraft);
-    },
-    setLoadingState(isLoading) {
-      undoRedoStore.dispatch('setLoadingState', isLoading);
-    },
-    clearSelection(){
-      this.$refs.selector.clearSelection();
-    },
-    isPointInSelection(event) {
-      const selector = this.$refs.selector.$el;
-      if (typeof selector.getBoundingClientRect === 'function') {
-        // check if mouse was clicked inside the selector
-        const { x: sx, y: sy, width:swidth, height: sheight } = selector.getBoundingClientRect();
-        if (event.clientX >= sx && event.clientX <= sx + swidth && event.clientY >= sy && event.clientY <= sy + sheight) {
-          return true;
-        }
-      }
-      return false;
-    },
-    async pointerDowInShape(event, element) {
-      const { clientX: x, clientY: y } = event;
-      const shapeView = this.paper.findViewByModel(element);
-      this.isDragging = false;
-      this.isSelecting = false;
-      this.isIntoTheSelection = false;
-      this.dragStart = { x, y };
-      // Verify if is in the selection box
-      if (this.isPointInSelection(event)) {
-        this.isIntoTheSelection = true;
-      } else {
-        if (!event.shiftKey) {
-          await this.$refs.selector.selectElement(shapeView);
-          await this.$nextTick();
-        }
-      }
-      this.$refs.selector.startDrag({
-        clientX: event.clientX,
-        clientY: event.clientY,
-      });
-    },
-    pointerDownHandler(event) {
-      const { clientX: x, clientY: y } = event;
-      this.isDragging = false;
-      this.isSelecting = false;
-      this.isIntoTheSelection = false;
-      this.dragStart = { x, y };
-      // Verify if is in the selection box
-      if (this.isPointInSelection(event)) {
-        this.isIntoTheSelection = true;
-        this.$refs.selector.startDrag({
-          clientX: event.clientX,
-          clientY: event.clientY,
-        });
-      } else {
-        this.isSelecting = true;
-        this.$refs.selector.startSelection(event);
-      }
-    },
-    pointerMoveHandler(event) {
-      const { clientX: x, clientY: y } = event;
-      if (this.isGrabbing) return;
-      if (this.dragStart && (Math.abs(x - this.dragStart.x) > 5 || Math.abs(y - this.dragStart.y) > 5)) {
-        this.isDragging = true;
-        this.dragStart = null;
-      } else {
-        if (this.isSelecting) {
-          this.$refs.selector.updateSelection(event);
-        } else {
-          if (this.isDragging) {
-            this.$refs.selector.drag(event);
-          }
-        }
-      }
-    },
-    pointerUpHandler(event, cellView) {
-      if (!this.isDragging && this.dragStart) {
-        // is clicked over the shape
-        if (cellView) {
-          this.$refs.selector.selectElement(cellView, event.shiftKey);
-        } else {
-          this.clearSelection();
-        }
-      } else {
-        if (this.isSelecting) {
-          this.$refs.selector.endSelection(this.paperManager.paper);
-        } else {
-          this.$refs.selector.stopDrag(event);
-        }
-      }
-      window.ProcessMaker.EventBus.$emit('custom-pointerclick', event);
-      this.isDragging = false;
-      this.dragStart = null;
-      this.isSelecting = false;
-    },
   },
   created() {
     if (runningInCypressTest()) {
@@ -1235,12 +971,14 @@ export default {
     });
 
     this.registerNode(Process);
+    // this.registerPmBlock(Process);
     /* Initialize the BpmnModdle and its extensions */
     window.ProcessMaker.EventBus.$emit('modeler-init', {
       registerInspectorExtension,
       registerBpmnExtension: this.registerBpmnExtension,
       registerNode: this.registerNode,
       registerStatusBar: this.registerStatusBar,
+      registerPmBlock: this.registerPmBlock,
     });
 
     this.moddle = new BpmnModdle(this.extensions);
@@ -1249,12 +987,13 @@ export default {
     this.$emit('set-xml-manager', this.xmlManager);
   },
   mounted() {
+    document.addEventListener('keydown', this.keydownListener);
+
     this.graph = new dia.Graph();
     store.commit('setGraph', this.graph);
     this.graph.set('interactiveFunc', cellView => {
-      const isPoolEdge = cellView.model.get('type') === 'standard.EmbeddedImage';
       return {
-        elementMove: isPoolEdge,
+        elementMove: cellView.model.get('elementMove'),
         labelMove: false,
       };
     });
@@ -1269,48 +1008,31 @@ export default {
 
     store.commit('setPaper', this.paperManager.paper);
 
+    this.paperManager.addEventHandler('blank:pointerclick', () => {
+      store.commit('highlightNode', this.processNode);
+    }, this);
+
     this.paperManager.addEventHandler('element:pointerclick', this.blurFocusedScreenBuilderElement, this);
 
     this.paperManager.addEventHandler('blank:pointerdown', (event, x, y) => {
-      if (this.isGrabbing) return;
       const scale = this.paperManager.scale;
       this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };
-      this.isOverShape = false;
-      this.pointerDownHandler(event);
+      this.isGrabbing = true;
     }, this);
-
-    this.paperManager.addEventHandler('cell:mouseover element:mouseover', ({ model: shape }) => {
-      if (this.isBpmnNode(shape) && shape.attr('body/cursor') !== 'default' && !this.isGrabbing) {
-        shape.attr('body/cursor', 'move');
-      }
-      // If the user is panning the Paper while hovering an element, ignore the default move cursor
-      if (this.isGrabbing && this.isBpmnNode(shape)) {
-        shape.attr('body/cursor', 'grabbing');
-      }
-    });
-    this.paperManager.addEventHandler('blank:pointerup', (event) => {
+    this.paperManager.addEventHandler('cell:pointerup blank:pointerup', () => {
       this.canvasDragPosition = null;
+      this.isGrabbing = false;
       this.activeNode = null;
-      this.pointerUpHandler(event);
     }, this);
-    this.paperManager.addEventHandler('cell:pointerup', (cellView, event) => {
-      this.canvasDragPosition = null;
-      this.activeNode = null;
-      this.pointerUpHandler(event, cellView);
-    }, this);
-
-    this.$el.addEventListener('mouseenter', () => {
-      store.commit('setClientLeftPaper', false);
-    });
 
     this.$el.addEventListener('mousemove', event => {
-      this.pointerMoveHandler(event);
-    });
-
-    this.$el.addEventListener('mouseleave', () => {
-      this.paperManager.removeEventHandler('blank:pointermove');
-      store.commit('setClientLeftPaper', true);
-    });
+      if (this.canvasDragPosition) {
+        this.paperManager.translate(
+          event.offsetX - this.canvasDragPosition.x,
+          event.offsetY - this.canvasDragPosition.y,
+        );
+      }
+    }, this);
 
     this.paperManager.addEventHandler('cell:pointerclick', (cellView, evt, x, y) => {
       const clickHandler = cellView.model.get('onClick');
@@ -1324,46 +1046,31 @@ export default {
         return;
       }
 
-      // ignore click event if the user is Grabbing the paper
-      if (this.isGrabbing) return;
-
       shape.component.$emit('click', event);
     });
 
-    this.paperManager.addEventHandler('cell:pointerdown', ({ model: shape }, event) => {
+    this.paperManager.addEventHandler('cell:pointerdown', ({ model: shape }) => {
       if (!this.isBpmnNode(shape)) {
         return;
       }
-      // If the user is pressing Space (grabbing) and clicking on a Cell, return
-      if (this.isGrabbing) {
-        return;
-      }
+
       this.setShapeStacking(shape);
       this.activeNode = shape.component.node;
-      this.isOverShape = true;
-      this.pointerDowInShape(event, shape);
     });
-    // If the user is grabbing the paper while he clicked in a cell, move the paper and not the cell
-    this.paperManager.addEventHandler('cell:pointermove', (_, event, x, y) => {
-      if (this.isGrabbing) {
-        if (!this.canvasDragPosition) {
-          const scale = this.paperManager.scale;
-          this.canvasDragPosition = { x: x * scale.sx, y: y * scale.sy };
-        }
-        if (this.canvasDragPosition && !this.clientLeftPaper) {
-          this.paperManager.translate(
-            event.offsetX - this.canvasDragPosition.x,
-            event.offsetY - this.canvasDragPosition.y
-          );
-        }
-      }
-    });
+
+    let cursor;
+    const setCursor = () => {
+      cursor = this.cursor;
+      this.cursor = 'crosshair';
+    };
+    const resetCursor = () => this.cursor = cursor;
+    setUpSelectionBox(setCursor, resetCursor, this.paperManager, this.graph);
 
     /* Register custom nodes */
     window.ProcessMaker.EventBus.$emit('modeler-start', {
-      loadXML: async(xml) => {
-        await this.loadXML(xml);
-        await undoRedoStore.dispatch('pushState', xml);
+      loadXML: xml => {
+        this.loadXML(xml);
+        undoRedoStore.dispatch('pushState', xml);
       },
       addWarnings: warnings => this.$emit('warnings', warnings),
       addBreadcrumbs: breadcrumbs => this.breadcrumbData.push(breadcrumbs),

--- a/src/components/rails/explorer-rail/explorer.vue
+++ b/src/components/rails/explorer-rail/explorer.vue
@@ -4,6 +4,7 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons';
 import nodeTypesStore from '@/nodeTypesStore';
 import FilterNodeTypes from '@/components/rails/explorer-rail/filterNodeTypes/filterNodeTypes.vue';
 import NodeTypesLoop from '@/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue';
+import PmBlocksLoop from '@/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue';
 
 export default {
   name: 'ExplorerRail',
@@ -14,11 +15,15 @@ export default {
     nodeTypes: {
       type: Array,
     },
+    pmBlockNodes: {
+      type: Array,
+    },
   },
   components: {
     FontAwesomeIcon,
     FilterNodeTypes,
     NodeTypesLoop,
+    PmBlocksLoop,
   },
   data() {
     return {
@@ -39,6 +44,7 @@ export default {
   },
   created() {
     nodeTypesStore.commit('setNodeTypes', this.nodeTypes);
+    nodeTypesStore.commit('setPmBlockNodeTypes', this.pmBlockNodes);
   },
   methods: {
     faTimes() {
@@ -59,6 +65,7 @@ export default {
     },
     clearFilteredObjects() {
       nodeTypesStore.commit('clearFilteredNodes');
+      nodeTypesStore.commit('clearFilteredPmBlockNodes');
     },
   },
 };
@@ -84,7 +91,10 @@ export default {
         v-on="$listeners"
       />
     </div>
-    <div class="pm-blocks__container">
+    <div class="pm-blocks__container"  v-if="tabIndex === 1">
+      <pm-blocks-loop
+        v-on="$listeners"
+      />
       <!--   Here goes the PM Blocks   -->
     </div>
   </div>

--- a/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
+++ b/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
@@ -113,54 +113,43 @@ export default {
     </div> -->
     <template>
       <!-- <template v-if="filteredPmBlockNodes.length === 0 && !searchTerm"> -->
-      <div class="pmBlocksContainer">
+      <div class="pmBlocksContainer p-2">
         <template v-for="nodeType in pmBlockNodeTypes">
           <div
-            class="pm-block-node-types__item"
+            class="pm-block-node-types__item p-2 d-block"
             :key="nodeType.id"
             @click.stop="onClickHandler($event, nodeType)"
           >
-            <img class="pm-block-node-types__item__icon" :src="nodeType.icon" :alt="$t(nodeType.label)">
-            <span>{{ $t(nodeType.label) }}</span>
+            <label>{{ $t(nodeType.label) }}</label>
+            <span class="d-block">{{ nodeType.description }}</span>
           </div>
         </template>
       </div>
+      <!-- </template> -->
     </template>
   </div>
 </template>
 
 <style lang="scss">
-#pmBlockNodeTypesList {
-  .pinnedObjects {
-    margin-bottom: 1rem;
-  }
-}
-.node-types {
+.pm-block-node-types {
   &__item {
-    display: flex;
-    padding: 0.5rem 0.3rem;
-    align-items: center;
+    display: block;
     border-radius: 4px;
     user-select: none;
+    margin-bottom: 8px;
+    border: 1px solid #b6bfc6;
     &:hover {
       background-color: #EBEEF2;
-      .pinIcon {
-        background-color: #DADDDF;
-      }
     }
-    &__icon {
-      width: 1.5rem;
-      height: 1.5rem;
+    label {
+      font-size: 14px;
+      line-height: 8px;
+      font-weight: 600;
+      color: #104A75;
     }
     span {
-      margin-left: 0.8rem;
-      font-size: 13px;
-      line-height: 19px;
-    }
-    .pinIcon {
-      margin-left: auto;
-      border-radius: 4px;
-      padding: 0.3rem;
+      font-size: 12px;
+      color:#6C757D;
     }
   }
 }

--- a/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
+++ b/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
@@ -113,43 +113,54 @@ export default {
     </div> -->
     <template>
       <!-- <template v-if="filteredPmBlockNodes.length === 0 && !searchTerm"> -->
-      <div class="pmBlocksContainer p-2">
+      <div class="pmBlocksContainer">
         <template v-for="nodeType in pmBlockNodeTypes">
           <div
-            class="pm-block-node-types__item p-2 d-block"
+            class="pm-block-node-types__item"
             :key="nodeType.id"
             @click.stop="onClickHandler($event, nodeType)"
           >
-            <label>{{ $t(nodeType.label) }}</label>
-            <span class="d-block">{{ nodeType.description }}</span>
+            <img class="pm-block-node-types__item__icon" :src="nodeType.icon" :alt="$t(nodeType.label)">
+            <span>{{ $t(nodeType.label) }}</span>
           </div>
         </template>
       </div>
-      <!-- </template> -->
     </template>
   </div>
 </template>
 
 <style lang="scss">
-.pm-block-node-types {
+#pmBlockNodeTypesList {
+  .pinnedObjects {
+    margin-bottom: 1rem;
+  }
+}
+.node-types {
   &__item {
-    display: block;
+    display: flex;
+    padding: 0.5rem 0.3rem;
+    align-items: center;
     border-radius: 4px;
     user-select: none;
-    margin-bottom: 8px;
-    border: 1px solid #b6bfc6;
     &:hover {
       background-color: #EBEEF2;
+      .pinIcon {
+        background-color: #DADDDF;
+      }
     }
-    label {
-      font-size: 14px;
-      line-height: 8px;
-      font-weight: 600;
-      color: #104A75;
+    &__icon {
+      width: 1.5rem;
+      height: 1.5rem;
     }
     span {
-      font-size: 12px;
-      color:#6C757D;
+      margin-left: 0.8rem;
+      font-size: 13px;
+      line-height: 19px;
+    }
+    .pinIcon {
+      margin-left: auto;
+      border-radius: 4px;
+      padding: 0.3rem;
     }
   }
 }

--- a/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
+++ b/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
@@ -1,0 +1,156 @@
+<script>
+import nodeTypesStore from '@/nodeTypesStore';
+
+export default {
+  name: 'PmBlocksLoop',
+  data() {
+    return {
+      wasClicked: false,
+      element: null,
+      selectedItem: null,
+      xOffset: 0,
+      yOffset: 0,
+      movedElement: null,
+      helperStyles: {
+        backgroundColor:'#ffffff',
+        position: 'absolute',
+        height: '40px',
+        width: '40px',
+        zIndex: '10',
+        opacity: '0.5',
+        pointerEvents: 'none',
+      },
+    };
+  },
+  methods: {
+    onClickHandler(event, control) {
+      this.createDraggingHelper(event, control);
+      document.addEventListener('mousemove', this.setDraggingPosition);
+      this.setDraggingPosition(event);
+      // Deselect control on click if same control is already selected
+      if (this.selectedItem === control.type) {
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        document.body.removeChild(this.movedElement);
+        this.$emit('onSetCursor', 'none');
+        this.selectedItem = null;
+        this.movedElement = null;
+        this.wasClicked = false;
+        return;
+      }
+      this.wasClicked = true;
+      this.element = control;
+      this.$emit('onSetCursor', 'crosshair');
+      this.selectedItem = control.type;
+      window.ProcessMaker.EventBus.$on('custom-pointerclick', message => {
+        window.ProcessMaker.EventBus.$off('custom-pointerclick');
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        if (this.movedElement) {
+          document.body.removeChild(this.movedElement);
+        }
+        this.selectedItem = null;
+        this.movedElement = null;
+        this.onCreateElement(message);
+      });
+    },
+    createDraggingHelper(event, control) {
+      if (this.movedElement) {
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        document.body.removeChild(this.movedElement);
+        this.movedElement = null;
+      }
+      const sourceElement = event.target;
+      this.movedElement = document.createElement('img');
+      Object.keys(this.helperStyles).forEach((property) => {
+        this.movedElement.style[property] = this.helperStyles[property];
+      });
+      this.movedElement.src = control.icon;
+      document.body.appendChild(this.movedElement);
+      this.xOffset = event.clientX - sourceElement.getBoundingClientRect().left;
+      this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
+    },
+    setDraggingPosition({ pageX, pageY }) {
+      this.movedElement.style.left = pageX  + 'px';
+      this.movedElement.style.top = pageY + 'px';
+    },
+    onCreateElement(event){
+      if (this.wasClicked && this.element) {
+        this.$emit('onCreateElement', { event, control: this.element });
+        this.$emit('onSetCursor', 'none');
+        event.preventDefault();
+        this.wasClicked = false;
+      }
+    },
+  },
+  computed: {
+    pmBlockNodeTypes() {
+      return nodeTypesStore.getters.getPmBlockNodeTypes;
+    },
+    filteredPmBlockNodes() {
+      return nodeTypesStore.getters.getFilteredPmBlockNodeTypes;
+    },
+    searchTerm() {
+      return nodeTypesStore.getters.getSearchTerm;
+    },
+  },
+};
+</script>
+
+<template>
+  <div id="pmBlockNodeTypesList">
+    <!-- <div id="filteredPmBlockNodes-container" v-if="filteredPmBlockNodes.length > 0">
+      <template v-for="object in filteredPmBlockNodes">
+        <div
+          class="node-types__item"
+          :key="object.id"
+          @mouseover="showPin = true"
+          @mouseleave="showPin = false"
+          @click.stop="onClickHandler($event, object)"
+        >
+          <img class="node-types__item__icon" :src="object.icon" :alt="$t(object.label)">
+          <span>{{ $t(object.label) }}</span>
+        </div>
+      </template>
+    </div> -->
+    <template>
+      <!-- <template v-if="filteredPmBlockNodes.length === 0 && !searchTerm"> -->
+      <div class="pmBlocksContainer p-2">
+        <template v-for="nodeType in pmBlockNodeTypes">
+          <div
+            class="pm-block-node-types__item p-2 d-block"
+            :key="nodeType.id"
+            @click.stop="onClickHandler($event, nodeType)"
+          >
+            <label>{{ $t(nodeType.label) }}</label>
+            <span class="d-block">{{ nodeType.description }}</span>
+          </div>
+        </template>
+      </div>
+      <!-- </template> -->
+    </template>
+  </div>
+</template>
+
+<style lang="scss">
+.pm-block-node-types {
+  &__item {
+    display: block;
+    border-radius: 4px;
+    user-select: none;
+    margin-bottom: 8px;
+    border: 1px solid #b6bfc6;
+    &:hover {
+      background-color: #EBEEF2;
+    }
+    label {
+      font-size: 14px;
+      line-height: 8px;
+      font-weight: 600;
+      color: #104A75;
+    }
+    span {
+      font-size: 12px;
+      color:#6C757D;
+    }
+  }
+}
+</style>

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -154,13 +154,18 @@ export default {
       spinner: faSpinner,
       ellipsisMenuActions: [
         {
-          value: 'discard-draft',
-          content: this.$t('Discard Draft'),
+          value: 'save-template',
+          content: this.$t('Save as Template'),
           icon: '',
         },
         {
-          value: 'save-template',
-          content: this.$t('Save as Template'),
+          value: 'save-pm-block',
+          content: this.$t('Save as PM Block'),
+          icon: '',
+        },
+        {
+          value: 'discard-draft',
+          content: this.$t('Discard Draft'),
           icon: '',
         },
       ],
@@ -192,6 +197,9 @@ export default {
           break;
         case 'save-template':
           this.$emit('publishTemplate');
+          break;
+        case 'save-pm-block':
+          this.$emit('publishPmBlock');
           break;
         default:
           break;

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -10,6 +10,7 @@ export default new Vuex.Store({
     nodeTypes: [],
     pinnedNodeTypes: [],
     filteredNodeTypes: [],
+    pmBlockNodeTypes: [],
     explorerOpen: false,
     searchTerm: '',
   },
@@ -19,6 +20,8 @@ export default new Vuex.Store({
     getFilteredNodeTypes: state => state.filteredNodeTypes,
     getExplorerOpen: state => state.explorerOpen,
     getSearchTerm: state => state.searchTerm,
+    getPmBlockNodeTypes: state => state.pmBlockNodeTypes,
+    getFilteredPmBlockNodeTypes: state => state.filteredPmBlockNodeTypes,
   },
   mutations: {
     setNodeTypes(state, nodeTypes) {
@@ -51,9 +54,40 @@ export default new Vuex.Store({
         return node.label.toLowerCase().includes(searchTerm.toLowerCase());
       });
     },
+    setPmBlockNodeTypes(state, pmBlockNodeTypes) {
+      state.pmBlockNodeTypes = pmBlockNodeTypes
+        .filter(pmBlockNode => pmBlockNode.control)
+        .map(pmBlockNode => ({
+          id: uniqueId('pmBlockNode_'),
+          type: pmBlockNode.id,
+          icon: pmBlockNode.icon,
+          label: pmBlockNode.label,
+          description: pmBlockNode.description,
+          bpmnType: pmBlockNode.bpmnType,
+          rank: pmBlockNode.rank || BOTTOM,
+          items: pmBlockNode.items?.map(item => ({ ...item, type: item.id })),
+        }))
+        .sort((node1, node2) => node1.rank - node2.rank);
+    },
+    setFilteredPmBlockNodeTypes(state, searchTerm) {
+      // TODO: Configure Pm Block search bar
+      console.log('FILTER PM BLOCK NODE TYPES', state, searchTerm);
+      // const nodeTypes = state.nodeTypes;
+      // state.searchTerm = searchTerm;
+      // const allNodes = uniqBy([...pinnedNodeTypes, ...nodeTypes], 'id');
+      // state.filteredNodeTypes = allNodes.filter(node => {
+      //   return node.label.toLowerCase().includes(searchTerm.toLowerCase());
+      // });
+    },
     clearFilteredNodes(state) {
       state.filteredNodeTypes = [];
       state.searchTerm = '';
+    },
+    clearFilteredPmBlockNodes(state) {
+      // TODO: Clear Pm Block search bar
+      console.log('CLEAR FILTER PM BLOCK NODE', state);
+      // state.filteredNodeTypes = [];
+      // state.searchTerm = '';
     },
     closeExplorer(state) {
       state.explorerOpen = false;

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -62,7 +62,6 @@ export default new Vuex.Store({
           type: pmBlockNode.id,
           icon: pmBlockNode.icon,
           label: pmBlockNode.label,
-          description: pmBlockNode.description,
           bpmnType: pmBlockNode.bpmnType,
           rank: pmBlockNode.rank || BOTTOM,
           items: pmBlockNode.items?.map(item => ({ ...item, type: item.id })),

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -62,6 +62,7 @@ export default new Vuex.Store({
           type: pmBlockNode.id,
           icon: pmBlockNode.icon,
           label: pmBlockNode.label,
+          description: pmBlockNode.description,
           bpmnType: pmBlockNode.bpmnType,
           rank: pmBlockNode.rank || BOTTOM,
           items: pmBlockNode.items?.map(item => ({ ...item, type: item.id })),

--- a/tests/unit/rails/explorer.spec.js
+++ b/tests/unit/rails/explorer.spec.js
@@ -10,7 +10,7 @@ const nodeTypes = [
   },
 ];
 
-const pmBlockNodeTypes = [
+const pmBlockNodes = [
   {
     id: 'processmaker-modeler-call-activity',
     bpmnType: 'bpmn:CallActivity',
@@ -28,7 +28,7 @@ describe('Explorer Rail', () => {
     wrapper = shallowMount(explorerRail, {
       propsData: {
         nodeTypes,
-        pmBlockNodeTypes,
+        pmBlockNodes,
       },
       mocks: {
         $t() {},

--- a/tests/unit/rails/explorer.spec.js
+++ b/tests/unit/rails/explorer.spec.js
@@ -10,7 +10,7 @@ const nodeTypes = [
   },
 ];
 
-const pmBlockNodes = [
+const pmBlockNodeTypes = [
   {
     id: 'processmaker-modeler-call-activity',
     bpmnType: 'bpmn:CallActivity',
@@ -28,7 +28,7 @@ describe('Explorer Rail', () => {
     wrapper = shallowMount(explorerRail, {
       propsData: {
         nodeTypes,
-        pmBlockNodes,
+        pmBlockNodeTypes,
       },
       mocks: {
         $t() {},

--- a/tests/unit/rails/explorer.spec.js
+++ b/tests/unit/rails/explorer.spec.js
@@ -28,7 +28,7 @@ describe('Explorer Rail', () => {
     wrapper = shallowMount(explorerRail, {
       propsData: {
         nodeTypes,
-        pmBlockNodeTypes
+        pmBlockNodeTypes,
       },
       mocks: {
         $t() {},

--- a/tests/unit/rails/explorer.spec.js
+++ b/tests/unit/rails/explorer.spec.js
@@ -10,6 +10,14 @@ const nodeTypes = [
   },
 ];
 
+const pmBlockNodes = [
+  {
+    id: 'processmaker-modeler-call-activity',
+    bpmnType: 'bpmn:CallActivity',
+    label: 'Call Activity',
+  },
+];
+
 const localVue = createLocalVue();
 
 localVue.use(BootstrapVue);
@@ -20,6 +28,7 @@ describe('Explorer Rail', () => {
     wrapper = shallowMount(explorerRail, {
       propsData: {
         nodeTypes,
+        pmBlockNodes,
       },
       mocks: {
         $t() {},

--- a/tests/unit/rails/explorer.spec.js
+++ b/tests/unit/rails/explorer.spec.js
@@ -28,7 +28,7 @@ describe('Explorer Rail', () => {
     wrapper = shallowMount(explorerRail, {
       propsData: {
         nodeTypes,
-        pmBlockNodeTypes,
+        pmBlockNodeTypes
       },
       mocks: {
         $t() {},


### PR DESCRIPTION
## Issue & Reproduction Steps

This pull request (PR) is in response to the Epic ticket FOUR-7365 and User Story ticket FOUR-7366. The primary objective is to enhance the modeler by introducing a new tab within the Explorer rail specifically designed to store configured PM Blocks.

The key changes in this PR are as follows:

1. **PM Block Registration:** The ability to register a PM Block from the PM Block packages has been implemented. This feature enables the modeler to differentiate between node objects and node blocks.

2. **Explorer Rail Enhancement:** Populate new 'PM Blocks' tab  in Explorer rail. 
Actual behavior: 



## How to Test
Test the steps above

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
