### PR TITLE
FOUR-10273 UNDO & REDO is not working with connectors flows

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -145,7 +145,7 @@ export default {
       this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
 
-      this.shape.listenTo(this.paper, 'cell:mouseleave', this.storeWaypoints);
+      this.shape.listenTo(this.paper, 'link:mouseleave', this.storeWaypoints);
 
       const sourceShape = this.shape.getSourceElement();
       sourceShape.embed(this.shape);
@@ -159,15 +159,12 @@ export default {
       });
     },
     async storeWaypoints() {
-      if (this.highlighted) {
+      if (this.highlighted && !this.listeningToMouseleave) {
         this.updateWaypoints();
         await this.$nextTick();
 
-        if (!this.listeningToMouseleave) {
-          this.listeningToMouseleave = true;
-          this.$emit('save-state');
-        }
-
+        this.listeningToMouseleave = true;
+        this.$emit('save-state');
       }
     },
     /**

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -139,10 +139,14 @@ export default {
       resetShapeColor(targetShape);
 
       this.shape.on('change:vertices', this.onChangeVertices);
-      this.shape.on('change:source', this.onChangeVertices);
-      this.shape.on('change:target', this.onChangeVertices);
+      this.shape.on('change:source', this.onChangeTargets);
+      this.shape.on('change:target', this.onChangeTargets);
       this.shape.listenTo(this.sourceShape, 'change:position', this.updateWaypoints);
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
+
+      this.shape.listenTo(this.paper, 'cell:mouseleave', async() => {
+        await this.storeWaypoints();
+      });
 
       const sourceShape = this.shape.getSourceElement();
       sourceShape.embed(this.shape);
@@ -155,16 +159,26 @@ export default {
         resolve();
       });
     },
+    async storeWaypoints() {
+      await this.$nextTick();
+      await this.waitForUpdateWaypoints();
+      await this.$nextTick();
+      this.$emit('save-state');
+    },
     /**
       * On Change vertices handler
       * @param {Object} link
       * @param {Array} vertices
       * @param {Object} options
       */
+    async onChangeTargets(link, vertices, options){
+      if (options && options.ui) {
+        await this.storeWaypoints();
+      }
+    },
     async onChangeVertices(link, vertices, options){
       if (options && options.ui) {
-        await this.$nextTick();
-        await this.waitForUpdateWaypoints();
+        this.updateWaypoints();
         await this.$nextTick();
         this.$emit('save-state');
       }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
After modifying the number of the vertices inflows they should return to their initial state when pressing the UNDO button

Actual behavior: 
The generic & association flow is not working with UNDO & REDO button

## Solution
- Add a listener to the last movement of a waypoint

## How to Test
1. Create a process
2. Add generic-flow Flow
3. Add Start Event → Task Form
4. Verify the number of vertices 
5. Move the generic-flow in the start event and task form
6. Press UNDO button
7. Verify the number of vertices 
8. Add association-flow Flow
9. Add Text annotation → Start Event
10. Verify the number of vertices 
11. Move the association-flow in the text annotation and start event
12. Press UNDO button
13. Verify the number of vertices 

## Related Tickets & Packages
[FOUR-10273](https://processmaker.atlassian.net/browse/FOUR-10273)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10273]: https://processmaker.atlassian.net/browse/FOUR-10273?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ