### PR TITLE
FOUR-10769: Create client for container type node (pool, lane)

### DIFF
--- a/src/components/crown/utils.js
+++ b/src/components/crown/utils.js
@@ -62,15 +62,16 @@ export function removeNodeAssociations(node, modeler) {
 
 export function removeBoundaryEvents(graph, node, removeNode) {
   const nodeShape = graph.getCells().find(el => el.component && el.component.node === node);
-
-  nodeShape.getEmbeddedCells({ deep: true })
-    .filter(cell => {
-      return cell.component && cell.component.node.isBpmnType('bpmn:BoundaryEvent');
-    })
-    .forEach(boundaryEventShape => {
-      graph.getConnectedLinks(boundaryEventShape).forEach(shape => removeNode(shape.component.node));
-      removeNode(boundaryEventShape.component.node);
-    });
+  if (nodeShape) {
+    nodeShape.getEmbeddedCells({ deep: true })
+      .filter(cell => {
+        return cell.component && cell.component.node.isBpmnType('bpmn:BoundaryEvent');
+      })
+      .forEach(boundaryEventShape => {
+        graph.getConnectedLinks(boundaryEventShape).forEach(shape => removeNode(shape.component.node));
+        removeNode(boundaryEventShape.component.node);
+      });
+  }
 }
 
 export function removeOutgoingAndIncomingRefsToFlow(node){

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1046,6 +1046,12 @@ export default {
       diagram.bounds.y = data.y;
       const newNode = this.createNode(data.type, definition, diagram);
       await this.addNode(newNode, data.id, true);
+      await this.$nextTick();
+      await this.paperManager.awaitScheduledUpdates();
+      //});
+      if (this.autoValidate) {
+        this.validateBpmnDiagram();
+      }
     },
     
     async handleDrop(data) {
@@ -1193,6 +1199,7 @@ export default {
         addNodeToProcess(node, targetProcess);
 
         this.planeElements.push(node.diagram);
+        this.multiplayerHook(node, false);
         store.commit('addNode', node);
         this.poolTarget = null;
       });

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1259,7 +1259,7 @@ export default {
               window.ProcessMaker.EventBus.$emit('multiplayer-replaceNode', { nodeData, newControl: newControl[0].type });
             }
           } else {
-            await this.replaceNodeProcedure(nodeData);
+            await this.replaceNodeProcedure(nodeData, true);
           }
         });
       });

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -531,12 +531,7 @@ export default {
     },
     getElementByNodeId(id) {
       const cells = this.paper.model.getCells();
-      for (const cell of cells) {
-        if (cell.component && cell.component.id === id) {
-          return cell;
-        }
-      }
-      return null; // Return null if no matching element is found
+      return cells.find((cell) => cell.component && cell.component.id === id);
     },
     async close() {
       this.$emit('close');
@@ -1112,9 +1107,9 @@ export default {
         'processmaker-modeler-sequence-flow',
         'processmaker-modeler-association',
         'processmaker-modeler-data-input-association',
-        'processmaker-modeler-data-output-association',
+        'processmaker-modeler-data-input-association',
       ];
-      const flowTypes =[
+      const flowTypes = [
         'processmaker-modeler-sequence-flow',
         'processmaker-modeler-message-flow',
       ];
@@ -1132,7 +1127,7 @@ export default {
             id: node.definition.id,
             isAddingLaneAbove: true,
           };
-          if (node.pool && node.pool.component) {
+          if (node?.pool?.component) {
             defaultData['poolId'] = node.pool.component.id;
           }
           window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1110,6 +1110,9 @@ export default {
         'processmaker-modeler-lane',
         'processmaker-modeler-generic-flow',
         'processmaker-modeler-sequence-flow',
+        'processmaker-modeler-association',
+        'processmaker-modeler-data-input-association',
+        'processmaker-modeler-data-output-association',
       ];
       const flowTypes =[
         'processmaker-modeler-sequence-flow',

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -529,6 +529,15 @@ export default {
         return this.paper.findViewByModel(shape);
       });
     },
+    getElementByNodeId(id) {
+      const cells = this.paper.model.getCells();
+      for (const cell of cells) {
+        if (cell.component && cell.component.id === id) {
+          return cell;
+        }
+      }
+      return null; // Return null if no matching element is found
+    },
     async close() {
       this.$emit('close');
     },
@@ -1035,21 +1044,17 @@ export default {
         control,
       });
     },
-    handleDrop(data) {
-      const { clientX, clientY, control } = data;
-      if (this.isMultiplayer) {
-        window.ProcessMaker.EventBus.$emit('multiplayer-addNode', {
-          clientX,
-          clientY,
-          control,
-          id: `node_${this.nodeIdGenerator.getDefinitionNumber()}`,
-        });
-      } else  {
-        this.handleDropProcedure(data);
-      }
+    async addRemoteNode(data){
+      const definition = this.nodeRegistry[data.type].definition(this.moddle, this.$t);
+      const diagram = this.nodeRegistry[data.type].diagram(this.moddle);
+      diagram.bounds.x = data.x;
+      diagram.bounds.y = data.y;
+      const newNode = this.createNode(data.type, definition, diagram);
+      await this.addNode(newNode, data.id, true);
     },
-    async handleDropProcedure(data, selected=true) {
-      const { clientX, clientY, control, nodeThatWillBeReplaced, id } = data;
+    
+    async handleDrop(data) {
+      const { clientX, clientY, control, nodeThatWillBeReplaced } = data;
       this.validateDropTarget({ clientX, clientY, control });
       if (!this.allowDrop) {
         return;
@@ -1068,11 +1073,10 @@ export default {
       if (newNode.isBpmnType('bpmn:BoundaryEvent')) {
         this.setShapeCenterUnderCursor(diagram);
       }
-      if (selected) {
-        this.highlightNode(newNode);
-      }
 
-      await this.addNode(newNode, id, selected);
+      this.highlightNode(newNode);
+
+      await this.addNode(newNode);
       if (!nodeThatWillBeReplaced) {
         return;
       }
@@ -1101,7 +1105,32 @@ export default {
       const view = newNodeComponent.shapeView;
       await this.$refs.selector.selectElement(view);
     },
-    async addNode(node, id = null, selected = true) {
+    multiplayerHook(node, fromClient) {
+      const blackList = [
+        'processmaker-modeler-lane',
+        'processmaker-modeler-generic-flow',
+        'processmaker-modeler-sequence-flow',
+      ];
+      if (!this.isMultiplayer) {
+        return;
+      }
+      if (!blackList.includes(node.type) && !fromClient) {
+        const defaultData = {
+          x: node.diagram.bounds.x,
+          y: node.diagram.bounds.y,
+          height: node.diagram.bounds.height,
+          width: node.diagram.bounds.width,
+          type: node.type,
+          id: node.definition.id,
+          isAddingLaneAbove: true,
+        };
+        if (node.pool && node.pool.component) {
+          defaultData['poolId'] = node.pool.component.id;
+        }
+        window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
+      }
+    },
+    async addNode(node, id = null, fromClient = false) {
       if (!node.pool) {
         node.pool = this.poolTarget;
       }
@@ -1111,6 +1140,9 @@ export default {
       node.setIds(this.nodeIdGenerator, id);
 
       this.planeElements.push(node.diagram);
+      // add multiplayer logic as a hook
+      this.multiplayerHook(node, fromClient);
+
       store.commit('addNode', node);
       this.poolTarget = null;
 
@@ -1126,7 +1158,7 @@ export default {
       ].includes(node.type)) {
         return;
       }
-      if (selected) {
+      if (!fromClient) {
         // Select the node after it has been added to the store (does not apply to flows)
         this.selectNewNode(node);
       }
@@ -1207,10 +1239,10 @@ export default {
     replaceNode({ node, typeToReplaceWith }) {
       this.performSingleUndoRedoTransaction(async() => {
         await this.paperManager.performAtomicAction(async() => {
-          const { x: clientX, y: clientY } = this.paper.localToClientPoint(node.diagram.bounds);
+          const { x, y } = node.diagram.bounds;
 
           const nodeData = {
-            clientX, clientY,
+            x, y,
             control: { type: typeToReplaceWith },
             nodeThatWillBeReplaced: node,
           };
@@ -1224,7 +1256,7 @@ export default {
             }).filter(Boolean);
             // If the new control is found, emit event to server to replace node
             if (newControl.length === 1) {
-              window.ProcessMaker.EventBus.$emit('multiplayer-replaceNode', { nodeData, newControl: newControl[0] });
+              window.ProcessMaker.EventBus.$emit('multiplayer-replaceNode', { nodeData, newControl: newControl[0].type });
             }
           } else {
             await this.replaceNodeProcedure(nodeData);
@@ -1240,7 +1272,7 @@ export default {
         data.clientY = clientY;
       }
 
-      const newNode = await this.handleDropProcedure(data);
+      const newNode = await this.handleDrop(data);
 
       await this.removeNode(data.nodeThatWillBeReplaced, { removeRelationships: false, isReplaced });
       this.highlightNode(newNode);
@@ -1250,7 +1282,7 @@ export default {
       this.performSingleUndoRedoTransaction(async() => {
         await this.paperManager.performAtomicAction(async() => {
           const { x: clientX, y: clientY } = this.paper.localToClientPoint(node.diagram.bounds);
-          const newNode = await this.handleDropProcedure({
+          const newNode = await this.handleDrop({
             clientX, clientY,
             control: { type: typeToReplaceWith },
             nodeThatWillBeReplaced: node,

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1048,7 +1048,6 @@ export default {
       await this.addNode(newNode, data.id, true);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
-      //});
       if (this.autoValidate) {
         this.validateBpmnDiagram();
       }

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1111,23 +1111,37 @@ export default {
         'processmaker-modeler-generic-flow',
         'processmaker-modeler-sequence-flow',
       ];
+      const flowTypes =[
+        'processmaker-modeler-sequence-flow',
+      ];
       if (!this.isMultiplayer) {
         return;
       }
-      if (!blackList.includes(node.type) && !fromClient) {
-        const defaultData = {
-          x: node.diagram.bounds.x,
-          y: node.diagram.bounds.y,
-          height: node.diagram.bounds.height,
-          width: node.diagram.bounds.width,
-          type: node.type,
-          id: node.definition.id,
-          isAddingLaneAbove: true,
-        };
-        if (node.pool && node.pool.component) {
-          defaultData['poolId'] = node.pool.component.id;
+      if (!fromClient) {
+        if (!blackList.includes(node.type) && !flowTypes.includes(node.type)) {
+          const defaultData = {
+            x: node.diagram.bounds.x,
+            y: node.diagram.bounds.y,
+            height: node.diagram.bounds.height,
+            width: node.diagram.bounds.width,
+            type: node.type,
+            id: node.definition.id,
+            isAddingLaneAbove: true,
+          };
+          if (node.pool && node.pool.component) {
+            defaultData['poolId'] = node.pool.component.id;
+          }
+          window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
         }
-        window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
+        if (flowTypes.includes(node.type)) {
+          window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
+            id: node.definition.id,
+            type: node.type,
+            sourceRefId: node.definition.sourceRef.id,
+            targetRefId: node.definition.targetRef.id,
+            waypoint: node.diagram.waypoint,
+          });
+        }
       }
     },
     async addNode(node, id = null, fromClient = false) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1113,6 +1113,7 @@ export default {
       ];
       const flowTypes =[
         'processmaker-modeler-sequence-flow',
+        'processmaker-modeler-message-flow',
       ];
       if (!this.isMultiplayer) {
         return;

--- a/src/components/nodes/genericFlow/genericFlow.vue
+++ b/src/components/nodes/genericFlow/genericFlow.vue
@@ -109,17 +109,6 @@ export default {
       const flow = new bpmnFlow.factory(this.nodeRegistry, this.moddle, this.paper);
       const genericLink = this.shape.findView(this.paper);
       const waypoint =  [genericLink.sourceAnchor.toJSON(), genericLink.targetAnchor.toJSON()];
-      // Multiplayer hook
-      if (this.$parent.isMultiplayer) {
-        window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
-          type: bpmnFlow.type,
-          id: `node_${this.$parent.nodeIdGenerator.getDefinitionNumber()}`,
-          sourceRefId: this.sourceNode.definition.id,
-          targetRefId: this.targetNode.definition.id,
-          waypoint,
-        });
-      }
-
       this.$emit('replace-generic-flow', {
         actualFlow: flow.makeFlowNode(this.sourceShape, this.target, waypoint),
         genericFlow: this.node,

--- a/src/components/nodes/messageFlow/index.js
+++ b/src/components/nodes/messageFlow/index.js
@@ -2,6 +2,9 @@ import component from './messageFlow.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
+import MessageFlow from '@/components/nodes/genericFlow/MessageFlow';
+
 import { id } from '@/components/nodes/messageFlow/config';
 
 export default {
@@ -42,4 +45,17 @@ export default {
       ],
     },
   ],
+  async multiplayerClient(modeler, data) {
+    const { paper } = modeler;
+    const sourceElem = modeler.getElementByNodeId( data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId( data.targetRefId);
+    if (sourceElem && targetElem) {
+      const flow = new MessageFlow(modeler.nodeRegistry, modeler.moddle, paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      modeler.addNode(actualFlow, data.id, true);
+      const nodeIdereator = getNodeIdGenerator(modeler.definitions);
+      nodeIdereator.updateCounters();
+    }
+  },
 };

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -155,6 +155,7 @@ export default {
       if (element.component.node.type !== laneId && toPool.component.laneSet) {
         toPool.component.updateLaneChildren();
       }
+      this.$emit('set-shape-stacking', element.component.shape);
     },
 
     moveElement(element, toPool) {

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -179,7 +179,7 @@ export default {
       this.shape.unembed(element);
       toPool.component.addToPool(element);
     },
-    async addLane(emitMultiplayer =  true) {
+    async addLane(emitMultiplayer = true) {
       /* A Lane element must be contained in a LaneSet element.
          * Get the current laneSet element or create a new one. */
 
@@ -201,8 +201,8 @@ export default {
 
       lanes.push(this.pushNewLane());
 
-      await Promise.all(lanes).
-        then((val) => {
+      await Promise.all(lanes)
+        .then((val) => {
           if (emitMultiplayer && this.$parent.isMultiplayer) {
             window.ProcessMaker.EventBus.$emit('multiplayer-addLanes', val);
           }
@@ -217,7 +217,7 @@ export default {
       const laneSet = this.moddle.create('bpmn:LaneSet');
       this.laneSet = laneSet;
       const generator = this.nodeIdGenerator;
-      const [laneSetId] =  id ? id : generator.generate();
+      const [laneSetId] =  id ?? generator.generate();
       this.laneSet.set('id', laneSetId);
       this.containingProcess.get('laneSets').push(laneSet);
     },

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -148,12 +148,13 @@ export default {
       /* Remove references to the element from the current process */
       pull(this.containingProcess.get('flowElements'), elementDefinition);
 
-      toPool.component.containingProcess.get('flowElements').push(elementDefinition);
-      this.moveEmbeddedElements(element, toPool);
-
       element.component.node.pool = toPool;
+    
       this.shape.unembed(element);
       toPool.component.shape.embed(element);
+      if (element.component.node.type !== laneId && toPool.component.laneSet) {
+        toPool.component.updateLaneChildren();
+      }
     },
 
     moveElement(element, toPool) {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -3,6 +3,9 @@ import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
 import { id } from '@/components/nodes/poolLane/config';
+import Node from '@/components/nodes/node';
+import { elementShouldHaveFlowNodeRef } from '@/components/nodes/pool/poolUtils';
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
 
 export default {
   id,
@@ -49,4 +52,37 @@ export default {
       ],
     },
   ],
+
+  async multiplayerClient(modeler, data) {
+    const pool = modeler.getElementByNodeId(data.poolId);
+    const definition = modeler.moddle.create('bpmn:Lane', {
+      name: data.name,
+    });
+    if (!pool.component.laneSet && pool.component.createLaneSet) {
+      pool.component.createLaneSet([data.laneSetId]);
+      /* If there are currently elements in the pool, add them to the first lane */
+      pool.component.shape.getEmbeddedCells().filter(element => elementShouldHaveFlowNodeRef(element))
+        .forEach(element => {
+          definition.get('flowNodeRef').push(element.component.node.definition);
+        });
+      const nodeIdereator = getNodeIdGenerator(modeler.definitions);
+      nodeIdereator.updateCounters();
+    }
+    const diagram = modeler.moddle.create('bpmndi:BPMNShape', {
+      bounds: modeler.moddle.create('dc:Bounds', {
+        height: data.height,
+        width: data.width,
+        x: data.x,
+        y: data.y,
+      }),
+    });
+    const node = new Node(
+      data.type,
+      definition,
+      diagram,
+    );
+    await modeler.addNode(node, data.id, true);
+    modeler.setShapeStacking(pool.component.shape);
+
+  },
 };

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -2,6 +2,8 @@ import component from './sequenceFlow.vue';
 import nameConfigSettings from '@/components/inspectors/nameConfigSettings';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
+import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
 
 export const id = 'processmaker-modeler-sequence-flow';
 
@@ -82,4 +84,17 @@ export default {
       ],
     },
   ],
+  async multiplayerClient(modeler, data) {
+    const { paper } = modeler;
+    const sourceElem = modeler.getElementByNodeId( data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId( data.targetRefId);
+    if (sourceElem && targetElem) {
+      const flow = new SequenceFlow(modeler.nodeRegistry, modeler.moddle, paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      modeler.addNode(actualFlow, data.id);
+      const nodeIdereator = getNodeIdGenerator(modeler.definitions);
+      nodeIdereator.updateCounters();
+    }
+  },
 };

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -92,7 +92,7 @@ export default {
       const flow = new SequenceFlow(modeler.nodeRegistry, modeler.moddle, paper);
       const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
       // add Nodes
-      modeler.addNode(actualFlow, data.id);
+      modeler.addNode(actualFlow, data.id, true);
       const nodeIdereator = getNodeIdGenerator(modeler.definitions);
       nodeIdereator.updateCounters();
     }

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -86,8 +86,8 @@ export default {
   ],
   async multiplayerClient(modeler, data) {
     const { paper } = modeler;
-    const sourceElem = modeler.getElementByNodeId( data.sourceRefId);
-    const targetElem = modeler.getElementByNodeId( data.targetRefId);
+    const sourceElem = modeler.getElementByNodeId(data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId(data.targetRefId);
     if (sourceElem && targetElem) {
       const flow = new SequenceFlow(modeler.nodeRegistry, modeler.moddle, paper);
       const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -239,20 +239,6 @@ export default {
         if (this.updateDefinitionLinks) {
           this.updateDefinitionLinks();
         }
-        if (this.shape.component.node.type === 'processmaker-modeler-data-input-association') {
-          if (this.$parent.isMultiplayer) {
-            const genericLink = this.shape.findView(this.paper);
-            const waypoint =  [genericLink.sourceAnchor.toJSON(), genericLink.targetAnchor.toJSON()];
-            window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
-              type: this.shape.component.node.type,
-              id: `node_${this.$parent.nodeIdGenerator.getDefinitionNumber()}`,
-              sourceRefId: this.sourceNode.definition.id,
-              targetRefId: this.targetNode.definition.id,
-              waypoint,
-            });
-          }
-        }
-
         this.$emit('save-state');
       });
 

--- a/src/mixins/poolLaneCrownConfig.js
+++ b/src/mixins/poolLaneCrownConfig.js
@@ -14,7 +14,6 @@ export default {
       ].includes(this.node.type)) {
         return;
       }
-
       if (this.node.pool) {
         if (!this.graph.getCell(this.node.pool)) {
           this.node.pool = this.graph.getElements().find(element => {
@@ -27,7 +26,6 @@ export default {
         if (this.isLane) {
           this.configureLaneInParentPool();
         }
-
         return;
       }
 

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -153,23 +153,26 @@ export default class Multiplayer {
   }
   removeNode(data) {
     const index =  this.getIndex(data.definition.id);
-    this.removeShape(data);
-    this.yArray.delete(index, 1); // delete one element
-
-    // Encode the state as an update and send it to the server
-    const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
-    // Send the update to the web socket server
-    this.clientIO.emit('removeElement', stateUpdate);
+    if (index >= 0) {
+      this.removeShape(data);
+      this.yArray.delete(index, 1); // delete one element
+      // Encode the state as an update and send it to the server
+      const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+      // Send the update to the web socket server
+      this.clientIO.emit('removeElement', stateUpdate);
+    }
   }
   getIndex(id) {
     let index = -1;
+    let found = false;
     for (const value of this.yArray) {
       index ++;
       if (value.get('id') === id) {
+        found = true;
         break ;
       }
     }
-    return index;
+    return found ? index: -1;
   }
   getNodeById(nodeId) {
     const node = this.modeler.nodes.find((element) => element.definition && element.definition.id === nodeId);

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -248,10 +248,6 @@ export default class Multiplayer {
     const { paper } = this.modeler;
     const element = this.modeler.getElementByNodeId(data.id);
     const newPool = this.modeler.getElementByNodeId(data.poolId);
-    // validate if the parent pool was updated
-    if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
-      element.component.node.pool.component.moveElementRemote(element, newPool);
-    }
     // Update the element's position attribute
     element.resize(
       /* Add labelWidth to ensure elements don't overlap with the pool label */
@@ -260,7 +256,13 @@ export default class Multiplayer {
     );
     element.set('position', { x: data.x, y: data.y });
     // Trigger a rendering of the element on the paper
-    paper.findViewByModel(element).update();
+    await paper.findViewByModel(element).update();
+    // validate if the parent pool was updated
+    await element.component.$nextTick();
+    await this.modeler.paperManager.awaitScheduledUpdates();
+    if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
+      element.component.node.pool.component.moveElementRemote(element, newPool);
+    }
   }
  
   addFlow(data) {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -172,7 +172,7 @@ export default class Multiplayer {
         break ;
       }
     }
-    return found ? index: -1;
+    return found ? index : -1;
   }
   getNodeById(nodeId) {
     const node = this.modeler.nodes.find((element) => element.definition && element.definition.id === nodeId);
@@ -312,7 +312,7 @@ export default class Multiplayer {
       width: lane.diagram.bounds.width,
       height: lane.diagram.bounds.height,
       poolId: lane.pool.component.node.definition.id,
-      laneSetId:  lane.pool.component.laneSet.id,
+      laneSetId: lane.pool.component.laneSet.id,
     };
     return data;
   }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -3,27 +3,6 @@ import * as Y from 'yjs';
 import { getNodeIdGenerator } from '../NodeIdGenerator';
 import Room from './room';
 import { faker } from '@faker-js/faker';
-import MessageFlow from '@/components/nodes/genericFlow/MessageFlow';
-import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
-import DataOutputAssociation from '@/components/nodes/genericFlow/DataOutputAssociation';
-const BpmnFlows = [
-  {
-    type: 'processmaker-modeler-text-annotation',
-    factory: DataOutputAssociation,
-  },
-  {
-    type: 'processmaker-modeler-sequence-flow',
-    factory: SequenceFlow,
-  },
-  {
-    type: 'processmaker-modeler-message-flow',
-    factory: MessageFlow,
-  },
-  {
-    type: 'processmaker-modeler-data-input-association',
-    factory: DataOutputAssociation,
-  },
-];
 export default class Multiplayer {
   clientIO = null;
   yDoc = null;
@@ -140,12 +119,13 @@ export default class Multiplayer {
     window.ProcessMaker.EventBus.$on('multiplayer-addFlow', ( data ) => {
       this.addFlow(data);
     });
+
+    window.ProcessMaker.EventBus.$on('multiplayer-addLanes', ( lanes ) => {
+      this.addLaneNodes(lanes);
+    });
   }
   addNode(data) {
-    // Add the new element to the process
-    this.createShape(data);
     // Add the new element to the shared array
-    // this.yArray.push([data]);
     const yMapNested = new Y.Map();
     this.doTransact(yMapNested, data);
     this.yArray.push([yMapNested]);
@@ -154,24 +134,19 @@ export default class Multiplayer {
     // Send the update to the web socket server
     this.clientIO.emit('createElement', stateUpdate);
   }
-  createShape(value) {
-    this.modeler.handleDropProcedure(value, false);
+  createShape(value){
+    if (this.modeler.nodeRegistry[value.type] && this.modeler.nodeRegistry[value.type].multiplayerClient) {
+      this.modeler.nodeRegistry[value.type].multiplayerClient(this.modeler, value);
+    } else {
+      this.modeler.addRemoteNode(value);
+    }
     this.#nodeIdGenerator.updateCounters();
+    
   }
   createRemoteShape(changes) {
-    const flows = [
-      'processmaker-modeler-sequence-flow',
-      'processmaker-modeler-text-annotation',
-      'processmaker-modeler-message-flow',
-      'processmaker-modeler-data-input-association',
-    ];
     return new Promise(resolve => {
       changes.map((data) => {
-        if (flows.includes(data.type)) {
-          this.createFlow(data);
-        } else {
-          this.createShape(data);
-        }
+        this.createShape(data);     
       });
       resolve();
     });
@@ -215,7 +190,8 @@ export default class Multiplayer {
     data.forEach((value) => {
       const index = this.getIndex(value.id);
       const nodeToUpdate =  this.yArray.get(index);
-      this.doTransact(nodeToUpdate, value.properties);
+      const updateData = value.poolId ? { ...value.properties, ...{ poolId: value.poolId } } : value.properties;
+      this.doTransact(nodeToUpdate, updateData);
     });
   }
   replaceNode(nodeData, newControl) {
@@ -224,13 +200,11 @@ export default class Multiplayer {
     const nodeToUpdate =  this.yArray.get(index);
     // Update the node id in the nodeData
     nodeData.id = `node_${this.#nodeIdGenerator.getDefinitionNumber()}`;
-    // Replace the node in the process
-    this.modeler.replaceNodeProcedure(nodeData, true);
     // Update the node id generator
     this.#nodeIdGenerator.updateCounters();
     // Update the node in the shared array
     this.yDoc.transact(() => {
-      nodeToUpdate.set('control', newControl);
+      nodeToUpdate.set('type', newControl);
       nodeToUpdate.set('id', nodeData.id);
     });
 
@@ -240,13 +214,14 @@ export default class Multiplayer {
     this.clientIO.emit('updateElement', { updateDoc: stateUpdate, isReplaced: true });
   }
   replaceShape(updatedNode) {
+    const { x: clientX, y: clientY } = this.modeler.paper.localToClientPoint(updatedNode);
     // Get the node to update
     const node = this.getNodeById(updatedNode.oldNodeId);
     // Update the node id in the nodeData
     const nodeData = {
-      clientX: updatedNode.clientX,
-      clientY: updatedNode.clientY,
-      control: { type: updatedNode.control.type },
+      clientX,
+      clientY,
+      control: { type: updatedNode.type },
       nodeThatWillBeReplaced: node,
       id: updatedNode.id,
     };
@@ -269,23 +244,25 @@ export default class Multiplayer {
     // Send the update to the web socket server
     this.clientIO.emit('updateElement', { updateDoc: stateUpdate, isReplaced: false });
   }
-  updateShapes(data) {
+  async updateShapes(data) {
     const { paper } = this.modeler;
-    const element = this.getJointElement(paper.model, data.id);
+    const element = this.modeler.getElementByNodeId(data.id);
+    const newPool = this.modeler.getElementByNodeId(data.poolId);
+    // validate if the parent pool was updated
+    if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
+      element.component.node.pool.component.moveElementRemote(element, newPool);
+    }
     // Update the element's position attribute
-    element.set('position', { x:data.clientX, y:data.clientY });
+    element.resize(
+      /* Add labelWidth to ensure elements don't overlap with the pool label */
+      data.width,
+      data.height,
+    );
+    element.set('position', { x: data.x, y: data.y });
     // Trigger a rendering of the element on the paper
     paper.findViewByModel(element).update();
   }
-  getJointElement(graph, targetValue) {
-    const cells = graph.getCells();
-    for (const cell of cells) {
-      if (cell.component.id === targetValue) {
-        return cell;
-      }
-    }
-    return null; // Return null if no matching element is found
-  }
+ 
   addFlow(data) {
     const yMapNested = new Y.Map();
     this.doTransact(yMapNested, data);
@@ -296,20 +273,49 @@ export default class Multiplayer {
     this.clientIO.emit('createElement', stateUpdate);
     this.#nodeIdGenerator.updateCounters();
   }
-  createFlow(data){
-    const { paper } = this.modeler;
-    const sourceElem = this.getJointElement(paper.model, data.sourceRefId);
-    const targetElem = this.getJointElement(paper.model, data.targetRefId);
-    if (sourceElem && targetElem) {
-      const bpmnFlow = BpmnFlows.find(FlowClass => {
-        return FlowClass.type === data.type;
-      });
-      const flow = new bpmnFlow.factory(this.modeler.nodeRegistry, this.modeler.moddle, this.modeler.paper);
-      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
-      // add Nodes
-      this.modeler.addNode(actualFlow, data.id);
-      this.#nodeIdGenerator.updateCounters();
-    }
 
+  addLaneNodes(lanes) {
+    const pool = this.getPool(lanes);
+    window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', [{
+      id: pool.component.node.definition.id,
+      properties: {
+        x: pool.component.node.diagram.bounds.x,
+        y: pool.component.node.diagram.bounds.y,
+        height: pool.component.node.diagram.bounds.height,
+        width: pool.component.node.diagram.bounds.width,
+        isAddingLaneAbove: pool.isAddingLaneAbove,
+      },
+    }]);
+    this.yDoc.transact(() => {
+      lanes.forEach((lane) => {
+        const yMapNested = new Y.Map();
+        const data =  this.prepareLaneData(lane);
+        this.doTransact(yMapNested, data);
+        this.yArray.push([yMapNested]);
+        const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+        this.clientIO.emit('createElement', stateUpdate);
+      });
+    });
   }
+  prepareLaneData(lane) {
+    const data = {
+      type: lane.type,
+      id: lane.definition.id,
+      name: lane.definition.name,
+      x: lane.diagram.bounds.x,
+      y: lane.diagram.bounds.y,
+      width: lane.diagram.bounds.width,
+      height: lane.diagram.bounds.height,
+      poolId: lane.pool.component.node.definition.id,
+      laneSetId:  lane.pool.component.laneSet.id,
+    };
+    return data;
+  }
+  getPool(lanes) {
+    if (lanes && lanes.length > 0) {
+      return lanes[0].pool;
+    } 
+    return false;
+  }
+
 }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -294,7 +294,7 @@ export default class Multiplayer {
     this.yDoc.transact(() => {
       lanes.forEach((lane) => {
         const yMapNested = new Y.Map();
-        const data =  this.prepareLaneData(lane);
+        const data = this.prepareLaneData(lane);
         this.doTransact(yMapNested, data);
         this.yArray.push([yMapNested]);
         const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -114,7 +114,7 @@ export default new Vuex.Store({
   },
   actions: {
     getUserPinnedObjects({ commit }) {
-      if (!window.ProcessMaker.user) {
+      if (window.ProcessMaker?.user?.id === 'standalone') {
         // For standalone version of Modeler
         const pinnedNodes = localStorage.pinnedNodes ? JSON.parse(localStorage.pinnedNodes) : [] ;
         pinnedNodes.forEach(node => {
@@ -137,7 +137,7 @@ export default new Vuex.Store({
     addUserPinnedObject({ commit, state }, pinnedNode) {
       commit('setPinnedNodes', pinnedNode);
       const pinnedNodes = state.pinnedNodeTypes;
-      if (!window.ProcessMaker.user) {
+      if (window.ProcessMaker?.user?.id === 'standalone') {
         // For standalone version of Modeler
         localStorage.pinnedNodes = JSON.stringify(pinnedNodes);
         return;
@@ -152,7 +152,7 @@ export default new Vuex.Store({
     removeUserPinnedObject({ commit, state }, nodeToUnpin) {
       commit('setUnpinNode', nodeToUnpin);
       const pinnedNodes = state.pinnedNodeTypes;
-      if (!window.ProcessMaker.user) {
+      if (window.ProcessMaker?.user?.id === 'standalone') {
         // For standalone version of Modeler
         localStorage.pinnedNodes = JSON.stringify(pinnedNodes);
         return;

--- a/src/setup/globals.js
+++ b/src/setup/globals.js
@@ -4,6 +4,7 @@ import MockAdapter from 'axios-mock-adapter';
 import mockProcesses from './mockProcesses.json';
 import mockSignals from './mockSignals.json';
 import mockProcessSvg from './mockProcessSvg';
+import { faker } from '@faker-js/faker';
 
 axios.defaults.baseURL = 'https://bpm4.local.processmaker.com/api/1.0/';
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
@@ -56,6 +57,11 @@ window.ProcessMaker = {
     process: {
       id: 1,
     },
+  },
+  user: {
+    id: 'standalone',
+    fullName:  faker.person.fullName(),
+    avatar: null,
   },
   
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
have a client for pool/lane nodes
Actual behavior: 
n/a
## Solution
- add create a pool by client.
- add remove a pool by client
- add create a lane by client.
- add remove a lane by client.
- add mode a pool by client.

[pool-lane.webm](https://github.com/ProcessMaker/modeler/assets/1401911/135443f3-3426-41e6-b4a2-f6c856f9baf5)

## How to Test
Test the steps above
1. `npm install`
2. run` npm run serve` (standalone)
3. configure and up the collaborative microservice 
4. draw pool/ lane


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-10769

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

