### PR TITLE
FOUR-8958: E2E Tests for Explorer and Click and Drop

### DIFF
--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -6,6 +6,7 @@
     <li
       v-for="item in controls"
       :class="['control-item', {'active': selectedItem && (selectedItem.type === item.type)}]"
+      :data-test="item.type"
       :id="item.id"
       :key="item.id"
       @click.stop="onClickHandler($event, item)"

--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -55,6 +55,7 @@ export default {
       <template v-for="object in filteredNodes">
         <div
           class="node-types__item"
+          :data-test="object.type"
           :key="object.id"
           @mouseover="showPin = true"
           @mouseleave="showPin = false"
@@ -85,6 +86,7 @@ export default {
         <template v-for="pinnedObject in pinnedObjects">
           <div
             class="node-types__item"
+            :data-test="pinnedObject.type"
             :key="pinnedObject.id"
             @mouseover="showPin = true"
             @mouseleave="showPin = false"
@@ -106,6 +108,7 @@ export default {
         <template v-for="nodeType in unpinnedObjects">
           <div
             class="node-types__item"
+            :data-test="nodeType.type"
             :key="nodeType.id"
             @mouseover="showPin = true"
             @mouseleave="showPin = false"

--- a/tests/e2e/specs/AssociationFlows.spec.js
+++ b/tests/e2e/specs/AssociationFlows.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   getLinksConnectedToElement,
   modalConfirm, waitToRenderAllShapes, waitForAnimations,
@@ -14,10 +14,10 @@ describe('Association Flows', () => {
   it('Change direction of association to none, one and both', () => {
     const directionSelectSelector = '[name=associationDirection]';
     const textAnnotationPosition = { x: 400, y: 100 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
 
     const taskPosition = { x: 400, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('association-flow-button', textAnnotationPosition, taskPosition);
 
@@ -39,7 +39,7 @@ describe('Association Flows', () => {
   it('should keep association flow when changing element type', () => {
     const startEventPosition = { x: 150, y: 150 };
     const textAnnotationPosition = { x: 400, y: 100 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
     waitToRenderAllShapes();
 
     connectNodesWithFlow('association-flow-button', textAnnotationPosition, startEventPosition);

--- a/tests/e2e/specs/BoundaryConditionalEvent.spec.js
+++ b/tests/e2e/specs/BoundaryConditionalEvent.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   setBoundaryEvent,
   waitToRenderAllShapes,
@@ -13,7 +13,7 @@ describe('Boundary Conditional Event', () => {
   const boundaryConditionalEventPosition = { x: 260, y: 200 };
 
   beforeEach(() => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryConditionalEvent, taskPosition);
   });
 

--- a/tests/e2e/specs/BoundaryEscalationEvent.spec.js
+++ b/tests/e2e/specs/BoundaryEscalationEvent.spec.js
@@ -1,4 +1,4 @@
-import { dragFromSourceToDest, getElementAtPosition, getGraphElements, waitToRenderAllShapes } from '../support/utils';
+import { clickAndDropElement, getElementAtPosition, getGraphElements, waitToRenderAllShapes } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 import { CommonBoundaryEventBehaviour } from '../support/BoundaryEventCommonBehaviour';
 import { defaultNodeColor } from '../../../src/components/nodeColors';
@@ -7,10 +7,10 @@ describe.skip('Boundary Escalation Event', () => {
 
   it('can toggle interrupting on Boundary Escalation Events', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.subProcess, taskPosition);
+    clickAndDropElement(nodeTypes.subProcess, taskPosition);
 
     const boundaryEscalationEventPosition = { x: 260, y: 260 };
-    dragFromSourceToDest(nodeTypes.boundaryEscalationEvent, boundaryEscalationEventPosition);
+    clickAndDropElement(nodeTypes.boundaryEscalationEvent, boundaryEscalationEventPosition);
 
     getElementAtPosition(boundaryEscalationEventPosition).click();
 
@@ -41,14 +41,14 @@ describe.skip('Boundary Escalation Event', () => {
     ];
 
     inValidBoundaryEscalationEventTargets.forEach(({ type, position }) => {
-      dragFromSourceToDest(type, position);
+      clickAndDropElement(type, position);
     });
 
     const numberOfElementsExpected = initialNumberOfElements + inValidBoundaryEscalationEventTargets.length;
     getGraphElements().should('have.length', numberOfElementsExpected);
 
     inValidBoundaryEscalationEventTargets.forEach(({ position }) => {
-      dragFromSourceToDest(nodeTypes.boundaryEscalationEvent, position);
+      clickAndDropElement(nodeTypes.boundaryEscalationEvent, position);
     });
 
     const callActivityEscalation = 1;

--- a/tests/e2e/specs/BoundaryEventValidation.spec.js
+++ b/tests/e2e/specs/BoundaryEventValidation.spec.js
@@ -1,4 +1,4 @@
-import { dragFromSourceToDest, getComponentsEmbeddedInShape, getElementAtPosition, setBoundaryEvent } from '../support/utils';
+import { clickAndDropElement, getComponentsEmbeddedInShape, getElementAtPosition, setBoundaryEvent } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 import uniqWith from 'lodash/uniqWith';
 import isEqual from 'lodash/isEqual';
@@ -6,7 +6,7 @@ import isEqual from 'lodash/isEqual';
 describe('Boundary event validation', () => {
   it('should add boundary events to empty ports around boundary event target, and not allow adding any more', () => {
     const taskPosition = { x: 250, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const numberOfPortsAroundTask = 12;
     for (let i = 0; i < numberOfPortsAroundTask; i++) {

--- a/tests/e2e/specs/BoundarySignalEvent.spec.js
+++ b/tests/e2e/specs/BoundarySignalEvent.spec.js
@@ -1,6 +1,6 @@
 import {
   assertDownloadedXmlContainsExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   setBoundaryEvent,
   typeIntoTextInput,
@@ -21,7 +21,7 @@ describe('Boundary Signal Event', () => {
         'create-signals':true,'view-signals':true,'edit-signals':true,'delete-signals':true,
       });
     });
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundarySignalEvent, taskPosition);
   });
 

--- a/tests/e2e/specs/BoundaryTimerEvent.spec.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getComponentsEmbeddedInShape,
   getElementAtPosition,
   getGraphElements,
@@ -19,7 +19,7 @@ import { CommonBoundaryEventBehaviour } from '../support/BoundaryEventCommonBeha
 describe('Boundary Timer Event', () => {
   it('update boundary timer event properties element', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
@@ -89,7 +89,7 @@ describe('Boundary Timer Event', () => {
         addNodeTypeToPaper(position, nodeTypes.task, selector);
         return;
       }
-      dragFromSourceToDest(type, position);
+      clickAndDropElement(type, position);
     });
 
     const numberOfElementsAfterAddingTasks = initialNumberOfElements + validBoundaryTimerEventTargets.length;
@@ -106,7 +106,7 @@ describe('Boundary Timer Event', () => {
 
   it('can toggle interrupting on Boundary Timer Events', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
@@ -171,7 +171,7 @@ describe('Boundary Timer Event', () => {
   it('moves to another task when dragged over', () => {
     const taskPosition = { x: 300, y: 300 };
     const numberOfBoundaryTimerEventsAdded = 1;
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const taskXml = '<bpmn:task id="node_2" name="Form Task" pm:assignment="requester" />';
@@ -180,7 +180,7 @@ describe('Boundary Timer Event', () => {
     assertDownloadedXmlContainsExpected(taskXml, boundaryEventOnTaskXml);
 
     const task2Position = { x: 500, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     const boundaryTimerEventSelector = '.main-paper ' +
       '[data-type="processmaker.components.nodes.task.Shape"] ~ ' +
@@ -218,11 +218,11 @@ describe('Boundary Timer Event', () => {
 
   it('keeps Boundary Timer Event in correct position when dragging and dropping', () => {
     const taskPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const task2Position = { x: 500, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     const boundaryTimerEventSelector = '.main-paper ' +
       '[data-type="processmaker.components.nodes.task.Shape"] ~ ' +

--- a/tests/e2e/specs/Colorizer.spec.js
+++ b/tests/e2e/specs/Colorizer.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   uploadXml,
 } from '../support/utils';
@@ -26,7 +26,7 @@ describe('Crown color picker', () => {
 
   it('should clear color from element', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition, nodeTypes.pool).click();
     cy.get('[data-test="picker-dropdown-button"]').click({ force: true });

--- a/tests/e2e/specs/CopyElements.spec.js
+++ b/tests/e2e/specs/CopyElements.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlContainsSubstringNTimes,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   typeIntoTextInput,
   waitToRenderAllShapes,
@@ -47,7 +47,7 @@ describe('Copy element', () => {
   it('should copy tasks', () => {
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     getElementAtPosition(taskPosition).click();
 
@@ -104,7 +104,7 @@ describe('Copy element', () => {
     waitToRenderAllShapes();
 
     const intermediateMessageThrowEventPosition = { x: 250, y: 450 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
     cy.get('[data-test=copy-button]').click();
     waitToRenderAllShapes();
@@ -139,12 +139,12 @@ describe('Copy element', () => {
     const firstPoolPosition = { x: 100, y: 150 };
     const secondPoolPosition = { x: 100, y: 450 };
 
-    dragFromSourceToDest(nodeTypes.pool, firstPoolPosition);
+    clickAndDropElement(nodeTypes.pool, firstPoolPosition);
     waitToRenderAllShapes();
-    dragFromSourceToDest(nodeTypes.pool, secondPoolPosition);
+    clickAndDropElement(nodeTypes.pool, secondPoolPosition);
 
     const taskInSecondPoolPosition = {x: 150, y: 500};
-    dragFromSourceToDest(nodeTypes.task, taskInSecondPoolPosition);
+    clickAndDropElement(nodeTypes.task, taskInSecondPoolPosition);
 
     cy.get('[data-test="copy-button"]').click();
     waitToRenderAllShapes();

--- a/tests/e2e/specs/CustomIcon.spec.js
+++ b/tests/e2e/specs/CustomIcon.spec.js
@@ -1,6 +1,6 @@
 import {
   addNodeTypeToPaper,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
 } from '../support/utils';
 
@@ -30,7 +30,7 @@ describe('customIcon', () => {
   });
 
   it('can set custom icon for Form Task', () => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     cy.get('[data-test="picker-dropdown-button"]').click();
     cy.get('[data-test="set-custom-icon"]').click();

--- a/tests/e2e/specs/DataObjectDataStore.spec.js
+++ b/tests/e2e/specs/DataObjectDataStore.spec.js
@@ -2,7 +2,7 @@ import {
   assertDownloadedXmlContainsExpected, assertDownloadedXmlDoesNotContainExpected, assertElementsAreConnected,
   assertDownloadedXmlMatch,
   connectNodesWithFlow,
-  dragFromSourceToDest, getCrownButtonForElement,
+  clickAndDropElement, getCrownButtonForElement,
   getElementAtPosition, getNumberOfLinks, uploadXml, waitToRenderAllShapes,
 } from '../support/utils';
 
@@ -15,7 +15,7 @@ describe('Data Objects and Data Stores', () => {
 
   [nodeTypes.dataObject, nodeTypes.dataStore].forEach(nodeType => {
     it(`does not support connecting sequence flows for ${nodeType}`, () => {
-      dragFromSourceToDest(nodeType, dataPosition);
+      clickAndDropElement(nodeType, dataPosition);
 
       getElementAtPosition(dataPosition)
         .click()
@@ -26,7 +26,7 @@ describe('Data Objects and Data Stores', () => {
 
   [nodeTypes.dataObject, nodeTypes.dataStore].forEach(nodeType => {
     it(`can add data output association flows for ${nodeType}`, () => {
-      dragFromSourceToDest(nodeType, dataPosition);
+      clickAndDropElement(nodeType, dataPosition);
       connectNodesWithFlow('generic-flow-button', startEventPosition, dataPosition);
 
       getNumberOfLinks().should('equal', 1);
@@ -70,7 +70,7 @@ describe('Data Objects and Data Stores', () => {
 
   [nodeTypes.dataObject, nodeTypes.dataStore].forEach(nodeType => {
     it(`does not support connecting data input association to start event for ${nodeType}`, () => {
-      dragFromSourceToDest(nodeType, dataPosition);
+      clickAndDropElement(nodeType, dataPosition);
       connectNodesWithFlow('association-flow-button', dataPosition, startEventPosition);
       getNumberOfLinks().should('equal', 0);
     });
@@ -78,8 +78,8 @@ describe('Data Objects and Data Stores', () => {
 
   [nodeTypes.dataObject, nodeTypes.dataStore].forEach(nodeType => {
     it(`can add data input association flows for ${nodeType}`, () => {
-      dragFromSourceToDest(nodeTypes.task, taskPosition);
-      dragFromSourceToDest(nodeType, dataPosition);
+      clickAndDropElement(nodeTypes.task, taskPosition);
+      clickAndDropElement(nodeType, dataPosition);
       connectNodesWithFlow('association-flow-button', dataPosition, taskPosition);
 
       const name = nodeType === 'processmaker-modeler-data-object' ? 'Data Object' : 'Data Store';
@@ -103,8 +103,8 @@ describe('Data Objects and Data Stores', () => {
   });
 
   it('removed the data input association on the task when the data object is deleted', () => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
-    dragFromSourceToDest(nodeTypes.dataObject, dataPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.dataObject, dataPosition);
     connectNodesWithFlow('association-flow-button', dataPosition, taskPosition);
     waitToRenderAllShapes();
 
@@ -142,8 +142,8 @@ describe('Data Objects and Data Stores', () => {
   });
 
   it('removes the data output association on the task when the data object is deleted', () => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
-    dragFromSourceToDest(nodeTypes.dataObject, dataPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.dataObject, dataPosition);
     connectNodesWithFlow('generic-flow-button', taskPosition, dataPosition);
 
     assertDownloadedXmlContainsExpected(`

--- a/tests/e2e/specs/DeletePool.spec.js
+++ b/tests/e2e/specs/DeletePool.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   getCrownButtonForElement,
   typeIntoTextInput,
@@ -27,7 +27,7 @@ function addPool()
 {
   return new Promise(resolve => {
     const poolPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
     getElementAtPosition(poolPosition, nodeTypes.pool).then(element => {
       resolve(element);
     });

--- a/tests/e2e/specs/Documentation.spec.js
+++ b/tests/e2e/specs/Documentation.spec.js
@@ -2,7 +2,7 @@ import {nodeTypes} from '../support/constants';
 import {
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getTinyMceEditor,
@@ -37,7 +37,7 @@ describe('Documentation accordion', () => {
       .forEach(type => {
         cy.clock();
 
-        dragFromSourceToDest(type, position);
+        clickAndDropElement(type, position);
         cy.get('iframe#documentation-editor_ifr').should('not.be.visible');
         cy.contains('Advanced').click();
         cy.tick(accordionOpenAnimationTime);
@@ -58,7 +58,7 @@ describe('Documentation accordion', () => {
         cy.clock();
         const docString = `${type} doc!`;
 
-        dragFromSourceToDest(type, position);
+        clickAndDropElement(type, position);
         cy.contains('Documentation').click();
         cy.tick(accordionOpenAnimationTime);
         getTinyMceEditor().clear().type(docString);
@@ -74,7 +74,7 @@ describe('Documentation accordion', () => {
   });
 
   it('can allow the documentation editor modal to edit the documentation', () => {
-    dragFromSourceToDest(nodeTypes.task, position);
+    clickAndDropElement(nodeTypes.task, position);
     cy.contains('Documentation').click();
     cy.wait(accordionOpenAnimationTime);
 

--- a/tests/e2e/specs/EventBasedGateway.spec.js
+++ b/tests/e2e/specs/EventBasedGateway.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getGraphElements,
@@ -32,7 +32,7 @@ describe('Event-Based Gateway', () => {
     connectNodesWithFlow('generic-flow-button', startEventPosition, eventBasedGatewayPosition);
 
     const intermediateCatchEventPosition = { x: 500, y: 250 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, intermediateCatchEventPosition);
 
     const intermediateMessageCatchEventPosition = { x: 500, y: 100 };
@@ -40,7 +40,7 @@ describe('Event-Based Gateway', () => {
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, intermediateMessageCatchEventPosition);
 
     const endEventPosition = { x: 500, y: 350 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, endEventPosition);
 
     const totalNumberOfValidElements = 8;
@@ -53,7 +53,7 @@ describe('Event-Based Gateway', () => {
       });
 
     const taskPosition = { x: 450, y: 350 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, taskPosition);
 
     getGraphElements().should('have.length', totalNumberOfValidElements);
@@ -65,7 +65,7 @@ describe('Event-Based Gateway', () => {
       });
 
     const scriptTaskPosition = { x: 450, y: 350 };
-    dragFromSourceToDest(nodeTypes.task, scriptTaskPosition);
+    clickAndDropElement(nodeTypes.task, scriptTaskPosition);
     cy.get('[data-test=switch-to-script-task]').click();
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, scriptTaskPosition);
 
@@ -78,7 +78,7 @@ describe('Event-Based Gateway', () => {
       });
 
     const exclusiveGatewayPosition = { x: 450, y: 350 };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, exclusiveGatewayPosition);
 
     getGraphElements().should('have.length', totalNumberOfValidElements);
@@ -126,7 +126,7 @@ describe('Event-Based Gateway', () => {
       });
 
     const textAnnotationPosition = { x: 450, y: 350 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, textAnnotationPosition);
 
     getGraphElements().should('have.length', totalNumberOfValidElements);
@@ -147,7 +147,7 @@ describe('Event-Based Gateway', () => {
     waitToRenderAllShapes();
 
     const taskPosition = { x: 500, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', eventBasedGatewayPosition, taskPosition);
     getElementAtPosition(eventBasedGatewayPosition).click();
 

--- a/tests/e2e/specs/ExclusiveGateway.spec.js
+++ b/tests/e2e/specs/ExclusiveGateway.spec.js
@@ -1,4 +1,4 @@
-import { dragFromSourceToDest, getElementAtPosition, typeIntoTextInput } from '../support/utils';
+import { clickAndDropElement, getElementAtPosition, typeIntoTextInput } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
 
@@ -7,7 +7,7 @@ describe('Exclusive Gateway', () => {
     const testString = 'testing';
     const exclusiveGatewayPosition = { x: 200, y: 200 };
 
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
 
     getElementAtPosition(exclusiveGatewayPosition).click();
 

--- a/tests/e2e/specs/InclusiveGateway.spec.js
+++ b/tests/e2e/specs/InclusiveGateway.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   typeIntoTextInput,
 } from '../support/utils';
@@ -34,7 +34,7 @@ describe('Inclusive Gateway', () => {
     assertDownloadedXmlContainsExpected(divergingString);
 
     const taskPosition = { x: 350, y: 350 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, inclusivePosition);
 

--- a/tests/e2e/specs/IntermediateCatchEvent.spec.js
+++ b/tests/e2e/specs/IntermediateCatchEvent.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   waitToRenderAllShapes,
@@ -12,10 +12,10 @@ describe('Intermediate Catch Event', () => {
   it('Removes messageRef when message is deleted', () => {
     const intermediateCatchEventPosition = { x: 250, y: 250 };
     const intermediateThrowEventPosition = { x: 250, y: 350 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-catch-event]').click();
 
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateThrowEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateThrowEventPosition);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
 
     getElementAtPosition(intermediateCatchEventPosition).click();

--- a/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
+++ b/tests/e2e/specs/IntermediateMessageThrowEvent.spec.js
@@ -4,7 +4,7 @@ import {
   assertDownloadedXmlContainsSubstringNTimes,
   assertDownloadedXmlDoesNotContainExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getNumberOfLinks,
@@ -154,9 +154,9 @@ describe('Intermediate Message Throw Event', () => {
 
   it('allows connection between pools', () => {
     addNodeTypeToPaper(intermediateMessageThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-message-throw-event');
-    dragFromSourceToDest(nodeTypes.pool, { x: 150, y: 150 });
+    clickAndDropElement(nodeTypes.pool, { x: 150, y: 150 });
     const secondPoolPosition = { x: 100, y: 450 };
-    dragFromSourceToDest(nodeTypes.pool, secondPoolPosition);
+    clickAndDropElement(nodeTypes.pool, secondPoolPosition);
 
     connectNodesWithFlow('generic-flow-button', intermediateMessageThrowEventPosition, secondPoolPosition);
     getNumberOfLinks().should('equal', 1);
@@ -165,9 +165,9 @@ describe('Intermediate Message Throw Event', () => {
 
   it('allows valid message flow connections', () => {
     addNodeTypeToPaper(intermediateMessageThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-message-throw-event');
-    dragFromSourceToDest(nodeTypes.pool, { x: 150, y: 150 });
+    clickAndDropElement(nodeTypes.pool, { x: 150, y: 150 });
     const secondPoolPosition = { x: 150, y: 450 };
-    dragFromSourceToDest(nodeTypes.pool, secondPoolPosition);
+    clickAndDropElement(nodeTypes.pool, secondPoolPosition);
 
     const validMessageThrowEventTargets = [
       { genericNode: nodeTypes.startEvent, nodeToSwitchTo: 'switch-to-message-start-event' },
@@ -190,9 +190,9 @@ describe('Intermediate Message Throw Event', () => {
 
   it('disallows invalid message flow connections', () => {
     addNodeTypeToPaper(intermediateMessageThrowEventPosition, nodeTypes.intermediateCatchEvent, 'switch-to-intermediate-message-throw-event');
-    dragFromSourceToDest(nodeTypes.pool, { x: 150, y: 150 });
+    clickAndDropElement(nodeTypes.pool, { x: 150, y: 150 });
     const secondPoolPosition = { x: 150, y: 450 };
-    dragFromSourceToDest(nodeTypes.pool, { x: 150, y: 450 });
+    clickAndDropElement(nodeTypes.pool, { x: 150, y: 450 });
 
     const invalidMessageThrowEventTargets = [
       { genericNode: nodeTypes.endEvent, nodeToSwitchTo: 'switch-to-message-end-event' },

--- a/tests/e2e/specs/IntermediateTimerEvent.spec.js
+++ b/tests/e2e/specs/IntermediateTimerEvent.spec.js
@@ -1,7 +1,7 @@
 import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   typeIntoTextInput,
   waitToRenderAllShapes,
@@ -11,7 +11,7 @@ import { nodeTypes } from '../support/constants';
 describe('Intermediate Timer Event', () => {
   it('Update delay field on Intermediate Timer Event', () => {
     const intermediateCatchEventPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
 
     getElementAtPosition(intermediateCatchEventPosition).click();
 
@@ -46,7 +46,7 @@ describe('Intermediate Timer Event', () => {
   </bpmn:intermediateCatchEvent>
   `;
 
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
     getElementAtPosition(intermediateCatchEventPosition).click();
 
     typeIntoTextInput(nameInput, testString);
@@ -63,7 +63,7 @@ describe('Intermediate Timer Event', () => {
     cy.clock();
 
     const intermediateCatchEventPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateCatchEventPosition);
 
     getElementAtPosition(intermediateCatchEventPosition).click();
     cy.contains('Timing Control').click();

--- a/tests/e2e/specs/KeyboardMovement.spec.js
+++ b/tests/e2e/specs/KeyboardMovement.spec.js
@@ -1,4 +1,4 @@
-import { dragFromSourceToDest, getElementAtPosition, waitToRenderAllShapes } from '../support/utils';
+import { clickAndDropElement, getElementAtPosition, waitToRenderAllShapes } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
 const CYPRESS_UNDO_SCROLL_ADJUSTMENT = 60.5;
@@ -6,7 +6,7 @@ const CYPRESS_UNDO_SCROLL_ADJUSTMENT = 60.5;
 describe('Keyboard movement interaction', () => {
   it('Can move a node using the keyboard arrows', () => {
     const taskPosition = { x: 400, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     getElementAtPosition(taskPosition).then($task => {
       const { top, left } = $task.position();
@@ -25,7 +25,7 @@ describe('Keyboard movement interaction', () => {
 
   it('can undo keyboard moves', () => {
     const taskPosition = { x: 400, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     getElementAtPosition(taskPosition).then($task => {
       const { top, left } = $task.position();
 

--- a/tests/e2e/specs/ManualTasks.spec.js
+++ b/tests/e2e/specs/ManualTasks.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   typeIntoTextInput,
   waitToRenderAllShapes,
@@ -12,7 +12,7 @@ describe('Manual Task', () => {
     const testString = 'testing';
 
     const manualTaskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, manualTaskPosition);
+    clickAndDropElement(nodeTypes.task, manualTaskPosition);
     cy.get('[data-test=switch-to-manual-task]').click();
 
     getElementAtPosition(manualTaskPosition).click();
@@ -23,7 +23,7 @@ describe('Manual Task', () => {
 
   it('Correctly renders Manual Task after undo/redo', () => {
     const manualTaskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, manualTaskPosition);
+    clickAndDropElement(nodeTypes.task, manualTaskPosition);
     cy.get('[data-test=switch-to-manual-task]').click();
 
     cy.get('[data-test=undo]').click();

--- a/tests/e2e/specs/Markers.spec.js
+++ b/tests/e2e/specs/Markers.spec.js
@@ -1,10 +1,10 @@
-import { dragFromSourceToDest, getElementAtPosition, typeIntoTextInput } from '../support/utils';
+import { clickAndDropElement, getElementAtPosition, typeIntoTextInput } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
 describe('Markers', () => {
   it('Add a task with a custom book marker', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.taskWithMarker, taskPosition);
+    clickAndDropElement(nodeTypes.taskWithMarker, taskPosition);
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.taskWithMarker);
     getElementAtPosition(taskPosition)
       .find('image[joint-selector*=topRight]:first')
@@ -14,7 +14,7 @@ describe('Markers', () => {
 
   xit('Dynamically remove custom book marker', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.taskWithMarker, taskPosition);
+    clickAndDropElement(nodeTypes.taskWithMarker, taskPosition);
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.taskWithMarker);
 
     getElementAtPosition(taskPosition).click();
@@ -29,7 +29,7 @@ describe('Markers', () => {
 
   it('A task could have multiple custom markers', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.taskWithMarker, taskPosition);
+    clickAndDropElement(nodeTypes.taskWithMarker, taskPosition);
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.taskWithMarker);
 
     getElementAtPosition(taskPosition).click();

--- a/tests/e2e/specs/MessageFlows.spec.js
+++ b/tests/e2e/specs/MessageFlows.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getLinksConnectedToElement,
@@ -19,10 +19,10 @@ import { nodeTypes } from '../support/constants';
 describe('Message Flows', () => {
   it('Can connect two pools with a message flow', () => {
     const pool1Position = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const pool2Position = { x: 250, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     connectNodesWithFlow('generic-flow-button', pool1Position, pool2Position, 'top');
 
@@ -39,14 +39,14 @@ describe('Message Flows', () => {
 
   it('Can connect elements in pools with a message flow', () => {
     const pool1Position = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const pool2Position = { x: 250, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     const offset = 100;
     const taskPosition = { x: pool2Position.x + offset, y: pool2Position.y + offset };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const startEventPosition = { x: 150, y: 150 };
     getElementAtPosition(startEventPosition, nodeTypes.startEvent)
@@ -68,14 +68,14 @@ describe('Message Flows', () => {
 
   it('Can connect pool to a task in a different pool', () => {
     const pool1Position = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const pool2Position = { x: 250, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     const offset = 100;
     const taskPosition = { x: pool2Position.x + offset, y: pool2Position.y + offset };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', pool1Position, taskPosition);
 
@@ -93,10 +93,10 @@ describe('Message Flows', () => {
     addNodeTypeToPaper(startEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
 
     const poolPosition = { x: 100, y: 400 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const taskPosition = {x: 250, y: 250};
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     cy.get('[data-test=switch-to-user-task').click();
 
     getElementAtPosition(poolPosition, nodeTypes.pool)
@@ -120,11 +120,11 @@ describe('Message Flows', () => {
     addNodeTypeToPaper(endEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
 
     const poolPosition = { x: 100, y: 250 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const offset = 100;
     const taskPosition = { x: poolPosition.x + offset, y: poolPosition.y + offset };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     cy.get('[data-test=switch-to-user-task').click();
 
     getElementAtPosition(poolPosition, nodeTypes.pool)
@@ -153,13 +153,13 @@ describe('Message Flows', () => {
 
   it('Adding a pool and lanes does not overlap message flow', () => {
     const poolPosition = { x: 150, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const poolTwoPosition = { x: 150, y: 600 };
-    dragFromSourceToDest(nodeTypes.pool, poolTwoPosition);
+    clickAndDropElement(nodeTypes.pool, poolTwoPosition);
 
     const taskPosition = { x: 200, y: 600 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const startEventPosition = { x: 150, y: 150 };
     getElementAtPosition(startEventPosition, nodeTypes.startEvent)
@@ -197,9 +197,9 @@ describe('Message Flows', () => {
     removeStartEvent();
     addNodeTypeToPaper(startEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
 
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
@@ -236,8 +236,8 @@ describe('Message Flows', () => {
     removeStartEvent();
     addNodeTypeToPaper(startEventPosition, nodeTypes.endEvent, 'switch-to-message-end-event');
 
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-sub-process');
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, nodeTypes.subProcess);
     connectNodesWithFlow('generic-flow-button', startEventPosition, boundaryEventPosition, 'center');

--- a/tests/e2e/specs/MessageStartEvent.spec.js
+++ b/tests/e2e/specs/MessageStartEvent.spec.js
@@ -1,10 +1,10 @@
-import { assertDownloadedXmlContainsExpected, dragFromSourceToDest, getElementAtPosition } from '../support/utils';
+import { assertDownloadedXmlContainsExpected, clickAndDropElement, getElementAtPosition } from '../support/utils';
 import { nodeTypes } from '../support/constants';
 
 describe('Message Start Event', () => {
   it('Can create message start event', () => {
     const messageStartEventPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.startEvent, messageStartEventPosition);
+    clickAndDropElement(nodeTypes.startEvent, messageStartEventPosition);
     cy.get('[data-test=switch-to-message-start-event]').click();
 
     assertDownloadedXmlContainsExpected(`
@@ -14,7 +14,7 @@ describe('Message Start Event', () => {
     `);
 
     const intermediateMessageThrowEvent = { x: 350, y: 350 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEvent);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediateMessageThrowEvent);
     cy.get('[data-test=switch-to-intermediate-message-throw-event]').click();
     getElementAtPosition(messageStartEventPosition).click();
     cy.get('[data-test="messageRef:select"]').selectOption('node_5_message');

--- a/tests/e2e/specs/Modeler.spec.js
+++ b/tests/e2e/specs/Modeler.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsSubstringNTimes,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getGraphElements,
@@ -25,24 +25,24 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements);
 
     const taskPosition = { x: 300, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const startEventPosition = { x: 150, y: 150 };
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     const task2Position = { x: 300, y: 350 };
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
     connectNodesWithFlow('generic-flow-button', taskPosition, task2Position);
 
     const task3Position = { x: 100, y: 350 };
-    dragFromSourceToDest(nodeTypes.task, task3Position);
+    clickAndDropElement(nodeTypes.task, task3Position);
     connectNodesWithFlow('generic-flow-button', task2Position, task3Position);
 
     const endEventPosition = { x: 100, y: 500 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
     connectNodesWithFlow('generic-flow-button', task3Position, endEventPosition);
 
-    dragFromSourceToDest(nodeTypes.pool, { x: 100, y: 100 });
+    clickAndDropElement(nodeTypes.pool, { x: 100, y: 100 });
 
     const numberOfNewElementsAdded = 9;
     getGraphElements().should('have.length', initialNumberOfElements + numberOfNewElementsAdded);
@@ -88,7 +88,7 @@ describe('Modeler', () => {
     getGraphElements().should('have.length', initialNumberOfElements);
 
     const taskPosition = { x: 400, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, taskPosition);
 
@@ -105,7 +105,7 @@ describe('Modeler', () => {
     cy.get('[name=id] input').should('have.value', 'node_1');
 
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     getElementAtPosition(taskPosition).click();
     cy.contains('Advanced').click();
 
@@ -114,20 +114,20 @@ describe('Modeler', () => {
     typeIntoTextInput('[name=id] input', 'node_3');
 
     const task2Position = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
     getElementAtPosition(task2Position).click();
 
     cy.get('[name=id] input').should('have.value', 'node_4');
 
     const task3Position = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, task3Position);
+    clickAndDropElement(nodeTypes.task, task3Position);
     getElementAtPosition(task3Position).click();
 
     cy.get('[name=id] input').should('have.value', 'node_5');
 
     uploadXml('../../../src/blank.bpmn');
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     getElementAtPosition(taskPosition).click();
 
     cy.get('[name=id] input').should('have.value', 'node_1');
@@ -142,7 +142,7 @@ describe('Modeler', () => {
     cy.get('[name=id] input').should('have.value', 'node_1');
 
     const taskPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     getElementAtPosition(taskPosition).click();
     cy.contains('Advanced').click();
 
@@ -178,12 +178,12 @@ describe('Modeler', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     const poolPosition = { x: 150, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(startEventPosition)
       .then(getLinksConnectedToElement)
@@ -275,7 +275,7 @@ describe('Modeler', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     getElementAtPosition(startEventPosition)
@@ -374,7 +374,7 @@ describe('Modeler', () => {
       .should('have.css', 'display', 'block');
 
     const poolPosition = { x: 150, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
     const poolSelector = '.main-paper [data-type="processmaker.modeler.bpmn.pool"]';
 
     cy.get(poolSelector)
@@ -418,27 +418,27 @@ describe('Modeler', () => {
     const taskPosition = { x: 745, y: 200 };
     cy.get('[data-test=panels-btn]').click();
     cy.wait(700);
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     getElementAtPosition({ x: taskPosition.x + 5, y: taskPosition.y }).click({ force: true }).getType()
       .should('equal', nodeTypes.task);
   });
 
   it('should not generate duplicate diagram IDs', () => {
     uploadXml('setUpForDuplicateDiagramId.xml');
-    dragFromSourceToDest(nodeTypes.task, { x: 300, y: 300 });
+    clickAndDropElement(nodeTypes.task, { x: 300, y: 300 });
     assertDownloadedXmlContainsSubstringNTimes('node_1_di',1,'Node 1 should occur once');
     assertDownloadedXmlContainsSubstringNTimes('node_2_di',1,'Node 2 should occur once');
   });
 
   it('should only show dropdown for the start event', () => {
     const startEventPosition = { x: 400, y: 400 };
-    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
+    clickAndDropElement(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
 
     cy.get('[data-test=switch-to-start-timer-event]').should('exist');
     cy.get('[data-test=switch-to-message-start-event]').should('exist');
 
-    dragFromSourceToDest(nodeTypes.task, { x: 300, y: 300 });
+    clickAndDropElement(nodeTypes.task, { x: 300, y: 300 });
 
     cy.get('[data-test=switch-to-start-timer-event]').should('not.exist');
     cy.get('[data-test=switch-to-message-start-event]').should('not.exist');
@@ -446,7 +446,7 @@ describe('Modeler', () => {
 
   it('should hide start event dropdown on unhighlight', () => {
     const startEventPosition = { x: 400, y: 400 };
-    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition);
+    clickAndDropElement(nodeTypes.startEvent, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();
     cy.get('.paper-container').click();
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).click();

--- a/tests/e2e/specs/Multiselect.spec.js
+++ b/tests/e2e/specs/Multiselect.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   getGraphElements,
   moveElementRelativeTo,
@@ -15,8 +15,8 @@ describe('Multiselect', () => {
     const newTask1Position = { x: task1Position.x + translateAmount, y: task1Position.y + translateAmount };
     const newTask2Position = { x: task2Position.x + translateAmount, y: task2Position.y + translateAmount };
 
-    dragFromSourceToDest(nodeTypes.task, task1Position);
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task1Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     cy.get('.paper-container').click();
 
@@ -53,8 +53,8 @@ describe('Multiselect', () => {
     const moveAmount = 5;
     const numberOfTimesToMove = translateAmount / moveAmount;
 
-    dragFromSourceToDest(nodeTypes.task, task1Position);
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task1Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     cy.get('.paper-container').click();
 
@@ -92,8 +92,8 @@ describe('Multiselect', () => {
     const newTask1Position = { x: task1Position.x + translateAmount, y: task1Position.y + translateAmount };
     const newTask2Position = { x: task2Position.x + translateAmount, y: task2Position.y + translateAmount };
 
-    dragFromSourceToDest(nodeTypes.task, task1Position);
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task1Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     cy.get('.paper-container').as('paperContainer').click();
 

--- a/tests/e2e/specs/Pools.spec.js
+++ b/tests/e2e/specs/Pools.spec.js
@@ -4,7 +4,7 @@ import {
   assertDownloadedXmlContainsSubstringNTimes,
   assertDownloadedXmlDoesNotContainExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getPositionInPaperCoords,
@@ -25,7 +25,7 @@ describe('Pools', () => {
     const testString = 'testing';
 
     const poolPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).click();
 
@@ -36,7 +36,7 @@ describe('Pools', () => {
   it('Can add top and bottom lane', () => {
     const poolPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition)
       .click()
@@ -50,7 +50,7 @@ describe('Pools', () => {
     const poolPosition = { x: 300, y: 300 };
     const lanePosition = { x: 300, y: 550 };
 
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).click().then($pool => {
       getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
@@ -68,7 +68,7 @@ describe('Pools', () => {
     const startEventPosition = { x: 150, y: 150 };
 
     const pool1Position = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const startEventIn1stPool = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /></bpmn:process>';
     const startEventIn1stPoolWithNullProps = '<bpmn:process id="Process_1" isExecutable="true"><bpmn:startEvent id="node_1" name="Start Event" /></bpmn:process>';
@@ -81,7 +81,7 @@ describe('Pools', () => {
       });
 
     const pool2Position = { x: 200, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     moveElement(startEventPosition, pool2Position);
     waitToRenderAllShapes();
@@ -117,10 +117,10 @@ describe('Pools', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 350, y: 350 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     getElementAtPosition(poolPosition)
@@ -142,7 +142,7 @@ describe('Pools', () => {
 
   it('Removes all references to element from lane', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition)
       .click()
@@ -167,7 +167,7 @@ describe('Pools', () => {
 
   it('Removes all references to element from a pool', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const startEventPosition = { x: 150, y: 150 };
     getElementAtPosition(startEventPosition).click().then($startEvent => {
@@ -185,13 +185,13 @@ describe('Pools', () => {
 
   it('moves boundary event to another process when dragged to that pool', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const pool2Position = { x: 100, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const boundaryTimerEventPosition = { x: 260, y: 260 };
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
@@ -217,7 +217,7 @@ describe('Pools', () => {
 
   it('should revert pool element to initial position on undo after dragging outside of pool onto grid', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const startEventPosition = { x: 150, y: 150 };
     moveElementRelativeTo(startEventPosition, 600, 600, nodeTypes.startEvent);
@@ -231,7 +231,7 @@ describe('Pools', () => {
 
   it('should not cover child elements with lane', () => {
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition, nodeTypes.pool)
       .click()
@@ -256,11 +256,11 @@ describe('Pools', () => {
 
   it('does not move boundary events independently from tasks when moving pool', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 
     const poolPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     getElementAtPosition(poolPosition).then($pool => {
       assertBoundaryEventIsCloseToTask();
@@ -279,13 +279,13 @@ describe('Pools', () => {
     const poolPosition2 = { x: 300, y: 400 };
 
     // Add pool
-    dragFromSourceToDest(nodeTypes.pool, poolPosition1);
+    clickAndDropElement(nodeTypes.pool, poolPosition1);
 
     getElementAtPosition(poolPosition1).click().then($pool => {
       getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
     });
 
-    dragFromSourceToDest(nodeTypes.pool, poolPosition2);
+    clickAndDropElement(nodeTypes.pool, poolPosition2);
 
     getElementAtPosition({ x: 600, y: 600 }).click().then($pool => {
       getCrownButtonForElement($pool, 'lane-below-button').click({ force: true });
@@ -314,9 +314,9 @@ describe('Pools', () => {
     const poolPosition2 = { x: 300, y: 400 };
     const taskPosition = { x: 350, y: 450 };
 
-    dragFromSourceToDest(nodeTypes.pool, poolPosition1);
-    dragFromSourceToDest(nodeTypes.pool, poolPosition2);
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition1);
+    clickAndDropElement(nodeTypes.pool, poolPosition2);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     setBoundaryEvent(nodeTypes.boundaryConditionalEvent, taskPosition);
 
     assertDownloadedXmlContainsSubstringNTimes('<bpmn:boundaryEvent', 1);
@@ -335,14 +335,14 @@ describe('Pools', () => {
     }
 
     function addElementsThatShouldNotHaveFlowNodeRefs() {
-      dragFromSourceToDest(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
-      dragFromSourceToDest(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
-      dragFromSourceToDest(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
+      clickAndDropElement(nodeTypes.dataStore, {x: poolPosition.x + 100, y: poolPosition.y + 100});
+      clickAndDropElement(nodeTypes.dataObject, {x: poolPosition.x + 150, y: poolPosition.y + 150});
+      clickAndDropElement(nodeTypes.textAnnotation, {x: poolPosition.x + 200, y: poolPosition.y + 200});
     }
 
     it('when adding elements to an existing lane', () => {
       removeStartEvent();
-      dragFromSourceToDest(nodeTypes.pool, poolPosition);
+      clickAndDropElement(nodeTypes.pool, poolPosition);
 
       addLaneBelow();
       addElementsThatShouldNotHaveFlowNodeRefs();
@@ -352,7 +352,7 @@ describe('Pools', () => {
 
     it('when adding elements to a pool and then adding a lane', () => {
       removeStartEvent();
-      dragFromSourceToDest(nodeTypes.pool, poolPosition);
+      clickAndDropElement(nodeTypes.pool, poolPosition);
 
       addElementsThatShouldNotHaveFlowNodeRefs();
       addLaneBelow();

--- a/tests/e2e/specs/SequenceFlows.spec.js
+++ b/tests/e2e/specs/SequenceFlows.spec.js
@@ -2,7 +2,7 @@ import {
   addNodeTypeToPaper,
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   getLinksConnectedToElement,
   modalConfirm,
@@ -21,7 +21,7 @@ describe('Sequence Flows', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
@@ -36,10 +36,10 @@ describe('Sequence Flows', () => {
 
   it('Update name and condition expression', () => {
     const exclusiveGatewayPosition = { x: 400, y: 300 };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
 
     const taskPosition = { x: 400, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', exclusiveGatewayPosition, taskPosition);
 
@@ -74,10 +74,10 @@ describe('Sequence Flows', () => {
    */
   it.skip('Allows modifying anchor points', () => {
     const taskPosition = { x: 200, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const task2Position = { x: 400, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, task2Position);
 
@@ -149,7 +149,7 @@ describe('Sequence Flows', () => {
   it('Retains target anchor point after parsing and moving shape', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 200, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
@@ -197,7 +197,7 @@ describe('Sequence Flows', () => {
   it('Retains source anchor point after parsing and moving shape', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 400, y: 400 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
@@ -244,13 +244,13 @@ describe('Sequence Flows', () => {
 
   it('connects sequence flows with a straight line', () => {
     const taskPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const endEventPosition = {
       x: taskPosition.x + (taskWidth / 2) - (startEventDiameter / 2) + 1,
       y: taskPosition.y + 200,
     };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, endEventPosition);
 
@@ -261,7 +261,7 @@ describe('Sequence Flows', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, startEventPosition);
     getElementAtPosition(startEventPosition, nodeTypes.startEvent).
@@ -273,8 +273,8 @@ describe('Sequence Flows', () => {
     const endEventPosition = { x: 350, y: 350 };
     const taskPosition = { x: 250, y: 250 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     connectNodesWithFlow('generic-flow-button', taskPosition, endEventPosition);
     getElementAtPosition(endEventPosition, nodeTypes.endEvent).

--- a/tests/e2e/specs/StartMessageEvent.spec.js
+++ b/tests/e2e/specs/StartMessageEvent.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   waitToRenderAllShapes,
@@ -13,10 +13,10 @@ describe('Start Message Event', () => {
   it('Removes messageRef when message is deleted', () => {
     const startMessageEventPosition = { x: 250, y: 250 };
     const endMessageEventPosition = { x: 250, y: 350 };
-    dragFromSourceToDest(nodeTypes.startEvent, startMessageEventPosition);
+    clickAndDropElement(nodeTypes.startEvent, startMessageEventPosition);
     cy.get('[data-test=switch-to-message-start-event]').click();
 
-    dragFromSourceToDest(nodeTypes.endEvent, endMessageEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endMessageEventPosition);
     cy.get('[data-test=switch-to-message-end-event]').click();
 
     getElementAtPosition(startMessageEventPosition).click();

--- a/tests/e2e/specs/SwitchingElements.spec.js
+++ b/tests/e2e/specs/SwitchingElements.spec.js
@@ -3,7 +3,7 @@ import {
   assertDownloadedXmlContainsExpected,
   assertDownloadedXmlDoesNotContainExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   uploadXml,
   getLinksConnectedToElement, modalAnimationTime, modalConfirm, setBoundaryEvent, waitToRenderAllShapes,
@@ -45,8 +45,8 @@ describe('Switching elements', () => {
   it('Switching an exclusive gateway to a parallel gateway should remove conditions from flows', () => {
     const gatewayPosition = {x: 300, y: 150};
     const taskPosition = {x: 450, y: 150};
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition);
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, gatewayPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', gatewayPosition, taskPosition);
 
     const flowExpression = '1234 == 1234';

--- a/tests/e2e/specs/TaskMarkerFlags.spec.js
+++ b/tests/e2e/specs/TaskMarkerFlags.spec.js
@@ -1,6 +1,6 @@
 import {
   assertDownloadedXmlContainsExpected,
-  dragFromSourceToDest, uploadXml,
+  clickAndDropElement, uploadXml,
 } from '../support/utils';
 
 import { nodeTypes } from '../support/constants';
@@ -15,7 +15,7 @@ function assertBottomCenterTaskMarkerHasImage(iconName, markerIndex = 0) {
 describe('Task Marker Flags', () => {
   beforeEach(() => {
     const taskPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     cy.contains('Advanced').click();
   });
 

--- a/tests/e2e/specs/Tasks.spec.js
+++ b/tests/e2e/specs/Tasks.spec.js
@@ -1,6 +1,6 @@
 import {
   addNodeTypeToPaper,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition, modalAnimationTime,
   modalCancel,
   modalConfirm,
@@ -15,7 +15,7 @@ describe('Tasks', () => {
   const testString = 'testing';
 
   it('Update task name', () => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     getElementAtPosition(taskPosition).click();
 
@@ -24,7 +24,7 @@ describe('Tasks', () => {
   });
 
   it('Correctly renders task after undo/redo', () => {
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     cy.get('[data-test=undo]').click();
     waitToRenderAllShapes();

--- a/tests/e2e/specs/TextAnnotation.spec.js
+++ b/tests/e2e/specs/TextAnnotation.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   typeIntoTextInput,
 } from '../support/utils';
@@ -14,7 +14,7 @@ describe('Text Annotation', () => {
     const testString = 'testing';
 
     const textAnnotationPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
 
     getElementAtPosition(textAnnotationPosition).click();
 
@@ -24,10 +24,10 @@ describe('Text Annotation', () => {
 
   it('should be able to add a text annotation outside of a pool', () => {
     const poolPosition = { x: 250, y: 200 };
-    dragFromSourceToDest(nodeTypes.pool, poolPosition);
+    clickAndDropElement(nodeTypes.pool, poolPosition);
 
     const textAnnotationPosition = { x: 400, y: 50 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
 
     connectNodesWithFlow('association-flow-button', textAnnotationPosition, poolPosition);
 
@@ -45,7 +45,7 @@ describe('Text Annotation', () => {
   it('keeps custom color when updating node text', () => {
     const colorToSelect = baseNodeColors[0];
     const textAnnotationPosition = { x: 400, y: 100 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
 
     getElementAtPosition(textAnnotationPosition).click();
     cy.get('[data-test="picker-dropdown-button"]').click();

--- a/tests/e2e/specs/UndoRedo.spec.js
+++ b/tests/e2e/specs/UndoRedo.spec.js
@@ -1,7 +1,7 @@
 import {
   assertDownloadedXmlContainsExpected,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getCrownButtonForElement,
   getElementAtPosition,
   getGraphElements,
@@ -18,10 +18,10 @@ const TOOLBAR_HEIGHT = 64;
 describe('Undo/redo', () => {
   it('Can undo and redo sequence flow condition expression', () => {
     const exclusiveGatewayPosition = { x: 250, y: 250 + TOOLBAR_HEIGHT };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, exclusiveGatewayPosition);
 
     const taskPosition = { x: 400, y: 500 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     connectNodesWithFlow('generic-flow-button', exclusiveGatewayPosition, taskPosition);
 
@@ -65,7 +65,7 @@ describe('Undo/redo', () => {
   it('Can undo and redo adding a task', () => {
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     cy.get('[data-test=undo]').click();
     waitToRenderAllShapes();
@@ -83,7 +83,7 @@ describe('Undo/redo', () => {
   it('Can undo and redo deleting a task', () => {
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     getElementAtPosition(taskPosition)
       .click()
@@ -136,7 +136,7 @@ describe('Undo/redo', () => {
     const taskPosition1 = { x: 150, y: 400 };
     const taskPosition2 = { x: taskPosition1.x + 200, y: taskPosition1.y };
     const taskPosition3 = { x: taskPosition2.x + 200, y: taskPosition2.y };
-    dragFromSourceToDest(nodeTypes.task, taskPosition1);
+    clickAndDropElement(nodeTypes.task, taskPosition1);
 
     getElementAtPosition(taskPosition1)
       .moveTo(taskPosition2.x, taskPosition2.y)
@@ -152,10 +152,10 @@ describe('Undo/redo', () => {
 
   it('Can undo and redo adding message flows', () => {
     const pool1Position = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const pool2Position = { x: 250, y: 500 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     connectNodesWithFlow('generic-flow-button', pool1Position, pool2Position, 'top');
 
@@ -199,10 +199,10 @@ describe('Undo/redo', () => {
     waitToRenderAllShapes();
 
     const testConnectorPosition = { x: 150, y: 300 };
-    dragFromSourceToDest(nodeTypes.testConnector, testConnectorPosition);
+    clickAndDropElement(nodeTypes.testConnector, testConnectorPosition);
 
     const sendTweetPosition = { x: 150, y: 450 };
-    dragFromSourceToDest(nodeTypes.sendTweet, sendTweetPosition);
+    clickAndDropElement(nodeTypes.sendTweet, sendTweetPosition);
 
     const testConnector = '<bpmn:serviceTask id="node_2" name="Test Connector" pm:config="{&#34;testMessage&#34;:&#34;&#34;}" implementation="test-message" />';
     const sendTweet = '<bpmn:serviceTask id="node_3" name="Send Tweet" pm:config="{&#34;tweet&#34;:&#34;&#34;}" implementation="processmaker-social-twitter-send" />';
@@ -225,7 +225,7 @@ describe('Undo/redo', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     const initialNumberOfWaypoints = 4;
@@ -257,7 +257,7 @@ describe('Undo/redo', () => {
   it('Can undo/redo modifying association flow vertices', () => {
     const startEventPosition = { x: 150, y: 150 };
     const textAnnotationPosition = { x: 300, y: 300 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
     connectNodesWithFlow('association-flow-button', textAnnotationPosition, startEventPosition);
 
     const initialNumberOfWaypoints = 2;
@@ -288,7 +288,7 @@ describe('Undo/redo', () => {
 
   it('undo/redo boundary timer event', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 

--- a/tests/e2e/specs/Validation.spec.js
+++ b/tests/e2e/specs/Validation.spec.js
@@ -1,7 +1,7 @@
 import {
   addNodeTypeToPaper,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition, getTinyMceEditor,
   waitToRenderAllShapes,
   waitToRenderNodeUpdates,
@@ -12,7 +12,7 @@ describe('Validation', () => {
 
   it('Validates gateway direction', () => {
     const gatewayPosition = { x: 250, y: 250 };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, gatewayPosition);
     cy.get('[data-test=switch-to-inclusive-gateway]').click();
 
     cy.get('[data-test="validation-toggle"]').click({ force: true });
@@ -66,7 +66,7 @@ describe('Validation', () => {
     });
 
     const taskPosition = { x: 150, y: 300 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     const numberOfNewDefinitionListElements = 2;
     cy.get('[data-test=validation-list]').children()
@@ -111,9 +111,9 @@ describe('Validation', () => {
     const parallelGatewayPosition = { x: 200, y: 200 };
 
     addNodeTypeToPaper(parallelGatewayPosition, nodeTypes.exclusiveGateway, 'switch-to-parallel-gateway');
-    dragFromSourceToDest(nodeTypes.task, taskPosition1);
-    dragFromSourceToDest(nodeTypes.task, taskPosition2);
-    dragFromSourceToDest(nodeTypes.task, taskPosition3);
+    clickAndDropElement(nodeTypes.task, taskPosition1);
+    clickAndDropElement(nodeTypes.task, taskPosition2);
+    clickAndDropElement(nodeTypes.task, taskPosition3);
 
     connectNodesWithFlow('generic-flow-button', taskPosition1, parallelGatewayPosition);
     connectNodesWithFlow('generic-flow-button', taskPosition2, parallelGatewayPosition);
@@ -137,8 +137,8 @@ describe('Validation', () => {
     const taskPosition = { x: 250, y: 250 };
     const endEventPosition = { x: 350, y: 350 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
     connectNodesWithFlow('generic-flow-button', taskPosition, endEventPosition);

--- a/tests/e2e/specs/bottonControlClickAnddrop/CreateElemenyClickAndDrop.spec.js
+++ b/tests/e2e/specs/bottonControlClickAnddrop/CreateElemenyClickAndDrop.spec.js
@@ -6,7 +6,8 @@ import {
 import { nodeTypes } from '../../support/constants';
 describe('Create Element' , () => {
   it('Verify if the number of the created elements is right', () => {
-    const startEventPosition = { x: 100, y: 100 };
+    const explorerX = 200;
+    const startEventPosition = { x: 100 + explorerX, y: 100 };
     const taskFormPosition = {
       x: startEventPosition.x + 200,
       y: startEventPosition.y,

--- a/tests/e2e/specs/canvasUsability/canvasSelection/DeselectWhenCanvasIsClicked.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/DeselectWhenCanvasIsClicked.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
 } from '../../../support/utils';
@@ -18,13 +18,13 @@ describe('Canvas Selection', () => {
     };
 
     // Drag a Task Form
-    dragFromSourceToDest(nodeTypes.task, taskFormPosition);
+    clickAndDropElement(nodeTypes.task, taskFormPosition);
 
     // Connect the Start Event with Task Form
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskFormPosition);
 
     // Drag an End Event
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     // Connect the Task Form with End Event
     connectNodesWithFlow('generic-flow-button', taskFormPosition, endEventPosition);

--- a/tests/e2e/specs/canvasUsability/canvasSelection/DeselectWhenNewElementAdded.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/DeselectWhenNewElementAdded.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
 } from '../../../support/utils';
@@ -18,13 +18,13 @@ describe('Canvas Selection', () => {
     };
 
     // Drag a Task Form
-    dragFromSourceToDest(nodeTypes.task, taskFormPosition);
+    clickAndDropElement(nodeTypes.task, taskFormPosition);
 
     // Connect the Start Event with Task Form
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskFormPosition);
 
     // Drag an End Event
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     // Connect the Task Form with End Event
     connectNodesWithFlow('generic-flow-button', taskFormPosition, endEventPosition);
@@ -52,7 +52,7 @@ describe('Canvas Selection', () => {
       x: endEventPosition.x,
       y: endEventPosition.y + 200,
     };
-    dragFromSourceToDest(nodeTypes.task, newTaskPosition);
+    clickAndDropElement(nodeTypes.task, newTaskPosition);
 
     // Validation 2: Verify that the previous selection was lost after dragging another element
     cy.get('[data-type="processmaker.components.nodes.startEvent.Shape"] [data-cy="selected"]').should('not.exist');

--- a/tests/e2e/specs/canvasUsability/canvasSelection/SelectingAnElementByClickingOnIt.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/SelectingAnElementByClickingOnIt.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getElementAtPosition,
@@ -19,13 +19,13 @@ describe('Canvas Selection', () => {
     };
 
     // Drag a Task Form
-    dragFromSourceToDest(nodeTypes.task, taskFormPosition);
+    clickAndDropElement(nodeTypes.task, taskFormPosition);
 
     // Connect the Start Event with Task Form
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskFormPosition);
 
     // Drag an End Event
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     // Connect the Task Form with End Event
     connectNodesWithFlow('generic-flow-button', taskFormPosition, endEventPosition);

--- a/tests/e2e/specs/canvasUsability/canvasSelection/SelectingAnElementIntoTheSelectedBox.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/SelectingAnElementIntoTheSelectedBox.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getElementAtPosition,
@@ -19,13 +19,13 @@ describe('Canvas Selection', () => {
     };
 
     // Drag a Task Form
-    dragFromSourceToDest(nodeTypes.task, taskFormPosition);
+    clickAndDropElement(nodeTypes.task, taskFormPosition);
 
     // Connect the Start Event with Task Form
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskFormPosition);
 
     // Drag an End Event
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     // Connect the Task Form with End Event
     connectNodesWithFlow('generic-flow-button', taskFormPosition, endEventPosition);

--- a/tests/e2e/specs/canvasUsability/canvasSelection/SelectionOfPoolsWithShiftClick.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/SelectionOfPoolsWithShiftClick.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   getElementAtPosition,
   waitToRenderAllShapes,
 } from '../../../support/utils';
@@ -9,23 +9,23 @@ describe('Selection of pool with shift click', () => {
   it('should add to selection a pool with shift key', () => {
     // Drag pool 1 and elements inside
     const pool1Position = { x: 100, y: 50 };
-    dragFromSourceToDest(nodeTypes.pool, pool1Position);
+    clickAndDropElement(nodeTypes.pool, pool1Position);
 
     const taskPosition1 = { x: 280, y: 180 };
     const endEventPosition1 = { x: 440, y: 240 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition1);
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition1);
+    clickAndDropElement(nodeTypes.task, taskPosition1);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition1);
 
     // Drag pool 2 and elements inside
     const pool2Position = { x: 100, y: 450 };
-    dragFromSourceToDest(nodeTypes.pool, pool2Position);
+    clickAndDropElement(nodeTypes.pool, pool2Position);
 
     const startEventPosition2 = { x: 180, y: 520 };
     const taskPosition2 = { x: 280, y: 500 };
     const endEventPosition2 = { x: 440, y: 520 };
-    dragFromSourceToDest(nodeTypes.startEvent, startEventPosition2);
-    dragFromSourceToDest(nodeTypes.task, taskPosition2);
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition2);
+    clickAndDropElement(nodeTypes.startEvent, startEventPosition2);
+    clickAndDropElement(nodeTypes.task, taskPosition2);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition2);
 
     // Select both pools with shift + click
     cy.get('body').type('{shift}', { release: false });

--- a/tests/e2e/specs/canvasUsability/canvasSelection/VerifySelectionWithProcess.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/VerifySelectionWithProcess.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes, getGraphElements,
 } from '../../../support/utils';
@@ -16,11 +16,11 @@ describe('Canvas Selection', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfEndEvent.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfEndEvent.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   waitToRenderAllShapes,
   getGraphElements,
   getIframeDocumnetation,
@@ -20,7 +20,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add End Event
     const endEventPosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 3: Config The End Event
     cy.get('[name="name"]').clear().type('End Event Test 1');
@@ -50,7 +50,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add End Event
     const endEventPosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Change the End Event to Message End Event

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfExclusiveGateway.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfExclusiveGateway.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   waitToRenderAllShapes,
   getGraphElements,
   getIframeDocumnetation,
@@ -20,7 +20,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Exclusive Gateway
     const gatewayPosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, gatewayPosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Config Exclusive Gateway
@@ -51,7 +51,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Exclusive Gateway
     const gatewayPosition = { x: 250, y: 350 };
-    dragFromSourceToDest(nodeTypes.exclusiveGateway, gatewayPosition);
+    clickAndDropElement(nodeTypes.exclusiveGateway, gatewayPosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Change the Exclusive Gateway to Inclusive Gateway

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   waitToRenderAllShapes,
   getGraphElements, getIframeDocumnetation, selectComponentType,
 } from '../../../support/utils';
@@ -18,7 +18,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Task Form
     const taskPosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Config The Form Task
     cy.get('[name="name"]').clear().type('Form Task Test 1');
@@ -48,7 +48,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Form Task
     const intermediatePosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.task, intermediatePosition);
+    clickAndDropElement(nodeTypes.task, intermediatePosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Change the Form Task to Manual Task

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfIntermediateEvent.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfIntermediateEvent.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   waitToRenderAllShapes,
   getGraphElements, getIframeDocumnetation, selectComponentType,
 } from '../../../support/utils';
@@ -18,7 +18,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Intermediate Event
     const intermediatePosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediatePosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediatePosition);
 
     //Step 3: Config The Intermediate Event
     cy.get('[name="name"]').clear().type('Intermediate Event Test 1');
@@ -47,7 +47,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Add Intermediate Event
     const intermediatePosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.intermediateCatchEvent, intermediatePosition);
+    clickAndDropElement(nodeTypes.intermediateCatchEvent, intermediatePosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Change the Intermediate Event to Signal Event

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfTextAnnotation.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfTextAnnotation.spec.js
@@ -2,7 +2,7 @@ import {
   waitToRenderAllShapes,
   getGraphElements,
   getIframeDocumnetation,
-  dragFromSourceToDest,
+  clickAndDropElement,
 } from '../../../support/utils';
 import {nodeTypes} from '../../../support/constants';
 
@@ -19,7 +19,7 @@ describe('Clone Improvement', () => {
 
     //Step 2: Drag Text Annotation
     const textAnnotationPosition = { x: 350, y: 250 };
-    dragFromSourceToDest(nodeTypes.textAnnotation, textAnnotationPosition);
+    clickAndDropElement(nodeTypes.textAnnotation, textAnnotationPosition);
     cy.get(selectorStartEvent).first().click();
 
     //Step 3: Set title in Text Annotation

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyBottomRailIsNotAffectedByControl++.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyBottomRailIsNotAffectedByControl++.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyBottomRailIsNotAffectedByControl--.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyBottomRailIsNotAffectedByControl--.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyControlsRailIsNotAffectedByControl++.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyControlsRailIsNotAffectedByControl++.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyControlsRailIsNotAffectedByControl--.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyControlsRailIsNotAffectedByControl--.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyInspectorRailIsNotAffectedByControl++.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyInspectorRailIsNotAffectedByControl++.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyInspectorRailIsNotAffectedByControl--.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyInspectorRailIsNotAffectedByControl--.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyTopRailIsNotAffectedByControl++.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyTopRailIsNotAffectedByControl++.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyTopRailIsNotAffectedByControl--.spec.js
+++ b/tests/e2e/specs/canvasUsability/zoomInOutHotKeys/VerifyTopRailIsNotAffectedByControl--.spec.js
@@ -1,5 +1,5 @@
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   connectNodesWithFlow,
   waitToRenderAllShapes,
   getGraphElements,
@@ -17,11 +17,11 @@ describe('Zoom In/Out Hot keys', () => {
 
     //Step 2: Drag Task component
     const taskPosition = { x: 300, y: 130 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     //Step 3: Drag End Event
     const endEventPosition = { x: 500, y: 150 };
-    dragFromSourceToDest(nodeTypes.endEvent, endEventPosition);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
 
     //Step 4: Connect the Start Event with Task
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);

--- a/tests/e2e/specs/explorerRail/ClickAndDrop.spec.js
+++ b/tests/e2e/specs/explorerRail/ClickAndDrop.spec.js
@@ -1,0 +1,22 @@
+
+// import {
+//   waitToRenderAllShapes,
+// } from '../../support/utils';
+import { nodeTypes } from '../../support/constants';
+const { clickAndDropElement, getElementAtPosition, waitToRenderAllShapes } = require('../../support/utils');
+
+describe('Click and Drop' , () => {
+  it('Elements are clicked and dropped into canvas', () => {
+    const explorerX = 200;
+    const task1Position = { x: 100 + explorerX, y: 200 };
+    const task2Position = { x: 250 + explorerX, y: 200 };
+    const endEventPosition = { x: 400 + explorerX, y: 200 };
+    clickAndDropElement(nodeTypes.task, task1Position);
+    clickAndDropElement(nodeTypes.task, task2Position);
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
+    waitToRenderAllShapes();
+    getElementAtPosition(task1Position).getType().should('equal', nodeTypes.task);
+    getElementAtPosition(task2Position).getType().should('equal', nodeTypes.task);
+    getElementAtPosition(endEventPosition).getType().should('equal', nodeTypes.endEvent);
+  });
+});

--- a/tests/e2e/specs/explorerRail/ExplorerRail.spec.js
+++ b/tests/e2e/specs/explorerRail/ExplorerRail.spec.js
@@ -1,0 +1,84 @@
+describe('Explorer Rail Tests', () => {
+  it('Should pin an element', () => {
+    // Try with Start Event
+    cy.get('[data-test=processmaker-modeler-start-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('.objectCategory').find('[data-test=processmaker-modeler-start-event]').should('not.exist');
+    cy.get('.pinnedObjects').find('[data-test=processmaker-modeler-start-event]').should('exist');
+    cy.get('.control-list > [data-test=processmaker-modeler-start-event]').should('exist');
+    
+    // Try with End Event
+    cy.get('[data-test=processmaker-modeler-end-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('.objectCategory').find('[data-test=processmaker-modeler-end-event]').should('not.exist');
+    cy.get('.pinnedObjects').find('[data-test=processmaker-modeler-end-event]').should('exist');
+    cy.get('.control-list > [data-test=processmaker-modeler-end-event]').should('exist');
+  }),
+  it('Should unpin element',() => {
+    // Pin a Start Event and End Event first
+    cy.get('[data-test=processmaker-modeler-start-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('[data-test=processmaker-modeler-end-event] > .pinIcon').click();
+    cy.wait(300);
+    
+    // Unpin
+    cy.get('[data-test=processmaker-modeler-start-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('.objectCategory').find('[data-test=processmaker-modeler-start-event]').should('exist');
+    if (document.getElementsByClassName('.pinnedNodes').length > 0) {
+      cy.get('.pinnedNodes').find('[data-test=processmaker-modeler-start-event]').should('not.exist');
+    } else {
+      cy.get('.node-types__container').find('.pinnedNodes').should('not.exist');
+    }
+    cy.get('.control-list > [data-test=processmaker-modeler-start-event]').should('not.exist');
+    
+    cy.get('[data-test=processmaker-modeler-end-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('.objectCategory').find('[data-test=processmaker-modeler-end-event]').should('exist');
+    if (document.getElementsByClassName('.pinnedNodes').length > 0) {
+      cy.get('.pinnedNodes').find('[data-test=processmaker-modeler-end-event]').should('not.exist');
+    } else {
+      cy.get('.node-types__container').find('.pinnedNodes').should('not.exist');
+    }
+    cy.get('.control-list > [data-test=processmaker-modeler-end-event]').should('not.exist');
+  }),
+  it('Should open and close the Explorer Rail properly', () => {
+    // Close with X icon on top
+    cy.get('.close--container').click();
+    cy.get('[data-test=body-container]').find('[data-test=explorer-rail]').should('not.exist');
+    cy.wait(300);
+    
+    // Open again
+    cy.get('.control-add').click();
+    cy.get('[data-test=body-container]').find('[data-test=explorer-rail]').should('exist');
+    cy.wait(300);
+    
+    // Close with + button on bottom rail
+    cy.get('.control-add').click();
+    cy.get('[data-test=body-container]').find('[data-test=explorer-rail]').should('not.exist');
+  });
+  it('Should close the Explorer Rail with all pinned elements and open with the same elements', () => {
+    // Pin items
+    cy.get('[data-test=processmaker-modeler-start-event] > .pinIcon').click();
+    cy.wait(300);
+    cy.get('[data-test=processmaker-modeler-end-event] > .pinIcon').click();
+    cy.wait(300);
+    
+    // Close with + button on bottom rail
+    cy.get('.control-add').click();
+    cy.wait(300);
+    cy.get('[data-test=body-container]').find('[data-test=explorer-rail]').should('not.exist');
+
+    cy.get('.control-list > [data-test=processmaker-modeler-start-event]').should('exist');
+    cy.get('.control-list > [data-test=processmaker-modeler-end-event]').should('exist');
+
+    // Open again
+    cy.get('.control-add').click();
+    cy.get('[data-test=body-container]').find('[data-test=explorer-rail]').should('exist');
+    cy.wait(300);
+    
+    cy.get('.pinnedObjects').find('[data-test=processmaker-modeler-start-event]').should('exist');
+    cy.get('.pinnedObjects').find('[data-test=processmaker-modeler-end-event]').should('exist');
+
+  });
+});

--- a/tests/e2e/specs/undoRedoControl/UndoRedoControl.spec.js
+++ b/tests/e2e/specs/undoRedoControl/UndoRedoControl.spec.js
@@ -1,6 +1,6 @@
 import { nodeTypes } from '../../support/constants';
 import {
-  dragFromSourceToDest,
+  clickAndDropElement,
   waitToRenderAllShapes,
   getGraphElements,
   getElementAtPosition,
@@ -45,7 +45,7 @@ describe('Undo/Redo control test', () => {
   it('should undo/redo adding a task', () => {
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     cy.get(undoSelector).click();
     waitToRenderAllShapes();
@@ -63,7 +63,7 @@ describe('Undo/Redo control test', () => {
   it('should undo/redo deleting a task', () => {
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     getElementAtPosition(taskPosition)
       .click()
@@ -86,7 +86,7 @@ describe('Undo/Redo control test', () => {
     const startEventPosition = { x: 150, y: 150 };
     const taskPosition = { x: 300, y: 300 };
 
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
     connectNodesWithFlow('generic-flow-button', startEventPosition, taskPosition);
 
     const initialNumberOfWaypoints = 4;
@@ -117,7 +117,7 @@ describe('Undo/Redo control test', () => {
 
   it('should undo/redo boundary timer event', () => {
     const taskPosition = { x: 200, y: 200 };
-    dragFromSourceToDest(nodeTypes.task, taskPosition);
+    clickAndDropElement(nodeTypes.task, taskPosition);
 
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
 

--- a/tests/e2e/support/BoundaryEventCommonBehaviour.js
+++ b/tests/e2e/support/BoundaryEventCommonBehaviour.js
@@ -1,7 +1,7 @@
 import {
   addNodeTypeToPaper,
   connectNodesWithFlow,
-  dragFromSourceToDest,
+  clickAndDropElement,
   getComponentsEmbeddedInShape,
   getCrownButtonForElement,
   getElementAtPosition,
@@ -37,7 +37,7 @@ function configurePool(poolPosition, nodeType, taskType, taskTypeSelector) {
 
   addNodeTypeToPaper({ x: 250, y: 250 }, nodeTypes.task, taskTypeSelector);
   setBoundaryEvent(nodeType, taskPosition, taskType);
-  dragFromSourceToDest(nodeTypes.pool, poolPosition);
+  clickAndDropElement(nodeTypes.pool, poolPosition);
 }
 
 export function CommonBoundaryEventBehaviour({ type, nodeType, eventXMLSnippet, taskType, taskTypeSelector, invalidTargets, skip = false }) {
@@ -281,7 +281,7 @@ export function CommonBoundaryEventBehaviour({ type, nodeType, eventXMLSnippet, 
       const invalidNodeTargetPosition = { x: 450, y: 150 };
 
       invalidTargets.forEach(invalidTargetNode => {
-        dragFromSourceToDest(invalidTargetNode.type, invalidNodeTargetPosition);
+        clickAndDropElement(invalidTargetNode.type, invalidNodeTargetPosition);
 
         cy.window().its('store.state.paper').then(paper => {
           const newPosition = paper.localToPagePoint(invalidNodeTargetPosition.x, invalidNodeTargetPosition.y);
@@ -329,7 +329,7 @@ export function CommonBoundaryEventBehaviour({ type, nodeType, eventXMLSnippet, 
     });
 
     it('should turn pool red when hovered over and then back to default colour when no longer over pool', () => {
-      dragFromSourceToDest(nodeTypes.pool, taskPosition);
+      clickAndDropElement(nodeTypes.pool, taskPosition);
       addNodeTypeToPaper(taskPosition, nodeTypes.task, taskTypeSelector);
       setBoundaryEvent(nodeType, taskPosition, taskType);
       getElementAtPosition(taskPosition, nodeType).then($boundaryEvent => {

--- a/tests/e2e/support/index.js
+++ b/tests/e2e/support/index.js
@@ -16,7 +16,7 @@
 // Import commands.js using ES2015 syntax:
 import './commands';
 import '@cypress/code-coverage/support';
-import { dragFromSourceToDest, waitToRenderAllShapes } from './utils';
+import { clickAndDropElement, waitToRenderAllShapes } from './utils';
 import { nodeTypes } from './constants';
 
 // Alternatively you can use CommonJS syntax:
@@ -38,7 +38,9 @@ Cypress.on('scrolled', $el => {
 
 beforeEach(() => {
   cy.loadModeler();
-  dragFromSourceToDest(nodeTypes.startEvent, { x: 150, y: 150 });
+  cy.get('.control-add').click();
+  const explorerX = 200;
+  clickAndDropElement(nodeTypes.startEvent, { x: 10 + explorerX, y: 200 });
   waitToRenderAllShapes();
   cy.get('.paper-container').click();
 });

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -92,7 +92,7 @@ export function getComponentsEmbeddedInShape($element) {
     });
 }
 
-export function clickAndDropElement(source, position) {
+export function dragFromSourceToDest(source, position) {
   cy.window().its('store.state.paper').then(paper => {
     const { tx, ty } = paper.translate();
 

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -435,3 +435,21 @@ export function selectComponentType(component, type) {
   cy.get('[data-test="'+type+'"]').click();
   cy.get('[class="btn btn-primary"]').should('be.visible').click();
 }
+
+export function clickAndDropElement(node, position) {
+  cy.window().its('store.state.paper').then(paper => {
+    const { tx, ty } = paper.translate();
+
+    cy.get('.main-paper').then($paperContainer => {
+      const { x, y } = $paperContainer[0].getBoundingClientRect();
+      const mouseEvent = { clientX: position.x + x + tx, clientY: position.y + y + ty };
+
+      cy.get(`[data-test=${node}]`).click();
+      cy.document().trigger('mousemove', mouseEvent);
+      cy.wait(300);
+      cy.get('.paper-container').trigger('mousedown', mouseEvent);
+      cy.wait(300);
+      cy.get('.paper-container').trigger('mouseup', mouseEvent);
+    });
+  });
+}

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -92,7 +92,7 @@ export function getComponentsEmbeddedInShape($element) {
     });
 }
 
-export function dragFromSourceToDest(source, position) {
+export function clickAndDropElement(source, position) {
   cy.window().its('store.state.paper').then(paper => {
     const { tx, ty } = paper.translate();
 
@@ -378,7 +378,7 @@ export function assertBoundaryEventIsCloseToTask() {
 }
 
 export function addNodeTypeToPaper(nodePosition, genericNode, nodeToSwitchTo) {
-  dragFromSourceToDest(genericNode, nodePosition);
+  clickAndDropElement(genericNode, nodePosition);
   waitToRenderAllShapes();
   cy.get(`[data-test=${nodeToSwitchTo}]`).click();
   cy.wait(300);
@@ -443,6 +443,10 @@ export function clickAndDropElement(node, position) {
     cy.get('.main-paper').then($paperContainer => {
       const { x, y } = $paperContainer[0].getBoundingClientRect();
       const mouseEvent = { clientX: position.x + x + tx, clientY: position.y + y + ty };
+      // Handle coordinates if Explorer Rail is expanded
+      if (document.querySelectorAll('[data-test=explorer-rail]')) {
+        position.x += 200;
+      }
 
       cy.get(`[data-test=${node}]`).click();
       cy.document().trigger('mousemove', mouseEvent);


### PR DESCRIPTION
## Changes
Added 2 spec files for Explorer and Click and Drop.
Changed all instances of drag and drop on e2e tests to click and drop.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8958

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
