### PR TITLE
FOUR-8959: Hamburguer - add header to the inspector panel

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -140,9 +140,10 @@ export default {
     },
   },
   methods: {
+    /**
+     * On Close even handler 
+     */
     onClose(){
-      // eslint-disable-next-line no-console
-      console.log('onClose');
       this.$emit('toggle-panels-compressed');
     },
     handleAssignmentChanges(currentValue, previousValue) {

--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -12,6 +12,14 @@
         data-test="inspector-container"
         :style="{ height: parentHeight }"
       >
+        <template #header>
+          <div class="inspector-header">
+            <div class="inspector-header-title">
+              {{ $t('Configuration') }}
+            </div>
+            <button type="button" aria-label="Close" class="close" @click="onClose">×</button>
+          </div>
+        </template>
         <vue-form-renderer
           :key="highlightedNode._modelerId"
           v-if="highlightedNode"
@@ -70,6 +78,7 @@ export default {
       config: [],
       inspectorHandler: null,
       translated: [],
+      isVisible: true,
     };
   },
   watch: {
@@ -131,6 +140,11 @@ export default {
     },
   },
   methods: {
+    onClose(){
+      // eslint-disable-next-line no-console
+      console.log('onClose');
+      this.$emit('toggle-panels-compressed');
+    },
     handleAssignmentChanges(currentValue, previousValue) {
       if (currentValue === previousValue) {
         return;

--- a/src/components/inspectors/inspector.scss
+++ b/src/components/inspectors/inspector.scss
@@ -23,5 +23,16 @@ $inspector-column-max-width: 265px;
     .inspector-font-size {
       font-size: 0.875rem;
     }
+  };
+  &-header {
+    justify-content: space-between;
+    display: flex;
+    flex-direction: row;
+    &-title {
+      flex-grow: 0;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      flex-grow: 0;
+    };
   }
 }

--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -14,7 +14,7 @@ const process = {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-process',
           },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -50,6 +50,7 @@
         :definitions="definitions"
         :processNode="processNode"
         @save-state="pushToUndoStack"
+        @toggle-panels-compressed="panelsCompressed = !panelsCompressed"
         class="inspector h-100"
         :parent-height="parentHeight"
         :canvas-drag-position="canvasDragPosition"

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -26,7 +26,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-association',
           },

--- a/src/components/nodes/baseStartEvent/index.js
+++ b/src/components/nodes/baseStartEvent/index.js
@@ -33,7 +33,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-start-event',
           },

--- a/src/components/nodes/boundaryEvent/index.js
+++ b/src/components/nodes/boundaryEvent/index.js
@@ -34,7 +34,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-boundary-event',
           },

--- a/src/components/nodes/dataInputAssociation/index.js
+++ b/src/components/nodes/dataInputAssociation/index.js
@@ -15,7 +15,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'ConfiPropertiesguration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-data-input-association',
           },

--- a/src/components/nodes/dataInputAssociation/index.js
+++ b/src/components/nodes/dataInputAssociation/index.js
@@ -15,7 +15,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'ConfiPropertiesguration',
             icon: 'cog',
             name: 'inspector-accordion-data-input-association',
           },

--- a/src/components/nodes/dataObject/index.js
+++ b/src/components/nodes/dataObject/index.js
@@ -40,7 +40,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-data-object',
           },

--- a/src/components/nodes/dataOutputAssociation/index.js
+++ b/src/components/nodes/dataOutputAssociation/index.js
@@ -15,7 +15,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'ConfiguPropertiesration',
             icon: 'cog',
             name: 'inspector-accordion-data-output-association',
           },

--- a/src/components/nodes/dataOutputAssociation/index.js
+++ b/src/components/nodes/dataOutputAssociation/index.js
@@ -15,7 +15,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'ConfiguPropertiesration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-data-output-association',
           },

--- a/src/components/nodes/dataStore/index.js
+++ b/src/components/nodes/dataStore/index.js
@@ -40,7 +40,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-data-store',
           },

--- a/src/components/nodes/endEvent/index.js
+++ b/src/components/nodes/endEvent/index.js
@@ -76,7 +76,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-end-event',
           },

--- a/src/components/nodes/eventBasedGateway/index.js
+++ b/src/components/nodes/eventBasedGateway/index.js
@@ -34,7 +34,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-event-based-gateway',
           },

--- a/src/components/nodes/exclusiveGateway/index.js
+++ b/src/components/nodes/exclusiveGateway/index.js
@@ -67,7 +67,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-exlcusive-gateway',
           },

--- a/src/components/nodes/gateway/index.js
+++ b/src/components/nodes/gateway/index.js
@@ -32,7 +32,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-gateway',
           },

--- a/src/components/nodes/inclusiveGateway/index.js
+++ b/src/components/nodes/inclusiveGateway/index.js
@@ -37,7 +37,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-inclusive-gateway-config',
           },

--- a/src/components/nodes/intermediateEvent/index.js
+++ b/src/components/nodes/intermediateEvent/index.js
@@ -34,7 +34,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-intermediate-gateway-config',
           },

--- a/src/components/nodes/intermediateMessageEvent/index.js
+++ b/src/components/nodes/intermediateMessageEvent/index.js
@@ -37,7 +37,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-intermediate-message-event',
           },

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -135,7 +135,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-intermediate-timer-config',
           },

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -41,7 +41,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-manual-task',
           },

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -26,7 +26,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-message-flow',
           },

--- a/src/components/nodes/parallelGateway/index.js
+++ b/src/components/nodes/parallelGateway/index.js
@@ -34,7 +34,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-parallel-gateway-config',
           },

--- a/src/components/nodes/pool/index.js
+++ b/src/components/nodes/pool/index.js
@@ -36,7 +36,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-pool',
           },

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -33,7 +33,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-pool-lane',
           },

--- a/src/components/nodes/scriptTask/index.js
+++ b/src/components/nodes/scriptTask/index.js
@@ -40,7 +40,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-script-task',
           },

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -66,7 +66,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-sequence-flow',
           },

--- a/src/components/nodes/serviceTask/index.js
+++ b/src/components/nodes/serviceTask/index.js
@@ -23,7 +23,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-service-task',
           },

--- a/src/components/nodes/subProcess/index.js
+++ b/src/components/nodes/subProcess/index.js
@@ -59,7 +59,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-subprocess',
           },

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -87,7 +87,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-task',
           },

--- a/src/components/nodes/textAnnotation/index.js
+++ b/src/components/nodes/textAnnotation/index.js
@@ -51,7 +51,7 @@ export default {
           container: true,
           config: {
             initiallyOpen: true,
-            label: 'Configuration',
+            label: 'Properties',
             icon: 'cog',
             name: 'inspector-accordion-text-annotation',
           },


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
inspector panel mus have a header (title and close button)
Actual behavior: 
inspector panel has not a header
## Solution
- Inspector panel header was improved
- Configuration label was updated to property

https://github.com/ProcessMaker/modeler/assets/1401911/a2e728bf-fc5b-411b-9a7a-bbc65b0954fd

## How to Test
- go to stand alone designer 
- click in the shapes or the canvas
- see the inspector panel header

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8959

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
