### PR TITLE
[FOUR-9740] Update documentation links

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -179,7 +179,7 @@ export default {
 
       if (this.isSequenceFlow(type) && this.isConnectedToGateway(definition)) {
         let helper = this.$t('Enter the expression that describes the workflow condition');
-        helper += ' <a href="https://processmaker.gitbook.io/processmaker/v/processmaker-4.3/designing-processes/expression-syntax-components" target="_blank"><i class="far fa-question-circle mr-1"></a>';
+        helper += ' <a href="https://docs.processmaker.com/designing-processes/expression-syntax-components" target="_blank"><i class="far fa-question-circle mr-1"></a>';
         const expressionConfig = {
           component: 'FormInput',
           config: {


### PR DESCRIPTION
## Story
As a ProcessMaker user, I want to access ProcessMaker documentation via the new, more friendly documentation subdomain [docs.processmaker.com.](http://docs.processmaker.com/)

## Solution
- Change all links from [https://processmaker.gitbook.io/processmaker](https://processmaker.gitbook.io/processmaker) to [https://docs.processmaker.com/](https://docs.processmaker.com/).
- Ensure all packages also have the correct links.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-9740