### PR TITLE
FOUR-10903 | The Design View of Newly Created Templates Appears to Have Errors

### DIFF
--- a/src/components/nodes/task/shape.js
+++ b/src/components/nodes/task/shape.js
@@ -11,9 +11,6 @@ export default shapes.standard.Rectangle.extend({
   }, {
     tagName: 'image',
     selector: 'image',
-  }, {
-    tagName: 'i',
-    selector: 'icon',
   },
   markersMarkup('topLeft'),
   markersMarkup('topCenter'),
@@ -28,7 +25,6 @@ export default shapes.standard.Rectangle.extend({
     size: { width: 100, height: 60 },
     attrs: {
       'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16, 'data-test': 'nodeIcon' },
-      'icon': { ref: 'rect', 'ref-x': 4, 'ref-y': 4, width: 16, height: 16, 'data-test': 'nodeCustomIcon' },
       ...markersAttrs('topLeft', { 'ref-y': 4, ref: 'rect' }),
       ...markersAttrs('topCenter', { 'ref-y': 4, ref: 'rect' }),
       ...markersAttrs('topRight', { 'ref-y': 4, 'ref-x': 96, ref: 'rect' }, -1),


### PR DESCRIPTION
# Issue
Ticket: [FOUR-10903](https://processmaker.atlassian.net/browse/FOUR-10903)

When creating a new Process or Template, the SVG file associated with it contains blocks on the image.

# Solution
Remove the unnecessary 'icon' data from the task shape markup and attributes in shape.js.

# How to Test
1. Go to branch `observation/FOUR-110903` in `modeler`.
2. Go to Designer → +PROCESS. Create a new Process.
3. View the Process Documentation.
	- The image in the Process Documentation should not have any squares, errors, or incorrect figures.
4. Using that Process, create a Template.
5. Go to Designer → +PROCESS. From the Select Template Modal, select the Template you created.
	- The image in the Template Preview should not have any squares, errors, or incorrect figures.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-10903]: https://processmaker.atlassian.net/browse/FOUR-10903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ