### PR TITLE
FOUR-9037 hamburger button must be above of any element

### DIFF
--- a/src/components/inspectors/inspectorButton/inspectorButton.scss
+++ b/src/components/inspectors/inspectorButton/inspectorButton.scss
@@ -12,6 +12,7 @@
   border: 0 none;
   border-radius: 4px;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
+  z-index: 2;
 
   & > svg {
     fill: #44494E;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The hamburger button should not be covered by any element or modeler options

Actual behavior: 
The selection line and options are above the hamburger menu

## Solution
- Update the stack order of the hamburguer button 

## How to Test
Test the steps above

## Related Tickets & Packages
[FOUR-9037](https://processmaker.atlassian.net/browse/FOUR-9037)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9037]: https://processmaker.atlassian.net/browse/FOUR-9037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ