### PR TITLE
FOUR- 9365: Elements are now placed when switching from bottom controls to explorer

### DIFF
--- a/src/mixins/clickAndDrop.js
+++ b/src/mixins/clickAndDrop.js
@@ -86,6 +86,7 @@ export default {
       this.yOffset = event.clientY - sourceElement.getBoundingClientRect().top;
     },
     deselect() {
+      window.ProcessMaker.EventBus.$off('custom-pointerclick');
       document.removeEventListener('mousemove', this.setDraggingPosition);
       if (this.movedElement) {
         document.body.removeChild(this.movedElement);

--- a/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
+++ b/tests/e2e/specs/canvasUsability/cloneImprovement/VerifyThatConfigurationsWereClonedOfFormTask.spec.js
@@ -57,6 +57,7 @@ describe('Clone Improvement', () => {
     selectComponentType(selectorFormTask,'switch-to-manual-task');
 
     //Step 4: Clone the Manual Task
+    cy.wait(500);
     cy.get('[data-test="clone-button"]').click();
 
     //Validation 1: Verify that Manual was cloned


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Click an item from the Objects bar (the bottom rail). The cursor changes to place that object in the Process model.
2. Change your mind: click on the "Add" button to display the Explorer panel because the object you really want to place is not pinned. As the cursor moves to the Explorer panel, notice how the first object's cursor icon is not visible, indicating that the first object selection has been deselected.
3. Click on an unpinned object category. (This bug probably also replicates clicking a pinned category--just do so from the Explorer panel.) Notice how the object cursor's icon changes to that of the second object selected.
4. Click into the Process model to place that second item. 

Expected behavior: 
The item should be placed when clicking on the canvas.

Actual behavior: 
The item is not placed despite the cursor icon indicating that it would.

## Solution
- Added a missing line of the item placement event that indicates that a new item is being placed. When this line was missing the event would not know if the first time an element was put or not so it would not do anything until a new element was selected and placed into the canvas. 

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9365

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
