### PR TITLE
FOUR-7834: Changed paper reference to avoid panning errors

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1391,7 +1391,7 @@ export default {
       this.pointerUpHandler(event, cellView);
     }, this);
 
-    this.$el.addEventListener('mouseenter', () => {
+    this.$refs['paper-container'].addEventListener('mouseenter', () => {
       store.commit('setClientLeftPaper', false);
     });
 
@@ -1399,7 +1399,7 @@ export default {
       this.pointerMoveHandler(event);
     });
 
-    this.$el.addEventListener('mouseleave', () => {
+    this.$refs['paper-container'].addEventListener('mouseleave', () => {
       this.paperManager.removeEventHandler('blank:pointermove');
       store.commit('setClientLeftPaper', true);
     });


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Add a task event
2. Select the Task
3. Hold down space 
4. Drag the Paper from top to bottom

Expected behavior: 
The selection should not return to the initial state after dragging the container with hold-down space.

Actual behavior: 
The selection returns to the initial state as if it were spinning.

## Solution
- Changed the reference of the event listener from Modeler component to paper-container component in order to verify if client left the paper. This made the fix possible.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7834

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
