### PR TITLE
FOUR-9354: Crown in flows show message flow icon

### DIFF
--- a/src/components/crown/crownButtons/genericFlowButton.vue
+++ b/src/components/crown/crownButtons/genericFlowButton.vue
@@ -33,6 +33,7 @@ const dontShowOn = [
   'processmaker-modeler-terminate-end-event',
   'processmaker-modeler-text-annotation',
   'processmaker-modeler-sequence-flow',
+  'processmaker-modeler-message-flow',
 ];
 
 export default {


### PR DESCRIPTION
ci:deploy
ci:modeler:bugfix/FOUR-9354

## Issue & Reproduction Steps
    Create a process with 2 pools.

    Add a intermediate event in pool 1

    connect the event to pool 2, a message flow will be displayed (flow with dotted lines)

    Select the message flow.

 
Expected behavior: 
Message flows should not display a flow icon in the its crown

## Solution
- Excluded message flow from the nodes that can use a generic flow icon 

## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-9354](https://processmaker.atlassian.net/browse/FOUR-9354)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
