### PR TITLE
FOUR-11474: new elements are not synced after a save action

### DIFF
--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -68,13 +68,8 @@ export default class Multiplayer {
 
     this.clientIO.on('requestProcess', (payload) => {
       const { firstClient, clientId } = payload;
-
-      // Check if the current client is the first client
-      if (firstClient.id === this.clientIO.id) {
-        console.log('firstClient.id ', firstClient.id);
-        console.log('this.clientIO.id ', this.clientIO.id);
-        this.syncLocalNodes(clientId);
-      }
+      // Sync the local Nodes
+      this.syncLocalNodes(clientId);
     });
 
     // Listen for updates when a new element is added

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -67,9 +67,11 @@ export default class Multiplayer {
     });
 
     this.clientIO.on('requestProcess', (payload) => {
-      const { firstClient, clientId } = payload;
+      const { clientId } = payload;
       // Sync the local Nodes
-      this.syncLocalNodes(clientId);
+      if (clientId) {
+        this.syncLocalNodes(clientId);
+      }
     });
 
     // Listen for updates when a new element is added

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -56,7 +56,6 @@ export default class Multiplayer {
           };
           this.modeler.addPlayer(newPlayer);
         });
-        this.syncLocalNodes(this.clientIO.id);
       }
     });
 
@@ -72,6 +71,8 @@ export default class Multiplayer {
 
       // Check if the current client is the first client
       if (firstClient.id === this.clientIO.id) {
+        console.log('firstClient.id ', firstClient.id);
+        console.log('this.clientIO.id ', this.clientIO.id);
         this.syncLocalNodes(clientId);
       }
     });

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -8,10 +8,16 @@ import registerNodes from '@/setup/registerNodes';
 
 const blank = `
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
-<bpmn:process id="Process_1" isExecutable="true"></bpmn:process>
-<bpmndi:BPMNDiagram id="BPMNDiagram_1">
-<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"></bpmndi:BPMNPlane>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
+<bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
+<bpmn:task id="node_29" name="Form Task" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false"/>
+</bpmn:process>
+<bpmndi:BPMNDiagram id="BPMNDiagramId">
+<bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
+<bpmndi:BPMNShape id="node_29_di" bpmnElement="node_29">
+<dc:Bounds x="70" y="210" width="116" height="76"/>
+</bpmndi:BPMNShape>
+</bpmndi:BPMNPlane>
 </bpmndi:BPMNDiagram>
 </bpmn:definitions>
 `;

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -12,6 +12,8 @@ const blank = `
 <bpmn:process id="Process_1" isExecutable="true"></bpmn:process>
 <bpmndi:BPMNDiagram id="BPMNDiagram_1">
 <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"></bpmndi:BPMNPlane>
+</bpmndi:BPMNDiagram>
+</bpmn:definitions>
 `;
 
 window.ProcessMaker.EventBus.$on('modeler-init', registerNodes);

--- a/src/setup/initialLoad.js
+++ b/src/setup/initialLoad.js
@@ -8,18 +8,10 @@ import registerNodes from '@/setup/registerNodes';
 
 const blank = `
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:pm="http://processmaker.com/BPMN/2.0/Schema.xsd" xmlns:tns="http://sourceforge.net/bpmn/definitions/_1530553328908" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="http://bpmn.io/schema/bpmn" exporter="ProcessMaker Modeler" exporterVersion="1.0" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://bpmn.sourceforge.net/schemas/BPMN20.xsd">
-<bpmn:process id="ProcessId" name="ProcessName" isExecutable="true">
-<bpmn:task id="node_29" name="Form Task" pm:allowInterstitial="false" pm:assignment="requester" pm:assignmentLock="false" pm:allowReassignment="false"/>
-</bpmn:process>
-<bpmndi:BPMNDiagram id="BPMNDiagramId">
-<bpmndi:BPMNPlane id="BPMNPlaneId" bpmnElement="ProcessId">
-<bpmndi:BPMNShape id="node_29_di" bpmnElement="node_29">
-<dc:Bounds x="70" y="210" width="116" height="76"/>
-</bpmndi:BPMNShape>
-</bpmndi:BPMNPlane>
-</bpmndi:BPMNDiagram>
-</bpmn:definitions>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_03dabax" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="2.0.3">
+<bpmn:process id="Process_1" isExecutable="true"></bpmn:process>
+<bpmndi:BPMNDiagram id="BPMNDiagram_1">
+<bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1"></bpmndi:BPMNPlane>
 `;
 
 window.ProcessMaker.EventBus.$on('modeler-init', registerNodes);


### PR DESCRIPTION
## Issue & Reproduction Steps
When a user opens an already existing process, changes are not propagated to other users

Expected behavior: 
When a user opens an already existing process, changes must be propagated to other users
Actual behavior: 
changes are not propagated to other users
## Solution
- remove user filtering

ci:next

## How to Test
Test the steps above

1. Add a Form Task and Start Event without a flow in between.
2. Opena new window to the same URL and the Form Task was the only one visible.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11474

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
