### PR TITLE
FOUR-10022: Start Timer - No change of date and time allowed

### DIFF
--- a/src/components/inspectors/TimerExpression.vue
+++ b/src/components/inspectors/TimerExpression.vue
@@ -185,7 +185,7 @@ export default {
      * Parse an ISO8601 expression to get the timer configuration
      */
     parseTimerConfig(value) {
-      if (!value[0].timeCycle.body) {
+      if (!value[0]?.timeCycle?.body) {
         return;
       }
 

--- a/src/components/inspectors/WeekdaySelect.vue
+++ b/src/components/inspectors/WeekdaySelect.vue
@@ -107,6 +107,7 @@ export default {
           selected: false,
         },
       ],
+      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       cycleManager: new CycleManager(this.startDate, this.repeat, this.periodicityValue, this.selectedWeekdays, this.endDate, this.ends, this.times),
     };
   },

--- a/src/components/inspectors/WeekdaySelect.vue
+++ b/src/components/inspectors/WeekdaySelect.vue
@@ -107,7 +107,7 @@ export default {
           selected: false,
         },
       ],
-      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
+      // eslint-disable-next-line vue/no-computed-properties-in-data
       cycleManager: new CycleManager(this.startDate, this.repeat, this.periodicityValue, this.selectedWeekdays, this.endDate, this.ends, this.times),
     };
   },

--- a/src/components/inspectors/WeekdaySelect.vue
+++ b/src/components/inspectors/WeekdaySelect.vue
@@ -107,7 +107,7 @@ export default {
           selected: false,
         },
       ],
-      cycleManager: null,
+      cycleManager: new CycleManager(this.startDate, this.repeat, this.periodicityValue, this.selectedWeekdays, this.endDate, this.ends, this.times),
     };
   },
   watch: {
@@ -143,7 +143,6 @@ export default {
         foundDay.selected = true;
       }
     });
-    this.cycleManager = new CycleManager(this.startDate, this.repeat, this.periodicityValue, this.selectedWeekdays, this.endDate, this.ends, this.times);
   },
   computed: {
     repeatOnValidationError() {


### PR DESCRIPTION
## Issue & Reproduction Steps

1.   Create a new process.
2.   Add a Start Timer event.
3.   Add an End Event
4.   Connect all tasks.
5.   Change the time or date on the Start Timer Event functionality.
6.   When you click out of the event, the settings are reset to the initial ones about the Start Timer Event.

Expected behavior: 
he Start Timer Event should be able to keep the date and time change.

Actual behavior: 
The Start Timer Event, shows an erroneous behavior when making changes within the date and time.

## Solution
- Added optional chaining to access cycle body
-  Restored Cycle initialization in component data


## Related Tickets & Packages
[https://processmaker.atlassian.net/browse/FOUR-10022](https://processmaker.atlassian.net/browse/FOUR-10022)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
