### PR TITLE
FOUR 8507-B: pool crown options not visible

### DIFF
--- a/src/components/crown/crownButtons/addLaneAboveButton.vue
+++ b/src/components/crown/crownButtons/addLaneAboveButton.vue
@@ -14,9 +14,11 @@ import laneAboveIcon from '@/assets/lane-above.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faLaneAbove } from './icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
 
 export default {
-  components: { CrownButton },
+  components: { CrownButton, FontAwesomeIcon },
   data() {
     return {
       laneAboveIcon,

--- a/src/components/crown/crownButtons/addLaneBelowButton.vue
+++ b/src/components/crown/crownButtons/addLaneBelowButton.vue
@@ -14,9 +14,11 @@ import laneBelowIcon from '@/assets/lane-below.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faLaneBelow } from './icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
 
 export default {
-  components: { CrownButton },
+  components: { CrownButton, FontAwesomeIcon },
   data() {
     return {
       laneBelowIcon,

--- a/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
+++ b/src/components/crown/crownButtons/crownBoundaryEventDropdown.vue
@@ -45,10 +45,11 @@ import store from '@/store';
 import Node from '@/components/nodes/node';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faBoundaryEvent } from './icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 export default {
   name: 'CrownBoundaryEventDropdown',
-  components: { CrownButton },
+  components: { CrownButton, FontAwesomeIcon },
   props: {
     dropdownOpen: {
       type: Boolean,

--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -20,6 +20,7 @@ import store from '@/store';
 import { V } from 'jointjs';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faConnectElements } from './icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 
 // Don't show the magic flow button on:
 const dontShowOn = [
@@ -35,7 +36,7 @@ const dontShowOn = [
 ];
 
 export default {
-  components: { CrownButton },
+  components: { CrownButton, FontAwesomeIcon },
   props: ['node', 'moddle', 'nodeRegistry'],
   data() {
     return {

--- a/src/components/crown/crownMultiselect/crownAlign.vue
+++ b/src/components/crown/crownMultiselect/crownAlign.vue
@@ -39,8 +39,11 @@ import {
   faDistributeHorizontally,
 } from '../crownButtons/icons';
 import { get } from 'lodash';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
 
 export default {
+  components: {FontAwesomeIcon},
   props: {
     paper: Object,
     hasPools: Boolean,

--- a/src/components/crown/crownMultiselect/crownMultiselect.vue
+++ b/src/components/crown/crownMultiselect/crownMultiselect.vue
@@ -30,13 +30,15 @@ import runningInCypressTest from '@/runningInCypressTest';
 import crownAlign from './crownAlign';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faCenterVertically } from '../crownButtons/icons';
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
+
 
 export default {
   props: {
     paper: Object,
     hasPools: Boolean,
   },
-  components:{ crownAlign },
+  components:{ crownAlign, FontAwesomeIcon },
   data() {
     return {
       showAlignmentButtons: false,


### PR DESCRIPTION
## Issue & Reproduction Steps

The font-awesome-icon component is not registerd globally in PM. Now the buttons that use it are importing it


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
