### PR TITLE
 FOUR-10567: The asset preview does not disappear for controls that do not have that option.

### DIFF
--- a/src/components/crown/crownButtons/previewButton.vue
+++ b/src/components/crown/crownButtons/previewButton.vue
@@ -47,7 +47,11 @@ export default {
   },
   methods: {
     preview() {
-      this.$emit('previewNode', this.node);
+      if (window.ProcessMaker.$modeler.isOpenPreview) {
+        window.ProcessMaker.$modeler.isOpenPreview = false;
+      } else {
+        this.$emit('previewNode', this.node);
+      }
     },
   },
 };

--- a/src/components/crown/crownButtons/previewButton.vue
+++ b/src/components/crown/crownButtons/previewButton.vue
@@ -1,6 +1,6 @@
 <template>
   <crown-button
-    v-if="node.isBpmnType(...validPreviewElements)"
+    v-if="displayIcon"
     :title="$t('Preview')"
     role="menuitem"
     id="preview-button"
@@ -16,6 +16,7 @@
 import trashIcon from '@/assets/trash-alt-solid.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
+import store from '@/store';
 
 export default {
   components: { CrownButton },
@@ -24,7 +25,20 @@ export default {
     return {
       trashIcon,
       validPreviewElements,
+      displayIcon: false,
     };
+  },
+  mounted() {
+    const defaultDataTransform = (node) => Object.entries(node.definition).reduce((data, [key, value]) => {
+      data[key] = value;
+      return data;
+    }, {});
+    const nodeData = defaultDataTransform(this.node);
+
+    const previewConfig = window.ProcessMaker.$modeler.previewConfigs.find(config => {
+      return config.matcher(nodeData);
+    });
+    this.displayIcon =  !!previewConfig;
   },
   computed: {
     isPoolLane() {

--- a/src/components/crown/crownButtons/previewButton.vue
+++ b/src/components/crown/crownButtons/previewButton.vue
@@ -5,6 +5,7 @@
     role="menuitem"
     id="preview-button"
     aria-label="Preview"
+    data-test="preview-button"
     @click="preview()"
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
   >
@@ -16,7 +17,6 @@
 import trashIcon from '@/assets/trash-alt-solid.svg';
 import CrownButton from '@/components/crown/crownButtons/crownButton';
 import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
-import store from '@/store';
 
 export default {
   components: { CrownButton },

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -73,7 +73,6 @@
 <script>
 import store from '@/store';
 import NoPreviewAvailable from '@/components/inspectors/NoPreviewAvailable';
-import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
 
 export default {
   props: ['nodeRegistry', 'visible', 'previewConfigs'],
@@ -90,7 +89,6 @@ export default {
       width: 600,
       isDragging: false,
       currentPos: 600,
-      validPreviewElements,
     };
   },
   watch: {

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -7,7 +7,7 @@
     @mousedown="onMouseDown"
     @mouseup="onMouseUp"
     @mousemove="onMouseMove"
-    data-test="preview-pane"
+    data-test="preview-panel"
   >
     <b-row class="control-bar">
       <b-col cols="9">
@@ -142,10 +142,10 @@ export default {
       const nodeConfig = this.previewConfigs.find(config => {
         return config.matcher(this.data);
       });
+
       if (nodeConfig) {
         this.prepareData();
-      }
-      else {
+      } else {
         this.$emit('togglePreview', false);
       }
     },
@@ -168,7 +168,6 @@ export default {
           clone[prop] = this.data[prop];
         }
       }
-
 
       const nodeData = encodeURI(JSON.stringify(clone));
 

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -73,6 +73,7 @@
 <script>
 import store from '@/store';
 import NoPreviewAvailable from '@/components/inspectors/NoPreviewAvailable';
+import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
 
 export default {
   props: ['nodeRegistry', 'visible', 'previewConfigs'],
@@ -89,6 +90,7 @@ export default {
       width: 600,
       isDragging: false,
       currentPos: 600,
+      validPreviewElements,
     };
   },
   watch: {
@@ -138,7 +140,16 @@ export default {
       if (currentValue === previousValue) {
         return;
       }
-      this.prepareData();
+
+      const nodeConfig = this.previewConfigs.find(config => {
+        return config.matcher(this.data);
+      });
+      if (nodeConfig) {
+        this.prepareData();
+      }
+      else {
+        this.$emit('togglePreview', false);
+      }
     },
 
     onSelectedPreview(item) {
@@ -159,9 +170,13 @@ export default {
           clone[prop] = this.data[prop];
         }
       }
+
+
       const nodeData = encodeURI(JSON.stringify(clone));
 
-      this.previewUrl = previewConfig ? `${previewConfig.url}?node=${nodeData}` : null;
+      // if the node has the configurations (for example screenRef for a task in a task)
+      const nodeHasConfigParams = Object.keys(clone).length > 0;
+      this.previewUrl = previewConfig &&  nodeHasConfigParams ? `${previewConfig.url}?node=${nodeData}` : null;
       this.taskTitle = this.highlightedNode?.definition?.name;
       this.showPanel = true;
     },

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -7,7 +7,7 @@
     @mousedown="onMouseDown"
     @mouseup="onMouseUp"
     @mousemove="onMouseMove"
-    data-test="preview-column"
+    data-test="preview-pane"
   >
     <b-row class="control-bar">
       <b-col cols="9">

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -224,7 +224,6 @@ import ProcessmakerModelerGenericFlow from '@/components/nodes/genericFlow/gener
 import Selection from './Selection';
 import RemoteCursor from '@/components/multiplayer/remoteCursor/RemoteCursor.vue';
 import Multiplayer from '@/multiplayer/multiplayer';
-import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
 
 export default {
   components: {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -224,6 +224,7 @@ import ProcessmakerModelerGenericFlow from '@/components/nodes/genericFlow/gener
 import Selection from './Selection';
 import RemoteCursor from '@/components/multiplayer/remoteCursor/RemoteCursor.vue';
 import Multiplayer from '@/multiplayer/multiplayer';
+import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
 
 export default {
   components: {
@@ -418,6 +419,9 @@ export default {
       this.isOpenInspector = value;
     },
     handlePreview() {
+      if (this.highlightedNodes.length != 1) {
+        this.isOpenPreview = false;
+      }
       this.$refs['preview-panel'].previewNode(true);
       this.handleTogglePreview(true) ;
     },

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -23,22 +23,22 @@ window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML }) => {
 
 
 
-ProcessMaker.EventBus.$on(
-  "modeler-init",
+window.ProcessMaker.EventBus.$on(
+  'modeler-init',
   (event) => {
     event.registerPreview({
       url:'/designer/screens/preview',
       receivingParams: ['screenRef'],
       matcher: (nodeData) => {
         return nodeData?.$type  === 'bpmn:Task';
-      }
+      },
     });
     event.registerPreview({
       url:'/designer/scripts/preview',
       receivingParams: ['scriptRef'],
       matcher: (nodeData) => {
         return nodeData?.$type === 'bpmn:ScriptTask';
-      }
+      },
     });
   });
 

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -20,3 +20,25 @@ window.ProcessMaker.EventBus.$on('modeler-init', registerNodes);
 window.ProcessMaker.EventBus.$on('modeler-start', ({ loadXML }) => {
   loadXML(blank);
 });
+
+
+
+ProcessMaker.EventBus.$on(
+  "modeler-init",
+  (event) => {
+    event.registerPreview({
+      url:'/designer/screens/preview',
+      receivingParams: ['screenRef'],
+      matcher: (nodeData) => {
+        return nodeData?.$type  === 'bpmn:Task';
+      }
+    });
+    event.registerPreview({
+      url:'/designer/scripts/preview',
+      receivingParams: ['scriptRef'],
+      matcher: (nodeData) => {
+        return nodeData?.$type === 'bpmn:ScriptTask';
+      }
+    });
+  });
+

--- a/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
+++ b/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
@@ -1,10 +1,10 @@
 const { nodeTypes } = require('../../support/constants');
 const {
   clickAndDropElement,
-  waitToRenderAllShapes, getCrownButtonForElement,
+  waitToRenderAllShapes, getCrownButtonForElement, getElementAtPosition,
 } = require('../../support/utils');
 
-describe('Inspector panel test', { scrollBehavior: false }, () => {
+describe('Inspector panel tests', { scrollBehavior: false }, () => {
 
   beforeEach(() => {
     cy.get('.control-add').click();
@@ -18,16 +18,37 @@ describe('Inspector panel test', { scrollBehavior: false }, () => {
     waitToRenderAllShapes();
   });
 
+  it('preview icon should  be visible in tasks', () => {
+
+    const taskPosition = { x: 400, y: 100 };
+    clickAndDropElement(nodeTypes.task, taskPosition);
+
+    cy.get('[data-test=preview-button]').should('be.visible');
+  });
 
   it('should open preview panel when clicks on preview icon', () => {
     const taskPosition = { x: 500, y: 500 };
     clickAndDropElement(nodeTypes.task, taskPosition);
-    crown('preview-button');
+    //const previewButton = crown('preview-button');
+
+    getElementAtPosition(taskPosition)
+      .then($task => {
+        getCrownButtonForElement($task, 'preview-button').click({ force: true });
+      });
+
+    cy.get('[data-test=preview-panel]').should('be.visible');
+
+  });
+
+  it('preview icon should not be visible in start or end events', () => {
+
+    const startEventPosition = { x: 500, y: 500 };
+    clickAndDropElement(nodeTypes.startEvent, startEventPosition);
+    cy.get('[data-test=preview-button]').should('not.exist');
+
+    const endEventPosition = { x: 100, y: 800 };
+    clickAndDropElement(nodeTypes.endEvent, endEventPosition);
+    cy.get('[data-test=preview-button]').should('not.exist');
   });
 
 });
-
-function crown(buttonId)
-{
-  getCrownButtonForElement(null, buttonId).click({ force: true });
-}

--- a/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
+++ b/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
@@ -51,4 +51,17 @@ describe('Inspector panel tests', { scrollBehavior: false }, () => {
     cy.get('[data-test=preview-button]').should('not.exist');
   });
 
+  it.only('preview icon should switch between displaying and hiding the preview pane', () => {
+    const taskPosition = { x: 400, y: 100 };
+    clickAndDropElement(nodeTypes.task, taskPosition);
+
+    getElementAtPosition(taskPosition)
+      .then($task => {
+        getCrownButtonForElement($task, 'preview-button').click({ force: true });
+        cy.get('[data-test=preview-panel]').should('be.visible');
+
+        getCrownButtonForElement($task, 'preview-button').click({ force: true });
+        cy.get('[data-test=preview-panel]').should('not.be.visible');
+      });
+  });
 });

--- a/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
+++ b/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
@@ -51,7 +51,7 @@ describe('Inspector panel tests', { scrollBehavior: false }, () => {
     cy.get('[data-test=preview-button]').should('not.exist');
   });
 
-  it.only('preview icon should switch between displaying and hiding the preview pane', () => {
+  it('preview icon should switch between displaying and hiding the preview pane', () => {
     const taskPosition = { x: 400, y: 100 };
     clickAndDropElement(nodeTypes.task, taskPosition);
 


### PR DESCRIPTION
## Issue & Reproduction Steps

-Create a process
-Add Task form
-Add Start Event
-Select the task
-Click on “Preview“ option
-Click on Start Event

## Solution
- Added code to filter elements that have the preview option


## Related Tickets & Packages
[FOUR-10567](https://processmaker.atlassian.net/browse/FOUR-10567)
[FOUR-10589](https://processmaker.atlassian.net/browse/FOUR-10589)
[FOUR-10587](https://processmaker.atlassian.net/browse/FOUR-10587)
[FOUR-10584](https://processmaker.atlassian.net/browse/FOUR-10584)
[FOUR-10570](https://processmaker.atlassian.net/browse/FOUR-10570)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-10567]: https://processmaker.atlassian.net/browse/FOUR-10567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-11280]: https://processmaker.atlassian.net/browse/FOUR-11280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-10589]: https://processmaker.atlassian.net/browse/FOUR-10589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-10587]: https://processmaker.atlassian.net/browse/FOUR-10587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-10584]: https://processmaker.atlassian.net/browse/FOUR-10584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FOUR-10570]: https://processmaker.atlassian.net/browse/FOUR-10570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ