### PR TITLE
FOUR-10768: Create client for flows

### DIFF
--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -47,6 +47,7 @@ export default {
       if (cellView){
         point = V(this.paper.viewport).toLocalPoint(clientX, clientY);
       }
+      debugger;
       const comingFromDataStoreOrDataObject = this.node.isBpmnType('bpmn:DataStoreReference', 'bpmn:DataObjectReference');
 
       const dataAssociationConfig = comingFromDataStoreOrDataObject

--- a/src/components/crown/crownButtons/dataAssociationFlowButton.vue
+++ b/src/components/crown/crownButtons/dataAssociationFlowButton.vue
@@ -47,7 +47,6 @@ export default {
       if (cellView){
         point = V(this.paper.viewport).toLocalPoint(clientX, clientY);
       }
-      debugger;
       const comingFromDataStoreOrDataObject = this.node.isBpmnType('bpmn:DataStoreReference', 'bpmn:DataObjectReference');
 
       const dataAssociationConfig = comingFromDataStoreOrDataObject

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1145,9 +1145,8 @@ export default {
     async removeNode(node, options) {
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
-      } else  {
-        this.removeNodeProcedure(node, options);
       }
+      this.removeNodeProcedure(node, options);
     },
     async removeNodeProcedure(node, { removeRelationships = true } = {}) {
       if (!node) {

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -585,15 +585,21 @@ export default {
     },
     getProperties() {
       const changed = [];
-      this.selected.forEach(function(item) {
-        changed.push({
-          id: item.model.component.node.definition.id,
-          properties: {
-            clientX: item.model.get('position').x,
-            clientY: item.model.get('position').y,
-          },
+      const shapesToNotTranslate = [
+        'PoolLane',
+        'standard.Link',
+        'processmaker.components.nodes.boundaryEvent.Shape',
+      ];
+      this.selected.filter(shape => !shapesToNotTranslate.includes(shape.model.get('type')))
+        .forEach(shape => {
+          changed.push({
+            id: shape.model.component.node.definition.id,
+            properties: {
+              clientX: shape.model.get('position').x,
+              clientY: shape.model.get('position').y,
+            },
+          });
         });
-      });
       return changed;
     },
     /**

--- a/src/components/nodes/genericFlow/DataOutputAssociation.js
+++ b/src/components/nodes/genericFlow/DataOutputAssociation.js
@@ -68,17 +68,14 @@ export default class DataOutputAssociation extends DataAssociation {
     return (targetIsDataObject && dataObjectValidSources.includes(sourceType));
   }
 
-  makeFlowNode(sourceShape, targetShape, genericLink) {
+  makeFlowNode(sourceShape, targetShape, waypoint) {
     const diagram = dataOutputConfig.diagram(this.moddle);
     const dataOutputAssociation = dataOutputConfig.definition(this.moddle);
 
     dataOutputAssociation.set('sourceRef', sourceShape.component.node.definition);
     dataOutputAssociation.set('targetRef', targetShape.component.node.definition);
 
-    const start = genericLink.sourceAnchor;
-    const end = genericLink.targetAnchor;
-
-    diagram.waypoint = [start, end].map(point => this.moddle.create('dc:Point', point));
+    diagram.waypoint = waypoint.map(point => this.moddle.create('dc:Point', point));
 
     const node = new Node(
       dataOutputConfig.id,

--- a/src/components/nodes/genericFlow/Flow.js
+++ b/src/components/nodes/genericFlow/Flow.js
@@ -18,7 +18,7 @@ export default class Flow {
   }
 
   // eslint-disable-next-line no-unused-vars
-  makeFlowNode(sourceShape, targetShape, genericLink) {
+  makeFlowNode(sourceShape, targetShape, waypoint) {
     throw new Error('Best practice is to implement \'makeFlowDefinition\' in each class');
   }
 

--- a/src/components/nodes/genericFlow/MessageFlow.js
+++ b/src/components/nodes/genericFlow/MessageFlow.js
@@ -18,17 +18,14 @@ export default class MessageFlow extends Flow {
       Flow.allowOutgoingFlow(sourceConfig, sourceNode);
   }
 
-  makeFlowNode(sourceShape, targetShape, genericLink) {
+  makeFlowNode(sourceShape, targetShape, waypoint) {
     const diagram = this.nodeRegistry['processmaker-modeler-message-flow'].diagram(this.moddle);
     const messageFlowDefinition = this.nodeRegistry['processmaker-modeler-message-flow'].definition(this.moddle);
 
     messageFlowDefinition.set('sourceRef', sourceShape.component.node.definition);
     messageFlowDefinition.set('targetRef', targetShape.component.node.definition);
-
-    const start = genericLink.sourceAnchor;
-    const end = genericLink.targetAnchor;
-
-    diagram.waypoint = [start, end].map(point => this.moddle.create('dc:Point', point));
+ 
+    diagram.waypoint = waypoint.map(point => this.moddle.create('dc:Point', point));
 
     return new Node(
       'processmaker-modeler-message-flow',

--- a/src/components/nodes/genericFlow/SequenceFlow.js
+++ b/src/components/nodes/genericFlow/SequenceFlow.js
@@ -21,17 +21,14 @@ export default class SequenceFlow extends Flow {
       !DataAssociation.isADataNode(targetNode);
   }
 
-  makeFlowNode(sourceShape, targetShape, genericLink) {
+  makeFlowNode(sourceShape, targetShape, waypoint) {
     const diagram = this.nodeRegistry['processmaker-modeler-sequence-flow'].diagram(this.moddle);
     const sequenceFlowDefinition = this.nodeRegistry['processmaker-modeler-sequence-flow'].definition(this.moddle, this.$t);
 
     sequenceFlowDefinition.set('sourceRef', sourceShape.component.node.definition);
     sequenceFlowDefinition.set('targetRef', targetShape.component.node.definition);
 
-    const start = genericLink.sourceAnchor;
-    const end = genericLink.targetAnchor;
-
-    diagram.waypoint = [start, end].map(point => this.moddle.create('dc:Point', point));
+    diagram.waypoint = waypoint.map(point => this.moddle.create('dc:Point', point));
 
     if (
       sequenceFlowDefinition.sourceRef.$type === 'bpmn:ExclusiveGateway' ||

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -239,9 +239,7 @@ export default {
         if (this.updateDefinitionLinks) {
           this.updateDefinitionLinks();
         }
-        // console.log(this);
         if (this.shape.component.node.type === 'processmaker-modeler-data-input-association') {
-          // console.log(this.node);
           if (this.$parent.isMultiplayer) {
             const genericLink = this.shape.findView(this.paper);
             const waypoint =  [genericLink.sourceAnchor.toJSON(), genericLink.targetAnchor.toJSON()];

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -239,6 +239,21 @@ export default {
         if (this.updateDefinitionLinks) {
           this.updateDefinitionLinks();
         }
+        // console.log(this);
+        if (this.shape.component.node.type === 'processmaker-modeler-data-input-association') {
+          // console.log(this.node);
+          if (this.$parent.isMultiplayer) {
+            const genericLink = this.shape.findView(this.paper);
+            const waypoint =  [genericLink.sourceAnchor.toJSON(), genericLink.targetAnchor.toJSON()];
+            window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
+              type: this.shape.component.node.type,
+              id: `node_${this.$parent.nodeIdGenerator.getDefinitionNumber()}`,
+              sourceRefId: this.sourceNode.definition.id,
+              targetRefId: this.targetNode.definition.id,
+              waypoint,
+            });
+          }
+        }
 
         this.$emit('save-state');
       });

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -6,7 +6,6 @@ import { faker } from '@faker-js/faker';
 import MessageFlow from '@/components/nodes/genericFlow/MessageFlow';
 import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
 import DataOutputAssociation from '@/components/nodes/genericFlow/DataOutputAssociation';
-import DataAssociation from '@/components/nodes/genericFlow/DataAssociation';
 const BpmnFlows = [
   {
     type: 'processmaker-modeler-text-annotation',
@@ -241,7 +240,6 @@ export default class Multiplayer {
     return null; // Return null if no matching element is found
   }
   addFlow(data) {
-    console.log(data);
     const yMapNested = new Y.Map();
     this.doTransact(yMapNested, data);
     this.yArray.push([yMapNested]);
@@ -252,7 +250,6 @@ export default class Multiplayer {
     this.#nodeIdGenerator.updateCounters();
   }
   createFlow(data){
-    console.log(data);
     const { paper } = this.modeler;
     const sourceElem = this.getJointElement(paper.model, data.sourceRefId);
     const targetElem = this.getJointElement(paper.model, data.targetRefId);

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -6,6 +6,7 @@ import { faker } from '@faker-js/faker';
 import MessageFlow from '@/components/nodes/genericFlow/MessageFlow';
 import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
 import DataOutputAssociation from '@/components/nodes/genericFlow/DataOutputAssociation';
+import DataAssociation from '@/components/nodes/genericFlow/DataAssociation';
 const BpmnFlows = [
   {
     type: 'processmaker-modeler-text-annotation',
@@ -18,6 +19,10 @@ const BpmnFlows = [
   {
     type: 'processmaker-modeler-message-flow',
     factory: MessageFlow,
+  },
+  {
+    type: 'processmaker-modeler-data-input-association',
+    factory: DataOutputAssociation,
   },
 ];
 export default class Multiplayer {
@@ -149,6 +154,7 @@ export default class Multiplayer {
       'processmaker-modeler-sequence-flow',
       'processmaker-modeler-text-annotation',
       'processmaker-modeler-message-flow',
+      'processmaker-modeler-data-input-association',
     ];
     return new Promise(resolve => {
       changes.map((data) => {
@@ -235,6 +241,7 @@ export default class Multiplayer {
     return null; // Return null if no matching element is found
   }
   addFlow(data) {
+    console.log(data);
     const yMapNested = new Y.Map();
     this.doTransact(yMapNested, data);
     this.yArray.push([yMapNested]);

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -3,7 +3,23 @@ import * as Y from 'yjs';
 import { getNodeIdGenerator } from '../NodeIdGenerator';
 import Room from './room';
 import { faker } from '@faker-js/faker';
-
+import MessageFlow from '@/components/nodes/genericFlow/MessageFlow';
+import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
+import DataOutputAssociation from '@/components/nodes/genericFlow/DataOutputAssociation';
+const BpmnFlows = [
+  {
+    type: 'processmaker-modeler-text-annotation',
+    factory: DataOutputAssociation,
+  },
+  {
+    type: 'processmaker-modeler-sequence-flow',
+    factory: SequenceFlow,
+  },
+  {
+    type: 'processmaker-modeler-message-flow',
+    factory: MessageFlow,
+  },
+];
 export default class Multiplayer {
   clientIO = null;
   yDoc = null;
@@ -100,13 +116,15 @@ export default class Multiplayer {
     window.ProcessMaker.EventBus.$on('multiplayer-addNode', ( data ) => {
       this.addNode(data);
     });
-
     window.ProcessMaker.EventBus.$on('multiplayer-removeNode', ( data ) => {
       this.removeNode(data);
     });
 
     window.ProcessMaker.EventBus.$on('multiplayer-updateNodes', ( data ) => {
       this.updateNodes(data);
+    });
+    window.ProcessMaker.EventBus.$on('multiplayer-addFlow', ( data ) => {
+      this.addFlow(data);
     });
   }
   addNode(data) {
@@ -127,11 +145,19 @@ export default class Multiplayer {
     this.#nodeIdGenerator.updateCounters();
   }
   createRemoteShape(changes) {
+    const flows = [
+      'processmaker-modeler-sequence-flow',
+      'processmaker-modeler-text-annotation',
+      'processmaker-modeler-message-flow',
+    ];
     return new Promise(resolve => {
       changes.map((data) => {
-        this.createShape(data);
+        if (flows.includes(data.type)) {
+          this.createFlow(data);
+        } else {
+          this.createShape(data);
+        }
       });
-
       resolve();
     });
   }
@@ -207,5 +233,31 @@ export default class Multiplayer {
       }
     }
     return null; // Return null if no matching element is found
+  }
+  addFlow(data) {
+    const yMapNested = new Y.Map();
+    this.doTransact(yMapNested, data);
+    this.yArray.push([yMapNested]);
+    // Encode the state as an update and send it to the server
+    const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+    // Send the update to the web socket server
+    this.clientIO.emit('createElement', stateUpdate);
+    this.#nodeIdGenerator.updateCounters();
+  }
+  createFlow(data){
+    console.log(data);
+    const { paper } = this.modeler;
+    const sourceElem = this.getJointElement(paper.model, data.sourceRefId);
+    const targetElem = this.getJointElement(paper.model, data.targetRefId);
+    if (sourceElem && targetElem) {
+      const bpmnFlow = BpmnFlows.find(FlowClass => {
+        return FlowClass.type === data.type;
+      });
+      const flow = new bpmnFlow.factory(this.modeler.nodeRegistry, this.modeler.moddle, this.modeler.paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      this.modeler.addNode(actualFlow, data.id);
+    }
+    
   }
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
create a client to manage the modeler sequence flows
Actual behavior: 
n/a
## Solution
- a client to create/remove  flow was added

## How to Test
Test the steps above
- npm run serve
- up the microservice-server
- open two instances of the modeler
- after multiplayer mode was enabled create two shapes and concect

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10768

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
