### PR TITLE
FOUR-8802: ESC hotkey, mixin for click and drop and nodeStore fixes were added

### DIFF
--- a/src/components/hotkeys/escKey.js
+++ b/src/components/hotkeys/escKey.js
@@ -1,0 +1,20 @@
+import nodeTypesStore from '@/nodeTypesStore';
+
+export default {
+  methods: {
+    escapeKeyHandler(event) {
+      if (this.selectedNode) {
+        event.preventDefault();
+        window.ProcessMaker.EventBus.$emit('custom-pointerclick', event);
+      }
+    },
+  },
+  computed: {
+    selectedNode() {
+      return nodeTypesStore.getters.getSelectedNode;
+    },
+    movedElement() {
+      return nodeTypesStore.getters.getGhostNode;
+    },
+  },
+};

--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -1,10 +1,11 @@
 import ZoomInOut from './zoomInOut';
 import CopyPaste from './copyPaste.js';
-import store from '@/store';
 import moveShapeByKeypress from './moveWithArrowKeys';
+import EscKey from './escKey';
+import store from '@/store';
 
 export default {
-  mixins: [ZoomInOut, CopyPaste],
+  mixins: [ZoomInOut, CopyPaste, EscKey],
   computed: {
     clientLeftPaper() {
       return store.getters.clientLeftPaper;
@@ -19,6 +20,7 @@ export default {
       // Pass event to all handlers
       this.zoomInOutHandler(event, options);
       this.copyPasteHandler(event, options);
+      this.escapeKeyHandler(event);
     },
     keyupListener(event) {
       if (event.code === 'Space') {

--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -5,7 +5,7 @@
   >
     <li
       v-for="item in controls"
-      :class="['control-item', {'active': selectedItem === item.type}]"
+      :class="['control-item', {'active': selectedItem && (selectedItem.type === item.type)}]"
       :id="item.id"
       :key="item.id"
       @click.stop="onClickHandler($event, item)"
@@ -35,6 +35,7 @@
 import InlineSvg from 'vue-inline-svg';
 import nodeTypesStore from '@/nodeTypesStore';
 import SubmenuPopper from './SubmenuPopper/SubmenuPopper.vue';
+import clickAndDrop from '@/mixins/clickAndDrop';
 
 export default ({
   components: {
@@ -44,28 +45,14 @@ export default ({
   props: {
     nodeTypes: Array,
   },
+  mixins: [clickAndDrop],
   data() {
     return {
       plusIcon: require('@/assets/railBottom/plus.svg'),
-      wasClicked: false,
-      element: null,
-      selectedItem: null,
-      selectedSubmenuItem: null,
-      xOffset: 0,
-      yOffset: 0,
-      movedElement: null,
-      isDragging: false,
-      helperStyles: {
-        backgroundColor:'#ffffff',
-        position: 'absolute',
-        height: '40px',
-        width: '40px',
-        zIndex: '10',
-        opacity: '0.5',
-        pointerEvents: 'none',
-      },
-      popperType: null,
     };
+  },
+  created() {
+    nodeTypesStore.dispatch('getUserPinnedObjects');
   },
   computed: {
     controls() {
@@ -79,68 +66,13 @@ export default ({
     clickToSubmenuHandler(data){
       window.ProcessMaker.EventBus.$off('custom-pointerclick');
       this.wasClicked = false;
-      this.parent = this.element;
+      this.parent = this.selectedItem;
       this.selectedSubmenuItem = data.control.type;
       this.onClickHandler(data.event, data.control);
-    },
-    onClickHandler(event, control) {
-      this.createDraggingHelper(event, control);
-      document.addEventListener('mousemove', this.setDraggingPosition);
-      this.setDraggingPosition(event);
-      this.wasClicked = true;
-      this.element = control;
-      this.$emit('onSetCursor', 'crosshair');
-      if (!this.parent) {
-        this.selectedItem = control.type;
-        this.popperType = control.type;
-      }
-      window.ProcessMaker.EventBus.$on('custom-pointerclick', message => {
-        window.ProcessMaker.EventBus.$off('custom-pointerclick');
-        document.removeEventListener('mousemove', this.setDraggingPosition);
-        if (this.movedElement) {
-          document.body.removeChild(this.movedElement);
-        }
-        this.popperType = null;
-        this.selectedSubmenuItem = null;
-        this.selectedItem = null;
-        this.movedElement = null;
-        this.onCreateElement(message);
-      });
-    },
-    onCreateElement(event){
-      if (this.wasClicked && this.element) {
-        if (this.parent) {
-          this.parent = null;
-        }
-        this.$emit('onCreateElement', { event, control: this.element });
-        this.$emit('onSetCursor', 'none');
-        event.preventDefault();
-        this.wasClicked = false;
-      }
-    },
-    setDraggingPosition({ pageX, pageY }) {
-      this.movedElement.style.left = `${pageX}px`;
-      this.movedElement.style.top = `${pageY}px`;
     },
     toggleExplorer() {
       nodeTypesStore.commit('toggleExplorer');
       nodeTypesStore.commit('clearFilteredNodes');
-    },
-    createDraggingHelper(event, control) {
-      if (this.movedElement) {
-        document.removeEventListener('mousemove', this.setDraggingPosition);
-        document.body.removeChild(this.movedElement);
-        this.movedElement = null;
-      }
-      const sourceElement = event.target;
-      this.movedElement = document.createElement('img');
-      Object.keys(this.helperStyles).forEach((property) => {
-        this.movedElement.style[property] = this.helperStyles[property];
-      });
-      this.movedElement.src = control.icon;
-      document.body.appendChild(this.movedElement);
-      this.xOffset = event.clientX - sourceElement.getBoundingClientRect().left;
-      this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
     },
   },
 });

--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -2,29 +2,16 @@
 import pinIcon from '@/assets/pin-angle.svg';
 import pinFillIcon from '@/assets/pin-angle-fill.svg';
 import nodeTypesStore from '@/nodeTypesStore';
+import clickAndDrop from '@/mixins/clickAndDrop';
 
 export default {
   name: 'NodeTypesLoop',
+  mixins: [clickAndDrop],
   data() {
     return {
       pinIcon,
       pinFillIcon,
       showPin: false,
-      wasClicked: false,
-      element: null,
-      selectedItem: null,
-      xOffset: 0,
-      yOffset: 0,
-      movedElement: null,
-      helperStyles: {
-        backgroundColor:'#ffffff',
-        position: 'absolute',
-        height: '40px',
-        width: '40px',
-        zIndex: '10',
-        opacity: '0.5',
-        pointerEvents: 'none',
-      },
     };
   },
   created() {
@@ -39,63 +26,6 @@ export default {
     },
     addPin(object) {
       return nodeTypesStore.dispatch('addUserPinnedObject', object);
-    },
-    onClickHandler(event, control) {
-      this.createDraggingHelper(event, control);
-      document.addEventListener('mousemove', this.setDraggingPosition);
-      this.setDraggingPosition(event);
-      // Deselect control on click if same control is already selected
-      if (this.selectedItem === control.type) {
-        document.removeEventListener('mousemove', this.setDraggingPosition);
-        document.body.removeChild(this.movedElement);
-        this.$emit('onSetCursor', 'none');
-        this.selectedItem = null;
-        this.movedElement = null;
-        this.wasClicked = false;
-        return;
-      }
-      this.wasClicked = true;
-      this.element = control;
-      this.$emit('onSetCursor', 'crosshair');
-      this.selectedItem = control.type;
-      window.ProcessMaker.EventBus.$on('custom-pointerclick', message => {
-        window.ProcessMaker.EventBus.$off('custom-pointerclick');
-        document.removeEventListener('mousemove', this.setDraggingPosition);
-        if (this.movedElement) {
-          document.body.removeChild(this.movedElement);
-        }
-        this.selectedItem = null;
-        this.movedElement = null;
-        this.onCreateElement(message);
-      });
-    },
-    createDraggingHelper(event, control) {
-      if (this.movedElement) {
-        document.removeEventListener('mousemove', this.setDraggingPosition);
-        document.body.removeChild(this.movedElement);
-        this.movedElement = null;
-      }
-      const sourceElement = event.target;
-      this.movedElement = document.createElement('img');
-      Object.keys(this.helperStyles).forEach((property) => {
-        this.movedElement.style[property] = this.helperStyles[property];
-      });
-      this.movedElement.src = control.icon;
-      document.body.appendChild(this.movedElement);
-      this.xOffset = event.clientX - sourceElement.getBoundingClientRect().left;
-      this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
-    },
-    setDraggingPosition({ pageX, pageY }) {
-      this.movedElement.style.left = pageX  + 'px';
-      this.movedElement.style.top = pageY + 'px';
-    },
-    onCreateElement(event){
-      if (this.wasClicked && this.element) {
-        this.$emit('onCreateElement', { event, control: this.element });
-        this.$emit('onSetCursor', 'none');
-        event.preventDefault();
-        this.wasClicked = false;
-      }
     },
   },
   computed: {

--- a/src/mixins/clickAndDrop.js
+++ b/src/mixins/clickAndDrop.js
@@ -1,0 +1,100 @@
+import nodeTypesStore from '@/nodeTypesStore';
+
+export default {
+  data() {
+    return {
+      wasClicked: false,
+      selectedSubmenuItem: null,
+      xOffset: 0,
+      yOffset: 0,
+      helperStyles: {
+        backgroundColor:'#ffffff',
+        position: 'absolute',
+        height: '40px',
+        width: '40px',
+        zIndex: '10',
+        opacity: '0.5',
+        pointerEvents: 'none',
+      },
+      popperType: null,
+    };
+  },
+  methods: {
+    onClickHandler(event, control) {
+      this.createDraggingHelper(event, control);
+      document.addEventListener('mousemove', this.setDraggingPosition);
+      this.setDraggingPosition(event);
+      // Deselect control on click if same control is already selected
+      if (this.selectedItem && (this.selectedItem.type === control.type)) {
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        document.body.removeChild(this.movedElement);
+        this.$emit('onSetCursor', 'none');
+        nodeTypesStore.commit('clearSelectedNode');
+        nodeTypesStore.commit('setGhostNode', null);
+        this.wasClicked = false;
+        return;
+      }
+      this.wasClicked = true;
+      nodeTypesStore.commit('setSelectedNode', control);
+      this.$emit('onSetCursor', 'crosshair');
+      if (!this.parent) {
+        this.popperType = control.type;
+      }
+      window.ProcessMaker.EventBus.$on('custom-pointerclick', message => {
+        window.ProcessMaker.EventBus.$off('custom-pointerclick');
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        if (this.movedElement) {
+          document.body.removeChild(this.movedElement);
+        }
+        this.popperType = null;
+        this.selectedSubmenuItem = null;
+        this.onCreateElement(message);
+        nodeTypesStore.commit('clearSelectedNode');
+        nodeTypesStore.commit('setGhostNode', null);
+      });
+    },
+    onCreateElement(event){
+      if (this.wasClicked && this.selectedItem) {
+        if (this.parent) {
+          this.parent = null;
+        }
+        this.$emit('onCreateElement', { event, control: this.selectedItem });
+        this.$emit('onSetCursor', 'none');
+        event.preventDefault();
+        this.wasClicked = false;
+      }
+    },
+    setDraggingPosition({ pageX, pageY }) {
+      let tempGhost = this.movedElement;
+      tempGhost.style.left = `${pageX}px`;
+      tempGhost.style.top = `${pageY}px`;
+      nodeTypesStore.commit('setGhostNode', tempGhost);
+    },
+    createDraggingHelper(event, control) {
+      if (this.movedElement) {
+        document.removeEventListener('mousemove', this.setDraggingPosition);
+        document.body.removeChild(this.movedElement);
+        nodeTypesStore.commit('setGhostNode', null);
+      }
+      const sourceElement = event.target;
+      nodeTypesStore.commit('setGhostNode', document.createElement('img'));
+      let tempGhost = this.movedElement;
+      Object.keys(this.helperStyles).forEach((property) => {
+        tempGhost.style[property] = this.helperStyles[property];
+      });
+      tempGhost.src = control.icon;
+      nodeTypesStore.commit('setGhostNode', tempGhost);
+      document.body.appendChild(this.movedElement);
+      this.xOffset = event.clientX - sourceElement.getBoundingClientRect().left;
+      this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
+    },
+  },
+  computed: {
+    selectedItem() {
+      return nodeTypesStore.getters.getSelectedNode;
+    },
+    movedElement() {
+      return nodeTypesStore.getters.getGhostNode;
+    },
+  },
+};

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -12,6 +12,8 @@ export default new Vuex.Store({
     filteredNodeTypes: [],
     explorerOpen: false,
     searchTerm: '',
+    selectedNode: null,
+    ghostNode: null,
   },
   getters: {
     getNodeTypes: state => state.nodeTypes,
@@ -19,6 +21,8 @@ export default new Vuex.Store({
     getFilteredNodeTypes: state => state.filteredNodeTypes,
     getExplorerOpen: state => state.explorerOpen,
     getSearchTerm: state => state.searchTerm,
+    getSelectedNode: state => state.selectedNode,
+    getGhostNode: state => state.ghostNode,
   },
   mutations: {
     setNodeTypes(state, nodeTypes) {
@@ -37,6 +41,8 @@ export default new Vuex.Store({
     },
     setPinnedNodes(state, payload) {
       state.pinnedNodeTypes.push(payload);
+      // Remove duplicates
+      state.pinnedNodeTypes = [...new Map(state.pinnedNodeTypes.map(node => [node['type'], node])).values()];
       state.pinnedNodeTypes.sort((node1, node2) => node1.rank - node2.rank);
     },
     setUnpinNode(state, payload) {
@@ -60,6 +66,15 @@ export default new Vuex.Store({
     },
     toggleExplorer(state) {
       state.explorerOpen = !state.explorerOpen;
+    },
+    setSelectedNode(state, payload) {
+      state.selectedNode = payload;
+    },
+    clearSelectedNode(state) {
+      state.selectedNode = null;
+    },
+    setGhostNode(state, payload) {
+      state.ghostNode = payload;
     },
   },
   actions: {


### PR DESCRIPTION
## Issues: 
### [FOUR-8839](https://processmaker.atlassian.net/browse/FOUR-8839)
Steps to Reproduce

1. Open modeler
2. select control of Explorer rail
3. Select control of the bottom rail
4. Drop on the canvas

#### Expected Behavior:
After pin or unpin another control in Explores the first control should be cleared, and the mouse should return to normal.
#### Actual Behavior:
Mouse selection is not deselected after click to pin or unpin another control in Explorer rail 

### [FOUR-8825](https://processmaker.atlassian.net/browse/FOUR-8825)
Steps to Reproduce
1. Open modeler
2. select control of Explorer rail
3. Select control of the bottom rail
4. Drop on the canvas

#### Expected Behavior:
It should not be possible to add more than one control at once
#### Actual Behavior:
It is possible to add more than one control at once 

### [FOUR-8710](https://processmaker.atlassian.net/browse/FOUR-8710)
Steps to Reproduce
1. Go to modeler
2. Open Explorer rail
3. Click on some element
4. Press ESC key

#### Actual Behavior:
The selected element is not deselected with the ESC key
#### Expected Behavior:
The selected element should be deselected with the ESC key


## Solution
- Implemented a mixin for clickAndDrop
- Added selectedNode and ghostNode variables to the nodeTypesStore
- Added escKey mixin to handle ESC hotkey

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8802
- https://processmaker.atlassian.net/browse/FOUR-8832
- https://processmaker.atlassian.net/browse/FOUR-8833
- https://processmaker.atlassian.net/browse/FOUR-8834
- https://processmaker.atlassian.net/browse/FOUR-8839
- https://processmaker.atlassian.net/browse/FOUR-8825
- https://processmaker.atlassian.net/browse/FOUR-8710

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8839]: https://processmaker.atlassian.net/browse/FOUR-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8825]: https://processmaker.atlassian.net/browse/FOUR-8825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8710]: https://processmaker.atlassian.net/browse/FOUR-8710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy

.