### PR TITLE
add select and move test

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1234,7 +1234,8 @@ export default {
     pointerMoveHandler(event) {
       const { clientX: x, clientY: y } = event;
       if (this.isGrabbing) return;
-      if (this.dragStart && (Math.abs(x - this.dragStart.x) > 5 || Math.abs(y - this.dragStart.y) > 5)) {
+      if (!this.isSelecting && this.dragStart && (Math.abs(x - this.dragStart.x) > 5 || Math.abs(y - this.dragStart.y) > 5)) {
+        alert('dragging');
         this.isDragging = true;
         this.dragStart = null;
       } else {
@@ -1248,7 +1249,7 @@ export default {
       }
     },
     pointerUpHandler(event, cellView) {
-      if (!this.isDragging && this.dragStart) {
+      if (!this.isSelecting && !this.isDragging && this.dragStart) {
         // is clicked over the shape
         if (cellView) {
           this.$refs.selector.selectElement(cellView, event.shiftKey);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1235,7 +1235,6 @@ export default {
       const { clientX: x, clientY: y } = event;
       if (this.isGrabbing) return;
       if (!this.isSelecting && this.dragStart && (Math.abs(x - this.dragStart.x) > 5 || Math.abs(y - this.dragStart.y) > 5)) {
-        alert('dragging');
         this.isDragging = true;
         this.dragStart = null;
       } else {

--- a/tests/e2e/specs/canvasUsability/canvasSelection/SelectAndMove.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/SelectAndMove.spec.js
@@ -1,0 +1,34 @@
+import { nodeTypes } from '../../../support/constants';
+const { clickAndDropElement, getElementAtPosition, waitToRenderAllShapes } = require('../../../support/utils');
+
+describe('Click and Drop' , () => {
+  it('Elements are clicked and dropped into canvas', () => {
+    const explorerX = 200;
+    const task1Position = { x: 100 + explorerX, y: 200 };
+    clickAndDropElement(nodeTypes.task, task1Position);
+    //Step 2: Clicks and drags the mouse over the elements
+    waitToRenderAllShapes();
+    cy.get('.paper-container').click();
+    cy.get('.paper-container').trigger('mousedown', { clientX: 200, clientY: 150 });
+    cy.wait(3000);
+    cy.get('.paper-container').trigger('mousemove', { clientX: 600, clientY: 700 });
+    cy.wait(3000);
+    cy.get('.paper-container').trigger('mouseup',{ clientX: 600, clientY: 600 });
+    cy.wait(3000);
+
+    //move the elements
+    cy.get('.paper-container').trigger('mousedown', { clientX: 380, clientY: 210 });
+    cy.wait(3000);
+    cy.get('.paper-container').trigger('mousemove', { clientX: 387, clientY: 220 });
+    cy.get('.paper-container').trigger('mousemove', { clientX: 400, clientY: 400 });
+    cy.wait(3000);
+    cy.get('.paper-container').trigger('mouseup',{ clientX: 400, clientY: 400 });
+    cy.wait(3000);
+    
+    getElementAtPosition({x:410, y:410}, nodeTypes.task, 12, 100).then(($task) => {
+      const { y } = $task[0].getBoundingClientRect();
+      expect(task1Position.y).to.be.lessThan(y);
+    });
+
+  });
+});

--- a/tests/e2e/specs/canvasUsability/canvasSelection/SelectAndMove.spec.js
+++ b/tests/e2e/specs/canvasUsability/canvasSelection/SelectAndMove.spec.js
@@ -1,8 +1,8 @@
 import { nodeTypes } from '../../../support/constants';
 const { clickAndDropElement, getElementAtPosition, waitToRenderAllShapes } = require('../../../support/utils');
 
-describe('Click and Drop' , () => {
-  it('Elements are clicked and dropped into canvas', () => {
+describe('Select and Move' , () => {
+  it('Elements are selected and moved', () => {
     const explorerX = 200;
     const task1Position = { x: 100 + explorerX, y: 200 };
     clickAndDropElement(nodeTypes.task, task1Position);
@@ -10,20 +10,14 @@ describe('Click and Drop' , () => {
     waitToRenderAllShapes();
     cy.get('.paper-container').click();
     cy.get('.paper-container').trigger('mousedown', { clientX: 200, clientY: 150 });
-    cy.wait(3000);
     cy.get('.paper-container').trigger('mousemove', { clientX: 600, clientY: 700 });
-    cy.wait(3000);
     cy.get('.paper-container').trigger('mouseup',{ clientX: 600, clientY: 600 });
-    cy.wait(3000);
 
     //move the elements
     cy.get('.paper-container').trigger('mousedown', { clientX: 380, clientY: 210 });
-    cy.wait(3000);
     cy.get('.paper-container').trigger('mousemove', { clientX: 387, clientY: 220 });
     cy.get('.paper-container').trigger('mousemove', { clientX: 400, clientY: 400 });
-    cy.wait(3000);
     cy.get('.paper-container').trigger('mouseup',{ clientX: 400, clientY: 400 });
-    cy.wait(3000);
     
     getElementAtPosition({x:410, y:410}, nodeTypes.task, 12, 100).then(($task) => {
       const { y } = $task[0].getBoundingClientRect();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
add a cypress test to  select and move an element
Actual behavior: 
cypress test select and move is not working
## Solution
- improved the cypress test
- add a validation for move and mouse up handler in order to select

## How to Test
Test the steps above
- run npm serve port 8080
- run npm run open-cypress
- run the test http://localhost:8080/__/#/tests/integration/canvasUsability/canvasSelection/SelectAndMove.spec.js 
<img width="1280" alt="Screen Shot 2023-06-29 at 15 47 23" src="https://github.com/ProcessMaker/modeler/assets/1401911/2660d523-794d-46a2-9c7d-ca490bc7bac2">



## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
