### PR TITLE
FOUR-10809: Integrate collaborative modeler to CORE

### DIFF
--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -48,7 +48,7 @@ export default class Multiplayer {
     this.room = new Room(`room-${window.ProcessMaker.modeler.process.id}`);
 
     // Connect to websocket server
-    this.clientIO = io(window.Processmaker.multiplayer.host, { transports: ['websocket', 'polling']});
+    this.clientIO = io(window.ProcessMaker.multiplayer.host, { transports: ['websocket', 'polling']});
 
     this.clientIO.on('connect', () => {
       // Join the room

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -48,7 +48,7 @@ export default class Multiplayer {
     this.room = new Room(`room-${window.ProcessMaker.modeler.process.id}`);
 
     // Connect to websocket server
-    this.clientIO = io(process.env.VUE_APP_WEBSOCKET_PROVIDER, { transports: ['websocket', 'polling']});
+    this.clientIO = io(window.Processmaker.multiplayer.host, { transports: ['websocket', 'polling']});
 
     this.clientIO.on('connect', () => {
       // Join the room

--- a/src/setup/globals.js
+++ b/src/setup/globals.js
@@ -33,6 +33,9 @@ window.ProcessMaker = {
   navbar: {
     alerts: [],
   },
+  multiplayer:{
+    host: process.env.VUE_APP_WEBSOCKET_PROVIDER,
+  },
   EventBus: new Vue(),
   apiClient: axios,
   alert(msg, variant, showValue = 60, stayNextScreen = false) {
@@ -54,4 +57,5 @@ window.ProcessMaker = {
       id: 1,
     },
   },
+  
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
PM require support for multiplayer

## Solution
- add two environment variables.
[collaborative in core.webm](https://github.com/ProcessMaker/modeler/assets/1401911/be674cc0-7dea-4927-bdb1-02e783d2bdac)

## How to Test
-  add the variables to .env file
`VUE_APP_WEBSOCKET_PROVIDER=socket.io
VUE_APP_WEBSOCKET_PROVIDER_URL=ws://<websocket_ip>:<websocket_port>`

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10809

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next