### PR TITLE
FOUR-9132: Search engine of Explorer rail is not reset in tabs

### DIFF
--- a/src/components/rails/explorer-rail/filterNodeTypes/filterNodeTypes.vue
+++ b/src/components/rails/explorer-rail/filterNodeTypes/filterNodeTypes.vue
@@ -18,6 +18,9 @@ export default {
         if (value.length > 0) nodeTypesStore.commit('setFilteredNodeTypes', value);
       }
     },
+    type(newValue, oldValue) {
+      this.searchTerm = oldValue === newValue ? this.searchTerm: '';
+    },
   },
   computed: {
     nodeTypes() {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Search engine should reset or clear when when it moves between tabs
Actual behavior: 
Search engine  is not reset after going to PM Block, it left to work  
## Solution
- add watch tab type, so when the tab type is distinct the search field will be cleaned

## How to Test
Test the steps above
- open modeler
- open the explorer rail
- type the word "Gateway"
- switch to the tab pmBlock
- the search field must be cleaned

https://github.com/ProcessMaker/modeler/assets/1401911/f54fc2e2-6f7e-44f9-9a64-fac3c18bf0e7


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9132
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
