### PR TITLE
FOUR-10505: Create client to remove elements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VUE_APP_WEBSOCKET_PROVIDER=ws://localhost:1234

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@processmaker/modeler",
   "version": "1.39.6",
   "scripts": {
-    "serve": "vue-cli-service serve",
+    "serve": "vue-cli-service serve --mode development",
     "test:unit": "vue-cli-service test:unit",
     "lint": "vue-cli-service lint --no-fix",
     "build-bundle": "vue-cli-service build --target lib --name modeler ./src/components/nodes/index.js",

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1145,7 +1145,6 @@ export default {
       });
     },
     async removeNode(node, options) {
-      debugger;
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
       } else  {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -328,7 +328,7 @@ export default {
       showInspectorButton: true,
       inspectorButtonRight: 65,
       multiplayer: null,
-      isMultiplayer: true,
+      isMultiplayer: false,
     };
   },
   watch: {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1144,11 +1144,12 @@ export default {
         this.poolTarget = null;
       });
     },
-    async removeNode(node, { removeRelationships = true } = {}) {
+    async removeNode(node, options) {
+      debugger;
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
       } else  {
-        this.removeNodeProcedure(node, removeRelationships);
+        this.removeNodeProcedure(node, options);
       }
     },
     async removeNodeProcedure(node, { removeRelationships = true } = {}) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -328,7 +328,7 @@ export default {
       showInspectorButton: true,
       inspectorButtonRight: 65,
       multiplayer: null,
-      isMultiplayer: false,
+      isMultiplayer: true,
     };
   },
   watch: {
@@ -1145,6 +1145,13 @@ export default {
       });
     },
     async removeNode(node, { removeRelationships = true } = {}) {
+      if (this.isMultiplayer) {
+        window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
+      } else  {
+        this.removeNodeProcedure(node, removeRelationships);
+      }
+    },
+    async removeNodeProcedure(node, { removeRelationships = true } = {}) {
       if (!node) {
         // already removed
         return;

--- a/src/components/nodes/node.js
+++ b/src/components/nodes/node.js
@@ -71,7 +71,7 @@ export default class Node {
   }
 
   setIds(nodeIdGenerator, id) {
-    const [nodeId, diagramId] = id ? [ id + '_di'] : nodeIdGenerator.generate();
+    const [nodeId, diagramId] = id ? [ id, id + '_di'] : nodeIdGenerator.generate();
     if (!this.id) {
       this.id = nodeId;
     }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -8,6 +8,7 @@ export default class Multiplayer {
   modeler = null;
   #nodeIdGenerator = null;
   room = null;
+  deletedItem = null;
   constructor(modeler) {
     // define document
     this.ydoc = new Y.Doc();
@@ -24,7 +25,7 @@ export default class Multiplayer {
     this.yarray = this.ydoc.getArray('count');
     // observe changes of the diagram
     this.yarray.observe(event => {
-      event.changes.delta.forEach((value) =>{
+      event.changes.delta.forEach((value) => {
         if (value.insert) {
           value.insert.forEach((value) => {
             this.createShape(value);
@@ -32,16 +33,42 @@ export default class Multiplayer {
           });
         }
       });
+      // remove nodes observer
+      event.changes.deleted.forEach((value)=>{
+        if (value.content && value.content.arr) {
+          this.removeShape(value.content.arr[0].id);
+        }
+      });
     });
     window.ProcessMaker.EventBus.$on('multiplayer-addNode', ( data ) => {
       this.addNode(data);
     });
+    window.ProcessMaker.EventBus.$on('multiplayer-removeNode', ( data ) => {
+      this.removeNode(data);
+    });
   }
   addNode(data) {
     this.yarray.push([data]);
- 
   }
   createShape(value) {
     this.modeler.handleDropProcedure(value, false);
+  }
+  removeNode(data) {
+    const index =  this.getIndex(data.definition);
+    this.yarray.delete(index, 1); // delete one element 
+  }
+  getIndex(definition) {
+    let index = -1;
+    for (const value of this.yarray) {
+      index ++;
+      if (value.id === definition.id) {
+        break ;
+      }
+    }
+    return index;
+  }
+  removeShape(nodeId) {
+    const node = this.modeler.nodes.find((element) => element.definition && element.definition.id === nodeId);
+    this.modeler.removeNodeProcedure(node, true);
   }
 }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -15,8 +15,8 @@ export default class Multiplayer {
     this.modeler = modeler;
     this.#nodeIdGenerator = getNodeIdGenerator(this.modeler.definitions);
 
-    this.room = new Room('room-' + window.ProcessMaker.modeler.process.id);
-    const wsProvider = new WebsocketProvider('ws://localhost:1234', this.room.getRoom(), this.ydoc);
+    this.room = new Room(`room-${window.ProcessMaker.modeler.process.id}`);
+    const wsProvider = new WebsocketProvider(process.env.VUE_APP_WEBSOCKET_PROVIDER, this.room.getRoom(), this.ydoc);
     wsProvider.on('status', () => {
       // todo status handler
     });

--- a/src/multiplayer/room.js
+++ b/src/multiplayer/room.js
@@ -1,4 +1,3 @@
-
 export default class Room {
   #room ='';
   constructor(name) {

--- a/src/setup/globals.js
+++ b/src/setup/globals.js
@@ -51,7 +51,7 @@ window.ProcessMaker = {
   },
   modeler: {
     process: {
-      id: 4,
+      id: 1,
     },
   },
 };

--- a/src/setup/globals.js
+++ b/src/setup/globals.js
@@ -51,7 +51,7 @@ window.ProcessMaker = {
   },
   modeler: {
     process: {
-      id: 3,
+      id: 4,
     },
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
As a developer I want a client to remove a node
Actual behavior: 
there is no a remove modeler-cli
## Solution
- remove node client was added

https://github.com/ProcessMaker/modeler/assets/1401911/e5bb0ef2-a8f3-4a5a-b214-43a0a5ebe65b


## How to Test
Test the steps above

1. npm install
2. npm run dev
3. HOST=localhost PORT=1234 npx y-websocket
4. set the property isMultiplayer to true into Modeler.vue file


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10505

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
