### PR TITLE
Bugfix/FOUR-8714: Problem with message signals and boundary timer

### DIFF
--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -65,6 +65,9 @@ export default merge(cloneDeep(boundaryEventConfig), {
         const eventDefinitions = [
           moddle.create('bpmn:TimerEventDefinition', eventDefinition),
         ];
+
+        eventDefinitions[0].id = node.definition.get('eventDefinitions')[0].id;
+
         setNodeProp(node, 'eventDefinitions', eventDefinitions);
       } else {
         setNodeProp(node, key, value[key]);


### PR DESCRIPTION
## Issue & Reproduction Steps
Please see https://processmaker.atlassian.net/browse/FOUR-8714

The issue still reproducing after the first fix. The problem was that the node id was correctly generated with the first fix but after modify something in the inspector, that id was lost. 
To keep the id, it was added to the timer event definition in the timer boundary event in index.

To Replicate the issue:
- Import the process of the ticket
- In the modeler remove the timer boundary event and the message event
- Add the timer first and then the message event
- Select the timer and open the inspector, modify the timer control (you need to perform some change in inspector)
- Select the message boundary event and configure the message
- Save the process
- Run a new request
- Complete the first task, then select **retrieve agreement** task and complete it. After complete this task you should see only the task **After Retrieve**


## Solution
- Add generated node id to event definition

**Working video**

https://github.com/ProcessMaker/modeler/assets/90727999/e2aa39e3-5707-4ef0-8f15-6b04a01c05b8



## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-8714](https://processmaker.atlassian.net/browse/FOUR-8714)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-8714]: https://processmaker.atlassian.net/browse/FOUR-8714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ