### PR TITLE
FOUR-8854 add scroll bar to bottom rail

### DIFF
--- a/src/components/railBottom/controls/Controls.vue
+++ b/src/components/railBottom/controls/Controls.vue
@@ -23,7 +23,7 @@
       <div
         :class="{'control-add': true, 'control-active': explorerOpen}"
         :title="$t('Add')"
-        v-b-tooltip.hover
+        v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
         @click="toggleExplorer"
       >
         <inline-svg :src="plusIcon" />
@@ -81,7 +81,7 @@ export default ({
       this.selectedSubmenuItem = null;
       this.popperType = this.currentType === control.type ? null : control.type;
       this.onClickHandler(event, control);
-      this.currentType = this.popperType; 
+      this.currentType = this.popperType;
     },
     toggleExplorer() {
       // Remove control click & drop selection when the Add button is clicked

--- a/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
+++ b/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
@@ -4,8 +4,9 @@
     trigger="clickToOpen"
     :options="{
       placement: 'top',
-      modifiers: { offset: { offset: '0,20px' } }
+      modifiers: { offset: { offset: '0,5px' }, preventOverflow: { escapeWithReference: true } }
     }"
+    :append-to-body=true
     :visible-arrow=false
     :force-show="popperType === data.type"
   >
@@ -29,7 +30,7 @@
       slot="reference"
       :alt=data.label
       :title="$t(data.label)"
-      v-b-tooltip.hover
+      v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     >
       <div class="control-submenu-options">
         <span />
@@ -41,7 +42,7 @@
   <a v-else class="control-submenu-item"
     :alt=data.label
     :title="$t(data.label)"
-    v-b-tooltip.hover
+    v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
   >
     <inline-svg :src=data.icon />
   </a>
@@ -85,7 +86,7 @@ export default ({
   flex-direction: column;
   align-items: flex-start;
   padding: 10px;
-  width: max-content;
+  width: 255px;
   left: 616px;
   background: #FFFFFF;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.1);
@@ -112,6 +113,7 @@ export default ({
     align-self: stretch;
     flex-grow: 0;
     border-radius: 4px;
+    cursor: pointer;
 
     &.active {
       background-color: #DEEBFF;

--- a/src/components/railBottom/controls/controls.scss
+++ b/src/components/railBottom/controls/controls.scss
@@ -9,6 +9,7 @@
     box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.1);
     border-radius: 8px;
     list-style: none;
+    overflow-x: auto;
   }
 
   &-item {
@@ -17,6 +18,7 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
+    min-width: 40px;
     width: 40px;
     height: 40px;
     margin-right: 12px;

--- a/src/components/railBottom/railBottom.scss
+++ b/src/components/railBottom/railBottom.scss
@@ -24,5 +24,7 @@
     align-items: center;
     column-gap: 22px;
     width: 100%;
+    padding-right: 5px;
+    overflow-x: hidden;
   }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Bottom rail should have a scroll bar to see all elements available

Actual behavior: 
Bottom rail does not have a scroll bar so it is not possible to click all buttons in the bottom rail

## Solution
Update the Bottom Rail in order to add a scroll bar to show many elements

## How to Test
1. Open the process designer
2. Click & Drag all of the possible elements from Explorer to Bottom Rail
3. An scroll bar must be displayed

## Related Tickets & Packages
[FOUR-8854](https://processmaker.atlassian.net/browse/FOUR-8854)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-8854]: https://processmaker.atlassian.net/browse/FOUR-8854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ