### PR TITLE
FOUR-10713: Change to use stringify instead of parse for JSON config

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -850,9 +850,8 @@ export default {
 
       this.removeUnsupportedElementAttributes(definition);
 
-      const config = definition.config ? JSON.parse(definition.config) : {};
+      const config = definition.config ? JSON.stringify(definition.config) : {};
       const type = config?.processKey || parser(definition, this.moddle);
-      
       const unnamedElements = ['bpmn:TextAnnotation', 'bpmn:Association', 'bpmn:DataOutputAssociation', 'bpmn:DataInputAssociation'];
       const requireName = unnamedElements.indexOf(bpmnType) === -1;
       if (requireName && !definition.get('name')) {


### PR DESCRIPTION
## Issue & Reproduction Steps
1. Create a new signal (let’s name it “example”)
2. Create a new process with a signal start event
3. Set the signal start event signal to “example”
4. Set the Request Variable input for the start signal event to “example_variable” (or whatever you like)
5. Create an end event after the signal start event and connect them
6. Save the process
7. Reload the page
8. Notice the following error: `Unexpected token ‘v’, “variable_example” is not valid JSON`

#### Download the example process:
[start_signal_request_variable_example.json.zip](https://github.com/ProcessMaker/modeler/files/12717934/start_signal_request_variable_example.json.zip)

## Expected behavior: 
Setting the “Request Variable” input for the Start Signal Event should not trigger a fatal error.

## Actual behavior: 
Setting the “Request Variable” input for the Start Signal Event causes modeler to fatally crash when loaded (after saving and refresh or loading in a new tab).

## Solution
- Change to use `JSON.stringify()` for the node config parsing instead of `JSON.parse()`

## How to Test
Reload process design page and the error should now not occur.

## Related Tickets & Packages
- [FOUR-10713](https://processmaker.atlassian.net/browse/FOUR-10713)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10713]: https://processmaker.atlassian.net/browse/FOUR-10713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ