### PR TITLE
FOUR-11062 support for creating and updating flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 /dist
 *coverage
+*screenshots
 reports
 .nyc_output
 /public/js

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1143,8 +1143,13 @@ export default {
           window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
         }
         if (this.flowTypes.includes(node.type)) {
-          const sourceRefId = node.definition.sourceRef?.id;
-          const targetRefId = node.definition.targetRef?.id;
+          let sourceRefId = node.definition.sourceRef?.id;
+          let targetRefId = node.definition.targetRef?.id;
+
+          if (node.type === 'processmaker-modeler-data-input-association') {
+            sourceRefId = Array.isArray(node.definition.sourceRef) && node.definition.sourceRef[0]?.id;
+            targetRefId = node.definition.targetRef?.$parent?.$parent.get('id');
+          }
 
           if (sourceRefId && targetRefId) {
             window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1144,8 +1144,8 @@ export default {
           window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
         }
         if (this.flowTypes.includes(node.type)) {
-          const sourceRefId = node.definition.sourceRef.id;
-          const targetRefId = node.definition.targetRef.id;
+          const sourceRefId = node.definition.sourceRef?.id;
+          const targetRefId = node.definition.targetRef?.id;
 
           if (sourceRefId && targetRefId) {
             window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -189,7 +189,7 @@ import getValidationProperties from '@/targetValidationUtils';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as processId } from '@/components/inspectors/process';
 import { id as sequenceFlowId } from '../nodes/sequenceFlow';
-import { id as associationId } from '../nodes/association';
+import { id as associationId } from '../nodes/association/associationConfig';
 import { id as messageFlowId } from '../nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '../nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '../nodes/dataInputAssociation/config';
@@ -1053,7 +1053,7 @@ export default {
         this.validateBpmnDiagram();
       }
     },
-    
+
     async handleDrop(data) {
       const { clientX, clientY, control, nodeThatWillBeReplaced } = data;
       this.validateDropTarget({ clientX, clientY, control });
@@ -1113,11 +1113,14 @@ export default {
         'processmaker-modeler-sequence-flow',
         'processmaker-modeler-association',
         'processmaker-modeler-data-input-association',
-        'processmaker-modeler-data-input-association',
+        'processmaker-modeler-data-output-association',
       ];
       const flowTypes = [
         'processmaker-modeler-sequence-flow',
         'processmaker-modeler-message-flow',
+        'processmaker-modeler-data-input-association',
+        'processmaker-modeler-data-output-association',
+        'processmaker-modeler-association',
       ];
       if (!this.isMultiplayer) {
         return;
@@ -1139,13 +1142,18 @@ export default {
           window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
         }
         if (flowTypes.includes(node.type)) {
-          window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
-            id: node.definition.id,
-            type: node.type,
-            sourceRefId: node.definition.sourceRef.id,
-            targetRefId: node.definition.targetRef.id,
-            waypoint: node.diagram.waypoint,
-          });
+          const sourceRefId = node.definition.sourceRef.id;
+          const targetRefId = node.definition.targetRef.id;
+
+          if (sourceRefId && targetRefId) {
+            window.ProcessMaker.EventBus.$emit('multiplayer-addFlow', {
+              id: node.definition.id,
+              type: node.type,
+              sourceRefId,
+              targetRefId,
+              waypoint: node.diagram.waypoint,
+            });
+          }
         }
       }
     },
@@ -1339,8 +1347,9 @@ export default {
         await this.paperManager.performAtomicAction(async() => {
           await this.highlightNode(null);
           await this.$nextTick();
-          await this.addNode(actualFlow);
           await store.commit('removeNode', genericFlow);
+          await this.$nextTick();
+          await this.addNode(actualFlow, genericFlow.definition.id);
           await this.$nextTick();
           await this.highlightNode(targetNode);
         });

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -332,6 +332,13 @@ export default {
       previewConfigs: [],
       multiplayer: null,
       isMultiplayer: false,
+      flowTypes: [
+        'processmaker-modeler-sequence-flow',
+        'processmaker-modeler-message-flow',
+        'processmaker-modeler-data-input-association',
+        'processmaker-modeler-data-output-association',
+        'processmaker-modeler-association',
+      ],
     };
   },
   watch: {
@@ -1115,18 +1122,13 @@ export default {
         'processmaker-modeler-data-input-association',
         'processmaker-modeler-data-output-association',
       ];
-      const flowTypes = [
-        'processmaker-modeler-sequence-flow',
-        'processmaker-modeler-message-flow',
-        'processmaker-modeler-data-input-association',
-        'processmaker-modeler-data-output-association',
-        'processmaker-modeler-association',
-      ];
+
       if (!this.isMultiplayer) {
         return;
       }
+
       if (!fromClient) {
-        if (!blackList.includes(node.type) && !flowTypes.includes(node.type)) {
+        if (!blackList.includes(node.type) && !this.flowTypes.includes(node.type)) {
           const defaultData = {
             x: node.diagram.bounds.x,
             y: node.diagram.bounds.y,
@@ -1141,7 +1143,7 @@ export default {
           }
           window.ProcessMaker.EventBus.$emit('multiplayer-addNode', defaultData);
         }
-        if (flowTypes.includes(node.type)) {
+        if (this.flowTypes.includes(node.type)) {
           const sourceRefId = node.definition.sourceRef.id;
           const targetRefId = node.definition.targetRef.id;
 

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -31,7 +31,7 @@ import { id as poolId } from '@/components/nodes/pool/config';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as genericFlowId } from '@/components/nodes/genericFlow/config';
 import { id as sequenceFlowId } from '@/components/nodes/sequenceFlow';
-import { id as associationId } from '@/components/nodes/association';
+import { id as associationId } from '@/components/nodes/association/associationConfig';
 import { id as messageFlowId } from '@/components/nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '@/components/nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '@/components/nodes/dataInputAssociation/config';
@@ -577,7 +577,7 @@ export default {
       await this.paperManager.awaitScheduledUpdates();
       this.overPoolStopDrag();
       this.updateSelectionBox();
-      if (this.isMultiplayer) { 
+      if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getProperties(this.selected));
       }
     },

--- a/src/components/nodes/association/AssociationFlow.js
+++ b/src/components/nodes/association/AssociationFlow.js
@@ -1,0 +1,27 @@
+import Node from '@/components/nodes/node';
+import * as associationConfig from './associationConfig';
+
+export class AssociationFlow {
+  constructor(nodeRegistry, moddle, paper) {
+    this.nodeRegistry = nodeRegistry;
+    this.moddle = moddle;
+    this.paper = paper;
+  }
+
+  makeFlowNode(sourceShape, targetShape, waypoint) {
+    const diagram = associationConfig.diagram(this.moddle);
+    const associationFlow = associationConfig.definition(this.moddle);
+
+    associationFlow.set('sourceRef', sourceShape.component.node.definition);
+    associationFlow.set('targetRef', targetShape.component.node.definition);
+
+    diagram.waypoint = waypoint.map(point => this.moddle.create('dc:Point', point));
+
+    const node = new Node(
+      associationConfig.id,
+      associationFlow,
+      diagram,
+    );
+    return node;
+  }
+}

--- a/src/components/nodes/association/associationConfig.js
+++ b/src/components/nodes/association/associationConfig.js
@@ -1,1 +1,16 @@
+export const id = 'processmaker-modeler-association';
+
+export const bpmnType = 'bpmn:Association';
+
 export const direction = { none: 'None', one: 'One', both: 'Both' };
+
+export function definition(moddle) {
+  return moddle.create(bpmnType, {
+    associationDirection: direction.none,
+    targetRef: { x: undefined, y: undefined },
+  });
+}
+
+export function diagram(moddle) {
+  return moddle.create('bpmndi:BPMNEdge');
+}

--- a/src/components/nodes/association/index.js
+++ b/src/components/nodes/association/index.js
@@ -1,22 +1,16 @@
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
 import component from './association.vue';
-import { direction } from './associationConfig';
+import { id, bpmnType, direction, definition, diagram } from './associationConfig';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
-
-export const id  = 'processmaker-modeler-association';
+import { AssociationFlow } from './AssociationFlow';
 
 export default {
   id,
   component,
-  bpmnType: 'bpmn:Association',
+  bpmnType,
   control: false,
-  definition(moddle) {
-    return moddle.create('bpmn:Association', {
-      associationDirection: `${direction.none}`,
-    });
-  },
-  diagram(moddle) {
-    return moddle.create('bpmndi:BPMNEdge');
-  },
+  definition,
+  diagram,
   inspectorConfig: [
     {
       name: 'Data Association',
@@ -53,4 +47,17 @@ export default {
       ],
     },
   ],
+  async multiplayerClient(modeler, data) {
+    const { paper } = modeler;
+    const sourceElem = modeler.getElementByNodeId(data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId(data.targetRefId);
+    if (sourceElem && targetElem) {
+      const flow = new AssociationFlow(modeler.nodeRegistry, modeler.moddle, paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      modeler.addNode(actualFlow, data.id, true);
+      const nodeIdIterator = getNodeIdGenerator(modeler.definitions);
+      nodeIdIterator.updateCounters();
+    }
+  },
 };

--- a/src/components/nodes/dataInputAssociation/DataInputAssociation.js
+++ b/src/components/nodes/dataInputAssociation/DataInputAssociation.js
@@ -1,0 +1,30 @@
+import Node from '@/components/nodes/node';
+import * as associationConfig from './config';
+import { getOrFindDataInput } from '@/components/crown/utils';
+
+export class DataInputAssociation {
+  constructor(nodeRegistry, moddle, paper) {
+    this.nodeRegistry = nodeRegistry;
+    this.moddle = moddle;
+    this.paper = paper;
+  }
+
+  makeFlowNode(sourceShape, targetShape, waypoint) {
+    const diagram = associationConfig.diagram(this.moddle);
+    const associationFlow = associationConfig.definition(this.moddle);
+
+    // When saving the BPMN, if this is not an array the sourceRef is not stored
+    const dataInput = getOrFindDataInput(this.moddle, targetShape.component.node, sourceShape.component.node.definition);
+    associationFlow.set('targetRef', dataInput);
+    associationFlow.set('sourceRef', [sourceShape.component.node.definition]);
+
+    diagram.waypoint = waypoint.map(point => this.moddle.create('dc:Point', point));
+
+    const node = new Node(
+      associationConfig.id,
+      associationFlow,
+      diagram,
+    );
+    return node;
+  }
+}

--- a/src/components/nodes/dataInputAssociation/index.js
+++ b/src/components/nodes/dataInputAssociation/index.js
@@ -1,7 +1,7 @@
 import component from './dataInputAssociation.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import * as config from './config';
-import DataOutputAssociation from '../genericFlow/DataOutputAssociation';
+import { DataInputAssociation } from './DataInputAssociation';
 import { getNodeIdGenerator } from '@/NodeIdGenerator';
 
 export default {
@@ -36,8 +36,10 @@ export default {
     const sourceElem = modeler.getElementByNodeId(data.sourceRefId);
     const targetElem = modeler.getElementByNodeId(data.targetRefId);
     if (sourceElem && targetElem) {
-      const flow = new DataOutputAssociation(modeler.nodeRegistry, modeler.moddle, paper);
+      const flow = new DataInputAssociation(modeler.nodeRegistry, modeler.moddle, paper);
       const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+
+      targetElem.component.node.definition.set('dataInputAssociations', [actualFlow.definition]);
       // add Nodes
       modeler.addNode(actualFlow, data.id, true);
       const nodeIdIterator = getNodeIdGenerator(modeler.definitions);

--- a/src/components/nodes/dataInputAssociation/index.js
+++ b/src/components/nodes/dataInputAssociation/index.js
@@ -1,6 +1,8 @@
 import component from './dataInputAssociation.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import * as config from './config';
+import DataOutputAssociation from '../genericFlow/DataOutputAssociation';
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
 
 export default {
   ...config,
@@ -29,4 +31,17 @@ export default {
       ],
     },
   ],
+  async multiplayerClient(modeler, data) {
+    const { paper } = modeler;
+    const sourceElem = modeler.getElementByNodeId(data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId(data.targetRefId);
+    if (sourceElem && targetElem) {
+      const flow = new DataOutputAssociation(modeler.nodeRegistry, modeler.moddle, paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      modeler.addNode(actualFlow, data.id, true);
+      const nodeIdIterator = getNodeIdGenerator(modeler.definitions);
+      nodeIdIterator.updateCounters();
+    }
+  },
 };

--- a/src/components/nodes/dataOutputAssociation/index.js
+++ b/src/components/nodes/dataOutputAssociation/index.js
@@ -1,6 +1,8 @@
 import component from './dataOutputAssociation.vue';
 import idConfigSettings from '@/components/inspectors/idConfigSettings';
 import * as config from './config';
+import { getNodeIdGenerator } from '@/NodeIdGenerator';
+import DataOutputAssociation from '../genericFlow/DataOutputAssociation';
 
 export default {
   ...config,
@@ -29,4 +31,17 @@ export default {
       ],
     },
   ],
+  async multiplayerClient(modeler, data) {
+    const { paper } = modeler;
+    const sourceElem = modeler.getElementByNodeId(data.sourceRefId);
+    const targetElem = modeler.getElementByNodeId(data.targetRefId);
+    if (sourceElem && targetElem) {
+      const flow = new DataOutputAssociation(modeler.nodeRegistry, modeler.moddle, paper);
+      const actualFlow = flow.makeFlowNode(sourceElem, targetElem, data.waypoint);
+      // add Nodes
+      modeler.addNode(actualFlow, data.id, true);
+      const nodeIdIterator = getNodeIdGenerator(modeler.definitions);
+      nodeIdIterator.updateCounters();
+    }
+  },
 };

--- a/src/components/nodes/genericFlow/DataOutputAssociation.js
+++ b/src/components/nodes/genericFlow/DataOutputAssociation.js
@@ -55,7 +55,7 @@ export default class DataOutputAssociation extends DataAssociation {
     const sourceIsDataObject = sourceNode.definition.$type === 'bpmn:DataObjectReference';
     const targetIsDataStore = targetNode.definition.$type === 'bpmn:DataStoreReference';
     const targetIsDataObject = targetNode.definition.$type === 'bpmn:DataObjectReference';
-    
+
     if (sourceIsDataStore && dataStoreValidTargets.includes(targetType)) {
       return true;
     }

--- a/src/components/nodes/genericFlow/genericFlow.vue
+++ b/src/components/nodes/genericFlow/genericFlow.vue
@@ -109,6 +109,7 @@ export default {
       const flow = new bpmnFlow.factory(this.nodeRegistry, this.moddle, this.paper);
       const genericLink = this.shape.findView(this.paper);
       const waypoint =  [genericLink.sourceAnchor.toJSON(), genericLink.targetAnchor.toJSON()];
+
       this.$emit('replace-generic-flow', {
         actualFlow: flow.makeFlowNode(this.sourceShape, this.target, waypoint),
         genericFlow: this.node,

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -1,6 +1,6 @@
 import { id as laneId } from '../components/nodes/poolLane/config';
 import { id as sequenceFlowId } from '../components/nodes/sequenceFlow';
-import { id as associationId } from '../components/nodes/association';
+import { id as associationId } from '../components/nodes/association/associationConfig';
 import { id as messageFlowId } from '../components/nodes/messageFlow/config';
 import { id as dataOutputAssociationFlowId } from '../components/nodes/dataOutputAssociation/config';
 import { id as dataInputAssociationFlowId } from '../components/nodes/dataInputAssociation/config';

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -164,6 +164,31 @@ export default {
         this.updateWaypoints();
         await this.$nextTick();
 
+        if (this.$parent.isMultiplayer && this.linkView) {
+          // update waypoints in multiplayer mode
+          const nodeType = this.linkView.model.component.node.type;
+          const sourceRefId = this.linkView.sourceView.model.component.node.definition.id;
+          const targetRefId = this.linkView.targetView.model.component.node.definition.id;
+
+          const changes = [
+            {
+              id: this.linkView.model.component.node.definition.id,
+              properties: {
+                type: nodeType,
+                waypoint: [
+                  this.linkView.sourceAnchor.toJSON(),
+                  ...this.shape.vertices(),
+                  this.linkView.targetAnchor.toJSON(),
+                ],
+                sourceRefId,
+                targetRefId,
+              },
+            },
+          ];
+
+          window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', changes);
+        }
+
         this.listeningToMouseleave = true;
         this.$emit('save-state');
       }
@@ -175,14 +200,15 @@ export default {
       * @param {Object} options
       */
     async onChangeTargets(link, vertices, options){
-      if (options && options.ui) {
+      if (options?.ui) {
         await this.$nextTick();
         await this.waitForUpdateWaypoints();
+        this.listeningToMouseleave = false;
         await this.storeWaypoints();
       }
     },
     async onChangeVertices(link, vertices, options){
-      if (options && options.ui) {
+      if (options?.ui) {
         this.updateWaypoints();
         await this.$nextTick();
         this.listeningToMouseleave = false;

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -23,6 +23,7 @@ export default {
   props: ['highlighted', 'paper', 'paperManager', 'isCompleted', 'isIdle'],
   data() {
     return {
+      linkView: null,
       sourceShape: null,
       target: null,
       listeningToMouseup: false,
@@ -189,9 +190,9 @@ export default {
       }
     },
     updateWaypoints() {
-      const linkView = this.shape.findView(this.paper);
-      const start = linkView.sourceAnchor;
-      const end = linkView.targetAnchor;
+      this.linkView = this.shape.findView(this.paper);
+      const start = this.linkView.sourceAnchor;
+      const end = this.linkView.targetAnchor;
 
       this.node.diagram.waypoint = [start,
         ...this.shape.vertices(),
@@ -239,6 +240,16 @@ export default {
         if (this.updateDefinitionLinks) {
           this.updateDefinitionLinks();
         }
+
+        if (this.linkView && ['processmaker-modeler-association', 'processmaker-modeler-data-input-association'].includes(this.shape.component.node.type)) {
+          const currentNode = this.shape.component.node;
+          // update sourceRef and targetRef
+          currentNode.definition.set('sourceRef', this.linkView.sourceView.model.component.node.definition);
+          currentNode.definition.set('targetRef', this.linkView.targetView.model.component.node.definition);
+
+          this.$parent.multiplayerHook(this.shape.component.node, false);
+        }
+
         this.$emit('save-state');
       });
 

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -268,11 +268,6 @@ export default {
         }
 
         if (this.linkView && ['processmaker-modeler-association', 'processmaker-modeler-data-input-association'].includes(this.shape.component.node.type)) {
-          const currentNode = this.shape.component.node;
-          // update sourceRef and targetRef
-          currentNode.definition.set('sourceRef', this.linkView.sourceView.model.component.node.definition);
-          currentNode.definition.set('targetRef', this.linkView.targetView.model.component.node.definition);
-
           this.$parent.multiplayerHook(this.shape.component.node, false);
         }
 

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -1,8 +1,8 @@
 import { io } from 'socket.io-client';
 import * as Y from 'yjs';
 import { getNodeIdGenerator } from '../NodeIdGenerator';
-import Room from './room';
 import { getDefaultAnchorPoint } from '@/portsUtils';
+import Room from './room';
 
 export default class Multiplayer {
   clientIO = null;

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -2,6 +2,7 @@ import { io } from 'socket.io-client';
 import * as Y from 'yjs';
 import { getNodeIdGenerator } from '../NodeIdGenerator';
 import Room from './room';
+import { getDefaultAnchorPoint } from '@/portsUtils';
 
 export default class Multiplayer {
   clientIO = null;
@@ -252,20 +253,52 @@ export default class Multiplayer {
     const { paper } = this.modeler;
     const element = this.modeler.getElementByNodeId(data.id);
     const newPool = this.modeler.getElementByNodeId(data.poolId);
-    // Update the element's position attribute
-    element.resize(
-      /* Add labelWidth to ensure elements don't overlap with the pool label */
-      data.width,
-      data.height,
-    );
-    element.set('position', { x: data.x, y: data.y });
-    // Trigger a rendering of the element on the paper
-    await paper.findViewByModel(element).update();
-    // validate if the parent pool was updated
-    await element.component.$nextTick();
-    await this.modeler.paperManager.awaitScheduledUpdates();
-    if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
-      element.component.node.pool.component.moveElementRemote(element, newPool);
+
+    if (this.modeler.flowTypes.includes(data.type)) {
+      // Update the element's waypoints
+      // Get the source and target elements
+      const sourceElem = this.modeler.getElementByNodeId(data.sourceRefId);
+      const targetElem = this.modeler.getElementByNodeId(data.targetRefId);
+
+      const { waypoint } = data;
+      const startWaypoint = waypoint.shift();
+      const endWaypoint = waypoint.pop();
+
+      // Update the element's waypoints
+      const newWaypoint = waypoint.map(point => this.modeler.moddle.create('dc:Point', point));
+      element.set('vertices', newWaypoint);
+
+      // Update the element's source anchor
+      element.source(sourceElem, {
+        anchor: () => {
+          return getDefaultAnchorPoint(this.getConnectionPoint(sourceElem, startWaypoint), sourceElem.findView(paper));
+        },
+        connectionPoint: { name: 'boundary' },
+      });
+
+      // Update the element's target anchor
+      element.target(targetElem, {
+        anchor: () => {
+          return getDefaultAnchorPoint(this.getConnectionPoint(targetElem, endWaypoint), targetElem.findView(paper));
+        },
+        connectionPoint: { name: 'boundary' },
+      });
+    } else {
+      // Update the element's position attribute
+      element.resize(
+        /* Add labelWidth to ensure elements don't overlap with the pool label */
+        data.width,
+        data.height,
+      );
+      element.set('position', { x: data.x, y: data.y });
+      // Trigger a rendering of the element on the paper
+      await paper.findViewByModel(element).update();
+      // validate if the parent pool was updated
+      await element.component.$nextTick();
+      await this.modeler.paperManager.awaitScheduledUpdates();
+      if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
+        element.component.node.pool.component.moveElementRemote(element, newPool);
+      }
     }
   }
 
@@ -323,5 +356,18 @@ export default class Multiplayer {
     }
     return false;
   }
+  getConnectionPoint(element, newPosition) {
+    const { x: elemX, y: elemY } = element.position();
+    const connectionOffset = {
+      x: newPosition.x - elemX,
+      y: newPosition.y - elemY,
+    };
 
+    const { x, y } = element.position();
+    const { width, height } = element.size();
+
+    return connectionOffset
+      ? { x: x + connectionOffset.x, y: y + connectionOffset.y }
+      : { x: x + (width / 2), y: y + (height / 2) };
+  }
 }

--- a/tests/e2e/specs/DataObjectDataStore.cy.js
+++ b/tests/e2e/specs/DataObjectDataStore.cy.js
@@ -33,7 +33,7 @@ describe('Data Objects and Data Stores', () => {
       getNumberOfLinks().should('equal', 1);
       assertDownloadedXmlContainsExpected(`
         <bpmn:startEvent id="node_1" name="Start Event">
-          <bpmn:dataOutputAssociation id="node_4">
+          <bpmn:dataOutputAssociation id="node_3">
             <bpmn:targetRef>node_2</bpmn:targetRef>
           </bpmn:dataOutputAssociation>
         </bpmn:startEvent>

--- a/tests/e2e/specs/MessageFlows.cy.js
+++ b/tests/e2e/specs/MessageFlows.cy.js
@@ -259,7 +259,7 @@ describe('Message Flows', { scrollBehavior: false }, () => {
     const boundaryEventId = 'node_22';
     const endEventXml = `<bpmn:endEvent id="${endEventId}" name="Message End Event">`;
     const boundaryEventXml = `<bpmn:boundaryEvent id="${boundaryEventId}" name="Boundary Message Event" attachedToRef="node_12">`;
-    const messageFlowXml = `<bpmn:messageFlow id="node_24" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
+    const messageFlowXml = `<bpmn:messageFlow id="node_23" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
 
     assertDownloadedXmlContainsExpected(endEventXml, boundaryEventXml, messageFlowXml);
   });

--- a/tests/e2e/specs/SequenceFlows.cy.js
+++ b/tests/e2e/specs/SequenceFlows.cy.js
@@ -58,7 +58,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
     typeIntoTextInput('[name=conditionExpression]', testExpressionString);
     cy.get('[name=conditionExpression]').should('have.value', testExpressionString);
 
-    const sequenceFlowXml = `<bpmn:sequenceFlow id="node_13" name="${testNameString}" sourceRef="node_2" targetRef="node_3"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testExpressionString}</bpmn:conditionExpression></bpmn:sequenceFlow>`;
+    const sequenceFlowXml = `<bpmn:sequenceFlow id="node_9" name="${testNameString}" sourceRef="node_2" targetRef="node_3"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testExpressionString}</bpmn:conditionExpression></bpmn:sequenceFlow>`;
 
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
@@ -290,7 +290,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
     const taskPosition = { x: 350, y: 250 };
     let numberOfSequenceFlowsAdded = 1;
 
-    const sequenceFlow = '<bpmn:sequenceFlow id="node_18" sourceRef="node_1" targetRef="node_8"';
+    const sequenceFlow = '<bpmn:sequenceFlow id="node_16" sourceRef="node_1" targetRef="node_8"';
 
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-script-task');
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.scriptTask);
@@ -315,7 +315,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
       expect($links.length).to.eq(numberOfSequenceFlowsAdded);
     });
 
-    const updatedSequenceFlow = '<bpmn:sequenceFlow id="node_18" sourceRef="node_1" targetRef="node_19"';
+    const updatedSequenceFlow = '<bpmn:sequenceFlow id="node_16" sourceRef="node_1" targetRef="node_18"';
     assertDownloadedXmlContainsExpected(updatedSequenceFlow);
   });
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Support for creating and updating flows in multiplayer mode

## Solution
- Create Data Input Flows
- Create Data Output Flows
- Create Association Flows
- Update every flow type waypoints
- Update every flow type anchors

## How to Test
- Click&Drop any elements
- Join them with any flow type
- Update the flow waypoints and anchors

## Related Tickets & Packages
[FOUR-11062](https://processmaker.atlassian.net/browse/FOUR-11062)

https://github.com/ProcessMaker/microservice-realtime/pull/13

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-11062]: https://processmaker.atlassian.net/browse/FOUR-11062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ