### PR TITLE
FOUR-9136 update color error to mark auto-validate errors

### DIFF
--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -2,7 +2,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import store from '@/store';
 
 const COLOR_DEFAULT = '#5096db';
-const COLOR_ERROR = '##FF0000';
+const COLOR_ERROR = '#FF0000';
 const COLOR_IN_PROGRESS = '#1572C2';
 const COLOR_IDLE = '#ced4da';
 const COLOR_COMPLETED = '#00875A';


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The elements that contain errors should be marked with a red selection after pressing auto-validate button 

Actual behavior: 
- The red selection is not marked on the elements after pressing auto-validate.
- The elements that contain issues are not marked in red  like in previous versions

## Solution
Update the error color in the highlightConfig file

## How to Test
1. Open the Process Designer
2. Click and Drag some controls into paper
3. Click on auto-validate button
4. Now, The elements with errors must be marked with a red selection

## Related Tickets & Packages
[FOUR-9136](https://processmaker.atlassian.net/browse/FOUR-9136)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9136]: https://processmaker.atlassian.net/browse/FOUR-9136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ