### PR TITLE
FOUR-9443 add events to flow anchor changes

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -139,12 +139,21 @@ export default {
       resetShapeColor(targetShape);
 
       this.shape.on('change:vertices', this.onChangeVertices);
+      this.shape.on('change:source', this.onChangeVertices);
+      this.shape.on('change:target', this.onChangeVertices);
       this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
 
       const sourceShape = this.shape.getSourceElement();
       sourceShape.embed(this.shape);
       this.$emit('set-shape-stacking', sourceShape);
+    },
+    waitForUpdateWaypoints() {
+      return new Promise(resolve => {
+        this.updateWaypoints();
+        this.updateWaypoints.flush();
+        resolve();
+      });
     },
     /**
       * On Change vertices handler
@@ -154,7 +163,8 @@ export default {
       */
     async onChangeVertices(link, vertices, options){
       if (options && options.ui) {
-        this.updateWaypoints();
+        await this.$nextTick();
+        await this.waitForUpdateWaypoints();
         await this.$nextTick();
         this.$emit('save-state');
       }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The flow anchors should hold in its place

Actual behavior: 
The flow anchors are displaced after closing and reopening a process

## Solution
Add an event listener to the source and target movement of a flow anchor

## How to Test
1. Switch to bugfix/FOUR-9443 branch in Modeler package
2. Building assets together with PM Core 
3. Create a new process or edit another one
4. Move the flow anchor (source/target)
5. The flow anchors must hold in its place after closing or publishing the process

## Related Tickets & Packages
[FOUR-9443](https://processmaker.atlassian.net/browse/FOUR-9443)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>

[FOUR-9443]: https://processmaker.atlassian.net/browse/FOUR-9443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ