### PR TITLE
FOUR-9993 - Add "Download" button in AI Designer to save the model as a PDF

### DIFF
--- a/src/components/railBottom/RailBottom.vue
+++ b/src/components/railBottom/RailBottom.vue
@@ -6,7 +6,7 @@
       ref="railLeftBox"
     >
       <MiniPaperControl
-        v-show="showComponent"
+        :class="{'hidden-opacity': showComponent === false}"
         :paper-manager="paperManager"
         :graph="graph"
       />

--- a/src/components/railBottom/railBottom.scss
+++ b/src/components/railBottom/railBottom.scss
@@ -28,3 +28,10 @@
     overflow-x: hidden;
   }
 }
+
+.hidden-opacity {
+    opacity: 0;
+    visibility: hidden;
+    position: absolute; 
+    pointer-events: none; 
+}


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR is part of: [Core's PR](https://github.com/ProcessMaker/processmaker/pull/5184)

## Solution
- Use a class-based method to hide the mini-paper instead of using `v-show`.
- Using `v-show / display:none;` creates a bug where a correct SVG cannot be obtained from the mini-map.
  - This CSS method provides the same functionality and allows obtaining a correct SVG to be transferred to the PDF.

## Related Tickets & Packages
- [FOUR-9993](https://processmaker.atlassian.net/browse/FOUR-9993)
- [PLAT-45](https://processmaker.atlassian.net/browse/PLAT-45)
- [Download Process Model Confluence](https://processmaker.atlassian.net/wiki/spaces/S/pages/3164569637/Download+Process+Model)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/5184)
- [Package-AI PR](https://github.com/ProcessMaker/package-ai/pull/16)

[FOUR-9993]: https://processmaker.atlassian.net/browse/FOUR-9993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLAT-45]: https://processmaker.atlassian.net/browse/PLAT-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ