### PR TITLE
FOUR-8858-B refactor auto validate e2e tests

### DIFF
--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -85,11 +85,6 @@ export default {
       this.isOpenPanel = value;
     },
   },
-  mounted() {
-    if (window.Cypress) {
-      window.TopRail = this;
-    }
-  },
 };
 </script>
 

--- a/tests/e2e/specs/autoValidate/AutoValidate.spec.js
+++ b/tests/e2e/specs/autoValidate/AutoValidate.spec.js
@@ -30,17 +30,20 @@ describe('Auto Validate test', { scrollBehavior: false }, () => {
   });
 
   it('should render new validate issue button', () => {
-    cy.get(validateButtonSelector).click()
+    cy.get(validateButtonSelector)
+      .click()
       .then(() => {
         cy.get(validateButtonSelector).should('have.css', 'background-color', buttonBgColorActive);
 
-        cy.get(validateButtonIssueSelector).should('be.visible');
-        cy.get(validatePanelSelector).should('not.be.visible');
+        cy.get(validateButtonIssueSelector)
+          .should('be.visible')
+          .then($btn => {
+            const issueBadge = $btn.children('.issue-badge');
+            expect(issueBadge).to.have.text(defaultNumberOfErrors);
 
-        cy.window().then(win => {
-          // Checks default number of errors when clicks on validate button
-          expect(win.TopRail.numberOfErrors).to.equal(defaultNumberOfErrors);
-        });
+          });
+
+        cy.get(validatePanelSelector).should('not.be.visible');
       });
   });
 
@@ -51,14 +54,13 @@ describe('Auto Validate test', { scrollBehavior: false }, () => {
         cy.get(validatePanelSelector).should('not.be.visible');
       });
 
-    cy.get(validateButtonIssueSelector).click()
-      .then(() => {
-        cy.window().then(win => {
-          // Checks default number of errors when clicks on validate button
-          expect(win.TopRail.numberOfErrors).to.equal(defaultNumberOfErrors);
-        });
+    cy.get(validateButtonIssueSelector).click();
+    cy.get(validateButtonIssueSelector)
+      .should('be.visible')
+      .then($btn => {
+        const issueBadge = $btn.children('.issue-badge');
+        expect(issueBadge).to.have.text(defaultNumberOfErrors);
 
-        // Checks default message errors when clicks on validate issue button
         cy.get(validatePanelSelector)
           .should('be.visible')
           .then(($panel => {
@@ -74,14 +76,13 @@ describe('Auto Validate test', { scrollBehavior: false }, () => {
         cy.get(validatePanelSelector).should('not.be.visible');
       });
 
-    cy.get(validateButtonIssueSelector).click()
-      .then(() => {
-        cy.window().then(win => {
-          // Checks default number of errors when clicks on validate button
-          expect(win.TopRail.numberOfErrors).to.equal(defaultNumberOfErrors);
-        });
+    cy.get(validateButtonIssueSelector).click();
+    cy.get(validateButtonIssueSelector)
+      .should('be.visible')
+      .then($btn => {
+        const issueBadge = $btn.children('.issue-badge');
+        expect(issueBadge).to.have.text(defaultNumberOfErrors);
 
-        // Checks default message errors when clicks on validate issue button
         cy.get(validatePanelSelector)
           .should('be.visible')
           .then(($panel => {
@@ -94,10 +95,11 @@ describe('Auto Validate test', { scrollBehavior: false }, () => {
     dragFromSourceToDest(nodeTypes.task, taskPosition);
     const currentNumberOfErrorsWithTask = defaultNumberOfErrors + 1;
 
-    cy.window().then(win => {
-      // Checks default number of errors when clicks on validate button
-      expect(win.TopRail.numberOfErrors).to.equal(currentNumberOfErrorsWithTask);
-    });
+    cy.get(validateButtonIssueSelector)
+      .then($btn => {
+        const issueBadge = $btn.children('.issue-badge');
+        expect(issueBadge).to.have.text(currentNumberOfErrorsWithTask);
+      });
 
     cy.get(validatePanelSelector)
       .should('be.visible')
@@ -110,10 +112,11 @@ describe('Auto Validate test', { scrollBehavior: false }, () => {
     dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition, nodeTypes.inclusiveGateway);
     const currentNumberOfErrorsWithGateway = defaultNumberOfErrors + 3;
 
-    cy.window().then(win => {
-      // Checks default number of errors when clicks on validate button
-      expect(win.TopRail.numberOfErrors).to.equal(currentNumberOfErrorsWithGateway);
-    });
+    cy.get(validateButtonIssueSelector)
+      .then($btn => {
+        const issueBadge = $btn.children('.issue-badge');
+        expect(issueBadge).to.have.text(currentNumberOfErrorsWithGateway);
+      });
 
     cy.get(validatePanelSelector)
       .should('be.visible')


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Add some essential e2e tests for the auto validate on the top rail

Actual behavior: 

## Solution
Refactor the e2e tests written for the auto validate on the top rail

## How to Test
1. Run the npm run open-cypress command in the root of the project
2. Click on the autoValidate/AutoValidate.spec.js test

## Related Tickets & Packages
#1582
[FOUR-8858](https://processmaker.atlassian.net/browse/FOUR-8858)

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8858]: https://processmaker.atlassian.net/browse/FOUR-8858?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ