### PR TITLE
FOUR-10767 element type transformation

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1143,7 +1143,9 @@ export default {
       });
     },
     async removeNode(node, options) {
-      if (this.isMultiplayer) {
+      // Check if the node is not replaced
+      if (this.isMultiplayer && !options?.isReplaced) {
+        // Emit event to server to remove node
         window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
       } else  {
         this.removeNodeProcedure(node, options);
@@ -1197,17 +1199,43 @@ export default {
       this.performSingleUndoRedoTransaction(async() => {
         await this.paperManager.performAtomicAction(async() => {
           const { x: clientX, y: clientY } = this.paper.localToClientPoint(node.diagram.bounds);
-          const newNode = await this.handleDropProcedure({
+
+          const nodeData = {
             clientX, clientY,
             control: { type: typeToReplaceWith },
             nodeThatWillBeReplaced: node,
-          });
+          };
 
-          await this.removeNode(node, { removeRelationships: false });
-          this.highlightNode(newNode);
-          this.selectNewNode(newNode);
+          if (this.isMultiplayer) {
+            // Get all node types
+            const nodeTypes = nodeTypesStore.getters.getNodeTypes;
+            // Get the new control
+            const newControl = nodeTypes.flatMap(nodeType => {
+              return nodeType.items?.filter(item => item.type === typeToReplaceWith);
+            }).filter(Boolean);
+            // If the new control is found, emit event to server to replace node
+            if (newControl.length === 1) {
+              window.ProcessMaker.EventBus.$emit('multiplayer-replaceNode', { nodeData, newControl: newControl[0] });
+            }
+          } else {
+            await this.replaceNodeProcedure(nodeData);
+          }
         });
       });
+    },
+    async replaceNodeProcedure(data, isReplaced = false) {
+      if (isReplaced) {
+        // Get the clientX and clientY from the node that will be replaced
+        const { x: clientX, y: clientY } = this.paper.localToClientPoint(data.nodeThatWillBeReplaced.diagram.bounds);
+        data.clientX = clientX;
+        data.clientY = clientY;
+      }
+
+      const newNode = await this.handleDropProcedure(data);
+
+      await this.removeNode(data.nodeThatWillBeReplaced, { removeRelationships: false, isReplaced });
+      this.highlightNode(newNode);
+      this.selectNewNode(newNode);
     },
     replaceAiNode({ node, typeToReplaceWith, assetId, assetName, redirectTo }) {
       this.performSingleUndoRedoTransaction(async() => {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -308,6 +308,7 @@ export default class Multiplayer {
       const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
       // add Nodes
       this.modeler.addNode(actualFlow, data.id);
+      this.#nodeIdGenerator.updateCounters();
     }
 
   }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -97,6 +97,17 @@ export default class Multiplayer {
       Y.applyUpdate(this.yDoc, new Uint8Array(updateDoc));
     });
 
+    // Listen for updates when an element is replaced
+    this.clientIO.on('replaceElement', async(payload) => {
+      const { updatedNode, updateDoc } = payload;
+
+      // Update the elements in the process
+      this.replaceShape(updatedNode);
+
+      // Update the element in the shared array
+      Y.applyUpdate(this.yDoc, new Uint8Array(updateDoc));
+    });
+
     window.ProcessMaker.EventBus.$on('multiplayer-addNode', ( data ) => {
       this.addNode(data);
     });
@@ -107,6 +118,10 @@ export default class Multiplayer {
 
     window.ProcessMaker.EventBus.$on('multiplayer-updateNodes', ( data ) => {
       this.updateNodes(data);
+    });
+
+    window.ProcessMaker.EventBus.$on('multiplayer-replaceNode', ({ nodeData, newControl }) => {
+      this.replaceNode(nodeData, newControl);
     });
   }
   addNode(data) {
@@ -176,6 +191,43 @@ export default class Multiplayer {
       const nodeToUpdate =  this.yArray.get(index);
       this.doTransact(nodeToUpdate, value.properties);
     });
+  }
+  replaceNode(nodeData, newControl) {
+    // Get the node to update
+    const index = this.getIndex(nodeData.nodeThatWillBeReplaced.definition.id);
+    const nodeToUpdate =  this.yArray.get(index);
+    // Update the node id in the nodeData
+    nodeData.id = `node_${this.#nodeIdGenerator.getDefinitionNumber()}`;
+    // Replace the node in the process
+    this.modeler.replaceNodeProcedure(nodeData, true);
+    // Update the node id generator
+    this.#nodeIdGenerator.updateCounters();
+    // Update the node in the shared array
+    this.yDoc.transact(() => {
+      nodeToUpdate.set('control', newControl);
+      nodeToUpdate.set('id', nodeData.id);
+    });
+
+    // Encode the state as an update and send it to the server
+    const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+
+    this.clientIO.emit('replaceElement', stateUpdate);
+  }
+  replaceShape(updatedNode) {
+    // Get the node to update
+    const node = this.getNodeById(updatedNode.oldNodeId);
+    // Update the node id in the nodeData
+    const nodeData = {
+      clientX: updatedNode.clientX,
+      clientY: updatedNode.clientY,
+      control: { type: updatedNode.control.type },
+      nodeThatWillBeReplaced: node,
+      id: updatedNode.id,
+    };
+
+    // Replace the node in the process
+    this.modeler.replaceNodeProcedure(nodeData, true);
+    this.#nodeIdGenerator.updateCounters();
   }
   doTransact(yMapNested, data) {
     this.yDoc.transact(() => {


### PR DESCRIPTION
## Issue & Reproduction Steps

## Solution
- Transformation of element types in multiplayer mode

## Related Tickets & Packages
[FOUR-10767](https://processmaker.atlassian.net/browse/FOUR-10767)

## How to Test
Test the steps above

1. Run the microservice-realtime server
2. Run two instances of the modeler to enable the multiplayer mode
3. Click & Drop an element
4. Change the type of this element

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10767]: https://processmaker.atlassian.net/browse/FOUR-10767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ