### PR TITLE
FOUR-9009 autovalidate must not be overlapped by other menus fixed

### DIFF
--- a/src/components/toolbar/toolbar.scss
+++ b/src/components/toolbar/toolbar.scss
@@ -1,7 +1,7 @@
 $toolbar-background-color: #fff;
 
 .toolbar {
-  z-index: 2;
+  z-index: 3;
   height: $toolbar-height;
   cursor: auto;
   width: 100%;

--- a/src/components/topRail/validateControl/validatePanel/validatePanel.scss
+++ b/src/components/topRail/validateControl/validatePanel/validatePanel.scss
@@ -12,7 +12,7 @@
     border: 1px solid #C4C8CC;
     border-radius: 4px;
     overflow-y: auto;
-    z-index: 1;
+    z-index: 3;
   }
 
   &-item {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Auto validate menu should not be overlaid by other menus
![image](https://github.com/ProcessMaker/modeler/assets/3604190/651093a2-7de0-4fd5-9d64-969db3f94c00)

Actual behavior: 
Auto validate menu is below the configuration menu
![image](https://github.com/ProcessMaker/modeler/assets/3604190/998f7565-6d01-4a14-8143-d56faecff7d7)

## Solution
- Fix the stack order of the validate panel

## How to Test
1. Go to the modeler
2. Open the inspector panel
3. Click on auto-validate button

## Related Tickets & Packages
[FOUR-9009](https://processmaker.atlassian.net/browse/FOUR-9009)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


 Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)

[FOUR-9009]: https://processmaker.atlassian.net/browse/FOUR-9009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ