### PR TITLE
FOUR-9463 it is not possible to click on undo-redo buttons

### DIFF
--- a/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
+++ b/src/components/railBottom/undoRedoControl/UndoRedoControl.vue
@@ -4,7 +4,7 @@
       class="ur-button"
       data-cy="undo-control"
       :disabled="!canUndo"
-      v-b-tooltip.hover
+      v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
       :title="$t('Undo')"
       @click="undo"
     >
@@ -15,7 +15,7 @@
       class="ur-button"
       data-cy="redo-control"
       :disabled="!canRedo"
-      v-b-tooltip.hover
+      v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
       :title="$t('Redo')"
       @click="redo"
     >


### PR DESCRIPTION
## Issue & Reproduction Steps

Actual behavior: 
It's not possible to click on the Undo/Redo controls because the tooltip overlaps them

## Solution
Update tooltip attributes of the Undo/Redo controls

## How to Test
Test the steps above

## Related Tickets & Packages
[FOUR-9463](https://processmaker.atlassian.net/browse/FOUR-9463)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9463]: https://processmaker.atlassian.net/browse/FOUR-9463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ