### PR TITLE
FOUR-8794: Deselect on Pin/Unpin & Avoid selecting element on pin/unpin in filtered nodes

### DIFF
--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -61,7 +61,7 @@ export default {
           :key="object.id"
           @mouseover="showPin = true"
           @mouseleave="showPin = false"
-          @click.stop="onClickHandler($event, object)"
+          @click.self="onClickHandler($event, object)"
         >
           <img class="node-types__item__icon" :src="object.icon" :alt="$t(object.label)">
           <span>{{ $t(object.label) }}</span>

--- a/src/mixins/clickAndDrop.js
+++ b/src/mixins/clickAndDrop.js
@@ -21,12 +21,6 @@ export default {
   },
   methods: {
     onClickHandler(event, control) {
-      // Checks if another submenu was opened
-      if (this.wasClicked || !nodeTypesStore.getters.getGhostNode) {
-        this.parent = null;
-        this.selectedSubmenuItem = null;
-        this.deselect();
-      }
       this.createDraggingHelper(event, control);
       document.addEventListener('mousemove', this.setDraggingPosition);
       this.setDraggingPosition(event);


### PR DESCRIPTION
### This PR solves:
- [FOUR-8794](https://processmaker.atlassian.net/browse/FOUR-8794)
- [FOUR-8839](https://processmaker.atlassian.net/browse/FOUR-8839)
- [FOUR-8996](https://processmaker.atlassian.net/browse/FOUR-8996)
 
## Issue & Reproduction Steps

### [FOUR-8794](https://processmaker.atlassian.net/browse/FOUR-8794) Steps to Reproduce
1. Go to modeler
2. Open Explore rail 
3. Search an element on the search engine of Explorer rail
4. Click on Pin up the element

### Expected behavior: 
The mouse should not select the element when the pin-up button is pressed.
How it works without doing any search in Explorer rail.
### Actual behavior: 
After searching for an element in Explorer rail, the mouse is select the icon when you press the Pin button 

### [FOUR-8839](https://processmaker.atlassian.net/browse/FOUR-8839) Steps to Reproduce
1. Open the modeler
2. Open Explorer Rail
3. Click on control
4. Click to pin or unpin another control in the Explorer rail

### Expected behavior: 
After pin or unpin another control in Explores the first control should be cleared, and the mouse should return to normal.
### Actual behavior: 
Mouse selection is not deselected after click to pin or unpin another control in Explorer rail

### [FOUR-8996](https://processmaker.atlassian.net/browse/FOUR-8996) Steps to Reproduce
1. Go to modeler
2. Open the Explorer rail
3. Click on any element of Explorer rail
4. Click on the same element in Explorer rail 

### Expected behavior: 
If you click on the same control again the control should be cleared and the mouse should return to normal.
### Actual behavior: 
The elements are not deselected when it is pressed by a second time. 

## Solution
- In sync with @devmiguelangel, removed the logic to avoid opening other submenus and that will be fixed in another PR.
- Added `click.self` to pin buttons on the search part of Explorer.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-8794](https://processmaker.atlassian.net/browse/FOUR-8794)
- [FOUR-8839](https://processmaker.atlassian.net/browse/FOUR-8839)
- [FOUR-8996](https://processmaker.atlassian.net/browse/FOUR-8996)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8794]: https://processmaker.atlassian.net/browse/FOUR-8794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8839]: https://processmaker.atlassian.net/browse/FOUR-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8996]: https://processmaker.atlassian.net/browse/FOUR-8996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8794]: https://processmaker.atlassian.net/browse/FOUR-8794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8839]: https://processmaker.atlassian.net/browse/FOUR-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-8996]: https://processmaker.atlassian.net/browse/FOUR-8996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ