### PR TITLE
FOUR-9013 add tooltip to the auto-validate button

### DIFF
--- a/src/components/topRail/validateControl/validateButton/ValidateButton.vue
+++ b/src/components/topRail/validateControl/validateButton/ValidateButton.vue
@@ -3,6 +3,8 @@
     type="button"
     @click.prevent="handleOpen"
     :class="['validate-button', { 'validate-button-active': isOpen }]"
+    :title="$t('Auto validate')"
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     data-cy="validate-button"
   >
     <inline-svg :src="isOpen ? validateOpenIcon : validateCloseIcon" />


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior:
The auto-validate button should have a tooltip

Actual behavior:
The auto-validate button does not have a tooltip so it is not possible therefore the function of the button is not very clear

## Solution
Add a tooltip to the auto-validate button

## How to Test
1. Open the designer
2. Move the mouse over the auto-validate button
3. The tooltip must be displayed

## Related Tickets & Packages
[FOUR-9013](https://processmaker.atlassian.net/browse/FOUR-9013)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9013]: https://processmaker.atlassian.net/browse/FOUR-9013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ