### PR TITLE
Bugfix/FOUR-10943: Sequence flows disappears when using the AI element

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1276,6 +1276,8 @@ export default {
           await this.removeNode(node, { removeRelationships: false });
           this.highlightNode(newNode);
           this.selectNewNode(newNode);
+          await this.pushToUndoStack();
+          await this.$nextTick();
           this.saveBpmn(redirectTo, newNode.id);
         });
       });


### PR DESCRIPTION
## Issue & Reproduction Steps

- Login
- Create or modify a process
- Add an AI assistant element
- Connect the ai assistant to some element
- Select the AI assistant and choose one option (i.e. Screen from text)
- After redirect to screen builder save
- You are going to be redirected back to the process in modeler

Expected behavior: 
Sequence flows should be saved correctly

Actual behavior: 
Sequence flows are not saved

## Solution
- Push to the undo stack to update the state

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-10943](https://processmaker.atlassian.net/browse/FOUR-10943)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10943]: https://processmaker.atlassian.net/browse/FOUR-10943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ