### PR TITLE
FOUR-8961: Hamburger - merge the inspector panel close button with the hamburger button

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -143,7 +143,7 @@ export default {
      * On Close even handler 
      */
     onClose(){
-      this.$emit('toggle-panels-compressed');
+      this.$emit('toggleInspector', false);
     },
     handleAssignmentChanges(currentValue, previousValue) {
       if (currentValue === previousValue) {

--- a/src/components/inspectors/inspectorButton/InspectorButton.vue
+++ b/src/components/inspectors/inspectorButton/InspectorButton.vue
@@ -15,17 +15,20 @@ export default {
   components: {
     InlineSvg,
   },
+  props: {
+    showInspector: {
+      type: Boolean,
+      default: true,
+    },
+  },
   data() {
     return {
-      showInspector: false,
       inspectorIcon: require('@/assets/inspector.svg'),
     };
   },
   methods: {
     toggleInspector() {
-      this.showInspector = !this.showInspector;
-
-      this.$emit('toggleInspector', this.showInspector);
+      this.$emit('toggleInspector', !this.showInspector);
     },
   },
 };

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -41,7 +41,10 @@
         <div ref="paper" data-test="paper" class="main-paper" />
       </b-col>
 
-      <InspectorButton @toggleInspector="handleToggleInspector" />
+      <InspectorButton
+        :showInspector="isOpenInspector"
+        @toggleInspector="handleToggleInspector"
+      />
 
       <InspectorPanel
         ref="inspector-panel"
@@ -52,11 +55,11 @@
         :definitions="definitions"
         :processNode="processNode"
         @save-state="pushToUndoStack"
-        @toggle-panels-compressed="panelsCompressed = !panelsCompressed"
         class="inspector h-100"
         :parent-height="parentHeight"
         :canvas-drag-position="canvasDragPosition"
         @shape-resize="shapeResize(false)"
+        @toggleInspector="handleToggleInspector"
       />
 
       <component


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
the hamburger button must work with the inspector panel close and open
Actual behavior: 
currently work isolated
## Solution
- hamburger and  inspector header close button was synchronized

## How to Test
Test the steps above
- open modeler
- click in the  hamburger button
- chick in the inspector header close button

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-8961
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
