### PR TITLE
FOUR-9351: Timer control does not show any configuration option

### DIFF
--- a/src/components/inspectors/IntermediateTimer.vue
+++ b/src/components/inspectors/IntermediateTimer.vue
@@ -19,7 +19,7 @@ import DurationExpression from './DurationExpression';
 import DateTimeExpression from './DateTimeExpression';
 import CycleExpression from './CycleExpression';
 import { DateTime } from 'luxon';
-import { defaultDurationValue } from '@/components/nodes/intermediateTimerEvent';
+import { defaultDurationTimerEvent } from '@/constants';
 
 const types = {
   timeDuration: 'DurationExpression',
@@ -61,7 +61,7 @@ export default {
   methods: {
     changeType(type) {
       const defaultValue = (this.isDelayType(type) || this.isCycleType(type))
-        ? defaultDurationValue
+        ? defaultDurationTimerEvent
         : DateTime
           .local()
           .toUTC()

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -6,8 +6,7 @@ import cloneDeep from 'lodash/cloneDeep';
 import interruptingToggleConfig from '../boundaryEvent/interruptingToggleInspector';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
-
-export const defaultDurationValue = 'PT1H';
+import { defaultDurationTimerEvent } from '@/constants';
 
 export const id = 'processmaker-modeler-boundary-timer-event';
 
@@ -24,7 +23,7 @@ export default merge(cloneDeep(boundaryEventConfig), {
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {
-            body: defaultDurationValue,
+            body: defaultDurationTimerEvent,
           }),
         }),
       ],

--- a/src/components/nodes/intermediateTimerEvent/index.js
+++ b/src/components/nodes/intermediateTimerEvent/index.js
@@ -4,8 +4,8 @@ import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
 import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+import { defaultDurationTimerEvent } from '@/constants';
 
-export const defaultDurationValue = 'PT1H';
 const id = 'processmaker-modeler-intermediate-catch-timer-event';
 
 export default {
@@ -67,7 +67,7 @@ export default {
       eventDefinitions: [
         moddle.create('bpmn:TimerEventDefinition', {
           timeDuration: moddle.create('bpmn:Expression', {
-            body: defaultDurationValue,
+            body: defaultDurationTimerEvent,
           }),
         }),
       ],

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,1 @@
+export const defaultDurationTimerEvent = 'PT1H';


### PR DESCRIPTION
## Issue & Reproduction Steps
- Add a timer event to any process
- Open the inspector

Expected behavior: 
Intermediate and boundary timer events should have the "Timing Control" enabled in the Inspector.

Actual behavior: 
The timing control can't be opened

## Solution
There was a circular reference that was causing the problem. A new file with global constants is used now instead of importing the constant from the inspector component .

## How to Test
Test the steps above

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
