### PR TITLE
FOUR-9145 | Remove ‘Save As Template’ and ‘Save as Block’ from Block Editing

### DIFF
--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -230,19 +230,15 @@ export default {
   },
   mounted() {
     const childProcess = this.$root.$children[0]?.process;
-    if (childProcess?.is_template) {
-      const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
-        return object.value === 'save-template';
-      });
+    const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
+      return object.value === 'save-template';
+    });
 
+    if (childProcess?.is_template) {
       this.ellipsisMenuActions.splice(indexOfActions, 1);
     }
 
     if (childProcess?.asset_type === 'PM_BLOCK') {
-      const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
-        return object.value === 'save-template';
-      });
-
       this.ellipsisMenuActions.splice(indexOfActions, 2);
     }
   },

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -237,6 +237,14 @@ export default {
 
       this.ellipsisMenuActions.splice(indexOfActions, 1);
     }
+
+    if (childProcess?.asset_type === 'PM_BLOCK') {
+      const indexOfActions = this.ellipsisMenuActions.findIndex(object => {
+        return object.value === 'save-template';
+      });
+
+      this.ellipsisMenuActions.splice(indexOfActions, 2);
+    }
   },
 };
 </script>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-9145](https://processmaker.atlassian.net/browse/FOUR-9145)

As a block author, I want to prevent creating additional Blocks or Templates off of the Block model, in order to limit cascading unforeseen consequences. As such, When editing a PM Block model (via the Edit PM Block link in its ellipsis menu), the modeler menu should not offer options to Save as Template nor to Save as PM Block.

# How to Test
1. Go to branch `feature/FOUR-9145` in `modeler`.
2. Go to Designer → PM Blocks → Edit PM Block
3. In the PM Block Editor, select the Ellipsis Menu. 
4. From the Ellipsis Menu, the only option that should display is 'Discard Draft'. There should not be options to 'Save as Template' or 'Save as PM Block'.

# Related Tickets & Packages
- [FOUR-7365](https://processmaker.atlassian.net/browse/FOUR-7365) | PM Blocks

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-9145]: https://processmaker.atlassian.net/browse/FOUR-9145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-7365]: https://processmaker.atlassian.net/browse/FOUR-7365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ