### PR TITLE
FOUR-9514 - Inflight Process Map > The process changes position with the mouse

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1259,7 +1259,7 @@ export default {
     pointerMoveHandler(event) {
       const { clientX: x, clientY: y } = event;
       if (store.getters.isReadOnly) {
-        if (this.canvasDragPosition) {
+        if (this.canvasDragPosition && !this.clientLeftPaper) {
           this.paperManager.translate(
             event.offsetX - this.canvasDragPosition.x,
             event.offsetY - this.canvasDragPosition.y,


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create a process
2. Complete the process
3. Go to Overview
4. Drag the process

Expected behavior:
- The process should not return to the initial state after dragging the container with the mouse

Actual behavior:
- The process returns to the initial state as if it were spinning

## Solution
- Added missing condition for when the Modeler is in "read-only" mode.
  - This way, when panning and the mouse exits the paper area, the elements will NOT change position. Now, both the Overview tab and the Modeler share the same functionality.

**Overview Tab Example:**

https://github.com/ProcessMaker/modeler/assets/90741874/5ebf94fe-12b1-410d-81e5-ecec6908965c

**Modeler Example:**

https://github.com/ProcessMaker/modeler/assets/90741874/6e5fa4a7-ccb6-4d45-8d14-a97cddf20b0f

## How to Test
- You can manually test in modeler standalone.
- You can also manually test by linking modeler in Core and following the steps of above.

## Related Tickets & Packages
- [FOUR-9514](https://processmaker.atlassian.net/browse/FOUR-9514)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-9514]: https://processmaker.atlassian.net/browse/FOUR-9514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ