### PR TITLE
FOUR-11474: When a user opens an already existing process, changes are not propagated to other users

### DIFF
--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -54,9 +54,9 @@ export default class Multiplayer {
             top: 90,
             left: 80,
           };
-
           this.modeler.addPlayer(newPlayer);
         });
+        this.syncLocalNodes(this.clientIO.id);
       }
     });
 
@@ -72,18 +72,7 @@ export default class Multiplayer {
 
       // Check if the current client is the first client
       if (firstClient.id === this.clientIO.id) {
-        // Get the process definition
-        const nodes = this.modeler.nodes.map((node) => this.modeler.multiplayerHook(node, false, true));
-
-        nodes.forEach((node) => {
-          const yMapNested = new Y.Map();
-          this.doTransact(yMapNested, node);
-          this.yArray.push([yMapNested]);
-          // Encode the state as an update and send it to the server
-          const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
-          // Send the update to the web socket server
-          this.clientIO.emit('createElement', { updateDoc: stateUpdate, clientId });
-        });
+        this.syncLocalNodes(clientId);
       }
     });
 
@@ -178,6 +167,24 @@ export default class Multiplayer {
       if (this.modeler.isMultiplayer) {
         this.updateInspectorProperty(data);
       }
+    });
+  }
+  /**
+   * Sync the modeler nodes with the microservice
+   * @param {String} clientId 
+   */
+  syncLocalNodes(clientId){
+    // Get the process definition
+    const nodes = this.modeler.nodes.map((node) => this.modeler.multiplayerHook(node, false, true));
+
+    nodes.forEach((node) => {
+      const yMapNested = new Y.Map();
+      this.doTransact(yMapNested, node);
+      this.yArray.push([yMapNested]);
+      // Encode the state as an update and send it to the server
+      const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+      // Send the update to the web socket server
+      this.clientIO.emit('createElement', { updateDoc: stateUpdate, clientId });
     });
   }
   addNode(data) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
local changes need to be synced.
Actual behavior: 
changes are not synced.
## Solution
- when the multiplayer is detected, the current shapes will be synced


[Uploading sync_ load.webm…]()

## How to Test
Test the steps above

1. Create or configure to users (user1, user2)
2. Create a process with user1
3. Add some nodes
4. Connect, using other browser, with user2
5. Edit the task name of the nodes created by user1

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11474

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
