### PR TITLE
FOUR-10808: improve loadXML() to support multiplayer

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -945,7 +945,6 @@ export default {
     },
     async createNodeAsync(type, definition, diagram) {
       const node =  this.createNode(type, definition, diagram);
-      console.log('el nodo', node);
       if (!this.isMultiplayer) {
         store.commit('addNode', node);
       }

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -941,7 +941,57 @@ export default {
     },
     async createNodeAsync(type, definition, diagram) {
       const node =  this.createNode(type, definition, diagram);
-      store.commit('addNode', node);
+      if (!this.isMultiplayer) {
+        store.commit('addNode', node);
+      }
+      else {
+        this.loadNodeForMultiplayer(node, definition, diagram);
+      }
+    },
+    loadNodeForMultiplayer(node, definition, diagram) {
+      if (node.type === 'processmaker-modeler-task' ||
+          node.type === 'processmaker-modeler-start-event' ||
+          node.type === 'processmaker-modeler-end-event'
+      ) {
+        let ctrl =  {
+          id: node.definition.id,
+          type: node.type,
+          label: node.name,
+          bpmnType: [node.definition.$type],
+          items: [ ],
+        };
+
+        window.ProcessMaker.EventBus.$emit('multiplayer-addNode', {
+          clientX: node.diagram.bounds.x,
+          clientY: node.diagram.bounds.y,
+          control: ctrl,
+          id: node.definition.id,
+        });
+      }
+
+      if (node.type === 'processmaker-modeler-sequence-flow') {
+        const nodeData = {
+          type: node.type,
+          id: node.definition.id,
+          sourceRefId: node.definition.sourceRef.id,
+          targetRefId: node.definition.targetRef.id,
+          waypoint: node.diagram.waypoint,
+        };
+        const initTime = new Date();
+        const sourceCheck = window.setInterval(() => {
+          const sourceExists = (node?.definition.$parent?.flowElements ?? [])
+            .find(n => n.id === nodeData.sourceRefId) ?? false;
+          const targetExists = (node?.definition.$parent?.flowElements ?? [])
+            .find(n => n.id === nodeData.targetRefId) ?? false;
+          const timelapse = new Date() - initTime;
+          if ((sourceExists && targetExists) || timelapse > 2000) {
+            this.multiplayer.createFlow(nodeData);
+            window.clearInterval(sourceCheck);
+          }
+        }, 100);
+
+        window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', nodeData);
+      }
     },
     createNode(type, definition, diagram) {
       if (Node.isTimerType(type)) {
@@ -1658,6 +1708,7 @@ export default {
         try {
           const multiplayer = new Multiplayer(this);
           multiplayer.init();
+          this.multiplayer = multiplayer;
         } catch (error) {
           console.warn('Could not initialize multiplayer', error);
         }

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -945,10 +945,10 @@ export default {
         store.commit('addNode', node);
       }
       else {
-        this.loadNodeForMultiplayer(node, definition, diagram);
+        this.loadNodeForMultiplayer(node);
       }
     },
-    loadNodeForMultiplayer(node, definition, diagram) {
+    loadNodeForMultiplayer(node) {
       if (node.type === 'processmaker-modeler-task' ||
           node.type === 'processmaker-modeler-start-event' ||
           node.type === 'processmaker-modeler-end-event'

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -953,49 +953,9 @@ export default {
       }
     },
     loadNodeForMultiplayer(node) {
-      if (node.type === 'processmaker-modeler-task' ||
-          node.type === 'processmaker-modeler-start-event' ||
-          node.type === 'processmaker-modeler-end-event'
-      ) {
-        let ctrl =  {
-          id: node.definition.id,
-          type: node.type,
-          label: node.name,
-          bpmnType: [node.definition.$type],
-          items: [ ],
-        };
-
-        window.ProcessMaker.EventBus.$emit('multiplayer-addNode', {
-          clientX: node.diagram.bounds.x,
-          clientY: node.diagram.bounds.y,
-          control: ctrl,
-          id: node.definition.id,
-        });
-      }
-
-      if (node.type === 'processmaker-modeler-sequence-flow') {
-        const nodeData = {
-          type: node.type,
-          id: node.definition.id,
-          sourceRefId: node.definition.sourceRef.id,
-          targetRefId: node.definition.targetRef.id,
-          waypoint: node.diagram.waypoint,
-        };
-        const initTime = new Date();
-        const sourceCheck = window.setInterval(() => {
-          const sourceExists = (node?.definition.$parent?.flowElements ?? [])
-            .find(n => n.id === nodeData.sourceRefId) ?? false;
-          const targetExists = (node?.definition.$parent?.flowElements ?? [])
-            .find(n => n.id === nodeData.targetRefId) ?? false;
-          const timelapse = new Date() - initTime;
-          if ((sourceExists && targetExists) || timelapse > 2000) {
-            this.multiplayer.createFlow(nodeData);
-            window.clearInterval(sourceCheck);
-          }
-        }, 100);
-
-        window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', nodeData);
-      }
+      this.multiplayerHook(node, false);
+      store.commit('addNode', node);
+      this.poolTarget = null;
     },
     createNode(type, definition, diagram) {
       if (Node.isTimerType(type)) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -945,6 +945,7 @@ export default {
     },
     async createNodeAsync(type, definition, diagram) {
       const node =  this.createNode(type, definition, diagram);
+      console.log('el nodo', node);
       if (!this.isMultiplayer) {
         store.commit('addNode', node);
       }
@@ -952,7 +953,15 @@ export default {
         this.loadNodeForMultiplayer(node);
       }
     },
-    loadNodeForMultiplayer(node) {
+    async loadNodeForMultiplayer(node) {
+      if (node.type === 'processmaker-modeler-lane') {
+        await this.addNode(node, node.definition.id, true);
+        this.nodeIdGenerator.updateCounters();
+        await this.$nextTick();
+        await this.paperManager.awaitScheduledUpdates();
+        window.ProcessMaker.EventBus.$emit('multiplayer-addLanes', [node]);
+        return;
+      }
       this.multiplayerHook(node, false);
       store.commit('addNode', node);
       this.poolTarget = null;
@@ -1062,7 +1071,7 @@ export default {
         this.validateBpmnDiagram();
       }
     },
-    
+
     async handleDrop(data) {
       const { clientX, clientY, control, nodeThatWillBeReplaced } = data;
       this.validateDropTarget({ clientX, clientY, control });


### PR DESCRIPTION
When a process BPMN is loaded, all clients are synchronized and the same process is visible to all users.

## How to Test
- Create a process BPMN with tasks and flows.
- Load it
- All clients connected to the process should see the same process.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-10808](https://processmaker.atlassian.net/browse/FOUR-10808)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
