### PR TITLE
 Fix error and enhance null safety in Modeler standalone (FOUR-9168)

### DIFF
--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -218,7 +218,7 @@ export default {
     },
   },
   mounted() {
-    if (this.$root.$children[0].process.is_template) {
+    if (this.$root.$children[0]?.process?.is_template) {
       const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
         return object.value === 'save-template';
       });


### PR DESCRIPTION
## Issue & Reproduction Steps

When using Modeler standalone, an error is thrown with the following stack trace:
```
Cannot read properties of undefined (reading 'is_template')
    at VueComponent.mounted (ToolBar.vue:221:1)
```

**Expected behavior:** 

Loading Modeler standalone should not throw an error related to the is_template property.

**Actual behavior**

Loading Modeler standalone throws an error related to the is_template property.

## Solution

This pull request (PR) addresses the issue by improving null safety and code readability.

Null Safety Enhancement: The conditional statement has been refactored to incorporate optional chaining (?.) when accessing the is_template property of this.$root.$children[0].process. This modification ensures that the code handles null or undefined values appropriately, reducing the possibility of errors.

## How to Test
To test the changes, follow these steps:

1. Load Modeler standalone.
2. Perform the actions that previously resulted in the error related to the is_template property.
3. Verify that the error no longer occurs.

Please review the changes and provide your feedback

## Related Tickets & Packages
-  [FOUR-9168](https://processmaker.atlassian.net/browse/FOUR-9168)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9168]: https://processmaker.atlassian.net/browse/FOUR-9168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ