### PR TITLE
FOUR-10728 Check if the config starts with { before JSON parse it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "jointjs": "^3.1.1",
         "js-yaml-loader": "^1.2.2",
         "lodash": "^4.17.21",
+        "lodash-contrib": "^4.1200.1",
         "luxon": "^1.21.1",
         "mocha-junit-reporter": "^2.0.0",
         "mustache": "^3.2.1",
@@ -20061,6 +20062,19 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-contrib": {
+      "version": "4.1200.1",
+      "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-4.1200.1.tgz",
+      "integrity": "sha512-5QkRLyRLjc7J3BOqkqW5BkKXVUMhvlDZ5VqDSrGJnipIIY1KsW/vs3rrIzHg3XqBO6Hibc4o8JTLhdJIHr52Wg==",
+      "dependencies": {
+        "lodash": "4.12.x"
+      }
+    },
+    "node_modules/lodash-contrib/node_modules/lodash": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
+      "integrity": "sha512-H7Y9y0h/WibZBZyt9IOEEDaNJCzmpEoUQNB6d/+sHuS6fKFWCRuYSAf5s2mfK3hYrPqHbosJI4/bv0HUf2OvVw=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -42835,6 +42849,21 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-contrib": {
+      "version": "4.1200.1",
+      "resolved": "https://registry.npmjs.org/lodash-contrib/-/lodash-contrib-4.1200.1.tgz",
+      "integrity": "sha512-5QkRLyRLjc7J3BOqkqW5BkKXVUMhvlDZ5VqDSrGJnipIIY1KsW/vs3rrIzHg3XqBO6Hibc4o8JTLhdJIHr52Wg==",
+      "requires": {
+        "lodash": "4.12.x"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.12.0.tgz",
+          "integrity": "sha512-H7Y9y0h/WibZBZyt9IOEEDaNJCzmpEoUQNB6d/+sHuS6fKFWCRuYSAf5s2mfK3hYrPqHbosJI4/bv0HUf2OvVw=="
+        }
+      }
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jointjs": "^3.1.1",
     "js-yaml-loader": "^1.2.2",
     "lodash": "^4.17.21",
+    "lodash-contrib": "^4.1200.1",
     "luxon": "^1.21.1",
     "mocha-junit-reporter": "^2.0.0",
     "mustache": "^3.2.1",

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -850,7 +850,7 @@ export default {
 
       this.removeUnsupportedElementAttributes(definition);
 
-      const config = definition.config && definition.config.startsWith('{') ? JSON.parse(definition.config) : {};
+      const config = definition.config && _.isJSON(definition.config) ? JSON.parse(definition.config) : {};
       const type = config?.processKey || parser(definition, this.moddle);
       
       const unnamedElements = ['bpmn:TextAnnotation', 'bpmn:Association', 'bpmn:DataOutputAssociation', 'bpmn:DataInputAssociation'];

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -850,7 +850,7 @@ export default {
 
       this.removeUnsupportedElementAttributes(definition);
 
-      const config = definition.config ? JSON.parse(definition.config) : {};
+      const config = definition.config && definition.config.startsWith('{') ? JSON.parse(definition.config) : {};
       const type = config?.processKey || parser(definition, this.moddle);
       
       const unnamedElements = ['bpmn:TextAnnotation', 'bpmn:Association', 'bpmn:DataOutputAssociation', 'bpmn:DataInputAssociation'];

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -150,6 +150,7 @@ import { dia } from 'jointjs';
 import boundaryEventConfig from '../nodes/boundaryEvent';
 import BpmnModdle from 'bpmn-moddle';
 import ExplorerRail from '../rails/explorer-rail/explorer';
+import { isJSON } from 'lodash-contrib';
 import pull from 'lodash/pull';
 import remove from 'lodash/remove';
 import store from '@/store';
@@ -850,7 +851,7 @@ export default {
 
       this.removeUnsupportedElementAttributes(definition);
 
-      const config = definition.config && _.isJSON(definition.config) ? JSON.parse(definition.config) : {};
+      const config = definition.config && isJSON(definition.config) ? JSON.parse(definition.config) : {};
       const type = config?.processKey || parser(definition, this.moddle);
       
       const unnamedElements = ['bpmn:TextAnnotation', 'bpmn:Association', 'bpmn:DataOutputAssociation', 'bpmn:DataInputAssociation'];


### PR DESCRIPTION
Modeler is always parsing the pm:config as a JSON string. But when a Signal Start Event is used, it uses the pm:config as string and not as a JSON.

## Issue & Reproduction Steps

- Create a process with Signal Start Event
- Set the request variable in the inspector of the signal start event
- Save the process
- When reopened it will throw the exception.

## Solution
- Validate if the pm:config is a JSON string before to parse it

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10728
- https://processmaker.atlassian.net/browse/FOUR-10713

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
