### PR TITLE
FOUR-10077 Increased the width of the inspector column by 65px

### DIFF
--- a/src/components/inspectors/inspector.scss
+++ b/src/components/inspectors/inspector.scss
@@ -1,4 +1,4 @@
-$inspector-column-max-width: 265px;
+$inspector-column-max-width: 330px;
 
 .inspector-column {
   max-width: $inspector-column-max-width;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Increase the inspector width by 65px;

Actual behavior: 
The inspector was 265px wide

## Solution
- Increased the inspector width to let the datepicker breathe

## How to Test
Test the steps above
- Drag a start timer event
- Open the inspector
- Scroll down to timing controls
- The datepicker should show without constrains or looking tight

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10077

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
