### PR TITLE
FOUR-11376: improve flow to support flow conditions

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1199,6 +1199,8 @@ export default {
               sourceRefId,
               targetRefId,
               waypoint: node.diagram.waypoint,
+              name: node.definition.name,
+              conditionExpression: null,
             };
 
             if (isProcessRequested) {

--- a/src/components/nodes/errorEndEvent/index.js
+++ b/src/components/nodes/errorEndEvent/index.js
@@ -52,7 +52,7 @@ export default merge(cloneDeep(endEventConfig), {
       });
     }
   },
-  multiplayerInspectorHandler(node, data){
+  multiplayerInspectorHandler(node, data) {
     const keys = Object.keys(data).filter((key) => key !== 'id');
     if (keys[0] === 'eventDefinitions') {
       const error = data[keys[0]][0].errorRef;

--- a/src/components/nodes/errorEndEvent/index.js
+++ b/src/components/nodes/errorEndEvent/index.js
@@ -52,7 +52,7 @@ export default merge(cloneDeep(endEventConfig), {
       });
     }
   },
-  multiplayerInspectorHandler(node, data) {
+  multiplayerInspectorHandler(node, data, setNodeProp) {
     const keys = Object.keys(data).filter((key) => key !== 'id');
     if (keys[0] === 'eventDefinitions') {
       const error = data[keys[0]][0].errorRef;
@@ -62,7 +62,9 @@ export default merge(cloneDeep(endEventConfig), {
           errorRef.name = error.name;
         }
       }
+      return;
     }
+    setNodeProp(node, keys[0], data[keys[0]]);
   },
   inspectorConfig: [
     {

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -67,11 +67,10 @@ export default {
   },
   multiplayerInspectorHandler(node, data, setNodeProp, moddle) {
     const keys = Object.keys(data).filter((key) => key !== 'id');
-    if (keys.length <= 0) {
+    if (keys.length === 0) {
       return;
     }
     if (keys[0] === 'conditionExpression') {
-      console.log('conditionExpression', data);
       const conditionExpression = moddle.create('bpmn:FormalExpression', { body: data[keys[0]][0].body });
       setNodeProp(node, keys[0], conditionExpression);
       return;

--- a/src/components/nodes/sequenceFlow/index.js
+++ b/src/components/nodes/sequenceFlow/index.js
@@ -52,6 +52,9 @@ export default {
         // Set the condition expression IFF the expresion body changed
         if (definition[key].body !== value[key]) {
           const conditionExpression = moddle.create('bpmn:FormalExpression', { body: value[key] });
+          window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+            id: node.definition.id , key, value: [conditionExpression],
+          });
           setNodeProp(node, key, conditionExpression);
         }
       } else {
@@ -61,6 +64,19 @@ export default {
         setNodeProp(node, key, value[key]);
       }
     }
+  },
+  multiplayerInspectorHandler(node, data, setNodeProp, moddle) {
+    const keys = Object.keys(data).filter((key) => key !== 'id');
+    if (keys.length <= 0) {
+      return;
+    }
+    if (keys[0] === 'conditionExpression') {
+      console.log('conditionExpression', data);
+      const conditionExpression = moddle.create('bpmn:FormalExpression', { body: data[keys[0]][0].body });
+      setNodeProp(node, keys[0], conditionExpression);
+      return;
+    }
+    setNodeProp(node, keys[0], data[keys[0]]);
   },
   inspectorConfig: [
     {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -509,7 +509,7 @@ export default class Multiplayer {
         return;
       }
       if (this.modeler.nodeRegistry[node.type] && this.modeler.nodeRegistry[node.type].multiplayerInspectorHandler) {
-        this.modeler.nodeRegistry[node.type].multiplayerInspectorHandler(node, data);
+        this.modeler.nodeRegistry[node.type].multiplayerInspectorHandler(node, data,this.setNodeProp, this.modeler.moddle);
         return;
       }
       const keys = Object.keys(data).filter((key) => key !== 'id');


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Enable multiplayer
3. Create a gateway
5. Create a task
7. Connect the gateway with the task
9. add flow expression 

Expected behavior: 
Sequence flows expression property must sync

Actual behavior: 
Sequence flows expression property do not sync

## Solution
- bpmn flow expression support was improved
[flow expression.webm](https://github.com/ProcessMaker/modeler/assets/1401911/3c02db5d-5e3a-4046-9c7f-4cdd18db49d9)

## How to Test
Test the steps above

1. Enable multiplayer
3. Create a gateway
5. Create a task
7. Connect the gateway with the task
9. add flow expression 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11376

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
