### PR TITLE
FOUR-8864: Elements are not deselected When these are pressing again

### DIFF
--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -50,6 +50,7 @@ export default ({
   data() {
     return {
       plusIcon: require('@/assets/railBottom/plus.svg'),
+      currentType: null,
     };
   },
   created() {
@@ -78,8 +79,9 @@ export default ({
      */
     onClickControlHandler(event, control) {
       this.selectedSubmenuItem = null;
-      this.popperType = null;
+      this.popperType = this.currentType === control.type ? null : control.type;
       this.onClickHandler(event, control);
+      this.currentType = this.popperType; 
     },
     toggleExplorer() {
       // Remove control click & drop selection when the Add button is clicked

--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -73,7 +73,7 @@ export default ({
       this.onClickHandler(data.event, data.control);
     },
     /**
-     * On click in the botton rail control handler
+     * On click on the botton rail control
      * @param {Object} event
      * @param {Object} control
      */

--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -8,7 +8,7 @@
       :class="['control-item', {'active': selectedItem && (selectedItem.type === item.type)}]"
       :id="item.id"
       :key="item.id"
-      @click.stop="onClickHandler($event, item)"
+      @click.stop="onClickControlHandler($event, item)"
       :data-test="`${item.type}-main`"
     >
       <SubmenuPopper
@@ -70,6 +70,16 @@ export default ({
       this.parent = this.selectedItem;
       this.selectedSubmenuItem = data.control.type;
       this.onClickHandler(data.event, data.control);
+    },
+    /**
+     * On click in the botton rail control handler
+     * @param {Object} event
+     * @param {Object} control
+     */
+    onClickControlHandler(event, control) {
+      this.selectedSubmenuItem = null;
+      this.popperType = null;
+      this.onClickHandler(event, control);
     },
     toggleExplorer() {
       // Remove control click & drop selection when the Add button is clicked


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
According to the Acceptance criteria to ClIck and Drop. If you click on the same control again the control should be cleared and the mouse should return to normal 
Actual behavior: 
The elements are not deselected when it is pressed by a second time. 
## Solution
-  the validation was completed for submenu
- a click in control handler was added

## How to Test
Test the steps above
- open the modeler npm run serve
- pin some controls 
- click in a control
- click again in the same control

https://github.com/ProcessMaker/modeler/assets/1401911/5d844f22-8f66-4c25-bb76-7f4dfafcb846



## Related Tickets & Packages
- [FOUR-8864](https://processmaker.atlassian.net/browse/FOUR-8864)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.



[FOUR-8864]: https://processmaker.atlassian.net/browse/FOUR-8864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ