### PR TITLE
FOUR-10572: Crown options of controls overlap the asset preview  (plus window pane visualizations fixes)

### DIFF
--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -1,5 +1,5 @@
 $inspector-column-max-width: 400px;
-$inspector-column-min-width: 400px;
+$inspector-column-min-width: 200px;
 
 #preview_panel::after {
   display: flex;
@@ -12,10 +12,12 @@ $inspector-column-min-width: 400px;
 
 .preview-column {
   max-width: $inspector-column-max-width;
+  min-width: $inspector-column-min-width;
   resize: both;
   overflow:auto;
   background-color: #F5F5F5;
   border-left: 8px solid #EBEEF2;
+  z-index: 2;
 }
 
 .paneiframe {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -84,7 +84,7 @@
         :parent-height="parentHeight"
         :canvas-drag-position="canvasDragPosition"
         @shape-resize="shapeResize(false)"
-        @toggleInspector="handleToggleInspector"
+        @toggleInspector="[handleToggleInspector($event), setInspectorButtonPosition($event)]"
       />
 
       <component

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -27,19 +27,19 @@ window.ProcessMaker.EventBus.$on(
   'modeler-init',
   (event) => {
     event.registerPreview({
-      url:'/designer/screens/preview',
+      url: '/designer/screens/preview',
       receivingParams: ['screenRef'],
       matcher: (nodeData) => nodeData?.$type  === 'bpmn:Task',
     });
 
     event.registerPreview({
-      url:'/designer/scripts/preview',
+      url: '/designer/scripts/preview',
       receivingParams: ['scriptRef'],
       matcher: (nodeData) => nodeData?.$type === 'bpmn:ScriptTask',
     });
 
     event.registerPreview({
-      url:'/designer/scripts/preview',
+      url: '/designer/scripts/preview',
       receivingParams: ['screenRef'],
       matcher: (nodeData) => nodeData?.$type === 'bpmn:ManualTask',
     });

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -29,16 +29,19 @@ window.ProcessMaker.EventBus.$on(
     event.registerPreview({
       url:'/designer/screens/preview',
       receivingParams: ['screenRef'],
-      matcher: (nodeData) => {
-        return nodeData?.$type  === 'bpmn:Task';
-      },
+      matcher: (nodeData) => nodeData?.$type  === 'bpmn:Task',
     });
+
     event.registerPreview({
       url:'/designer/scripts/preview',
       receivingParams: ['scriptRef'],
-      matcher: (nodeData) => {
-        return nodeData?.$type === 'bpmn:ScriptTask';
-      },
+      matcher: (nodeData) => nodeData?.$type === 'bpmn:ScriptTask',
+    });
+
+    event.registerPreview({
+      url:'/designer/scripts/preview',
+      receivingParams: ['screenRef'],
+      matcher: (nodeData) => nodeData?.$type === 'bpmn:ManualTask',
     });
   });
 

--- a/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
+++ b/tests/e2e/specs/previewPanel/PreviewPanel.cy.js
@@ -64,4 +64,31 @@ describe('Inspector panel tests', { scrollBehavior: false }, () => {
         cy.get('[data-test=preview-panel]').should('not.be.visible');
       });
   });
+
+  it('Manual tasks should have a preview', () => {
+    const taskPosition = { x: 400, y: 100 };
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    cy.get('[data-test=select-type-dropdown]').click();
+    cy.get('[data-test=switch-to-manual-task]').click();
+
+    getElementAtPosition(taskPosition)
+      .then($task => {
+        getCrownButtonForElement($task, 'preview-button').click({ force: true });
+        cy.get('[data-test=preview-panel]').should('be.visible');
+      });
+  });
+
+
+  it('After deleting a tas window pane should be hidden', () => {
+    const taskPosition = { x: 400, y: 100 };
+    clickAndDropElement(nodeTypes.task, taskPosition);
+
+    getElementAtPosition(taskPosition)
+      .then($task => {
+        getCrownButtonForElement($task, 'preview-button').click({ force: true });
+        getCrownButtonForElement($task, 'delete-button').click({ force: true });
+        cy.get('[data-test=preview-panel]').should('not.be.visible');
+      });
+  });
+
 });


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a process
- Add task form 
- Select the task form
- Press the “Preview“ button
- Drag the task form down the asset preview
- Change the  type the task form 

Expected behavior: 
The crown options of the control should not overlap the asset preview 
Actual behavior: 
The crown options of the control overlap the asset preview and appear an error if the type is changed 
## Solution
-

## How to Test
  - Create a process
- Add task form 
- Select the task form
- Press the “Preview“ button
- Drag the task form down the asset preview
- Change the  type the task form 

Verify that the crown is 'hidden' beneath the preview panel

## Related Tickets & Packages
This PR resolves:
https://processmaker.atlassian.net/browse/FOUR-10572
https://processmaker.atlassian.net/browse/FOUR-10573
https://processmaker.atlassian.net/browse/FOUR-10612
https://processmaker.atlassian.net/browse/FOUR-10613
https://processmaker.atlassian.net/browse/FOUR-11090
https://processmaker.atlassian.net/browse/FOUR-10839


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
