### PR TITLE
FOUR-11277: When displaying the Modeler Preview Pane, it does not resemble Figma.

### DIFF
--- a/src/assets/spinner.svg
+++ b/src/assets/spinner.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; background: rgb(245, 245, 245); display: block; shape-rendering: auto;" width="50px" height="50px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="margin: auto; background: rgb(255, 255, 255); display: block; shape-rendering: auto;" width="50px" height="50px" viewBox="0 0 100 100" preserveAspectRatio="xMidYMid">
     <circle cx="50" cy="50" fill="none" stroke="#1572c2" stroke-width="10" r="35" stroke-dasharray="164.93361431346415 56.97787143782138">
         <animateTransform attributeName="transform" type="rotate" repeatCount="indefinite" dur="1s" values="0 50 50;360 50 50" keyTimes="0;1"/>
     </circle>

--- a/src/components/inspectors/LoadingPreview.vue
+++ b/src/components/inspectors/LoadingPreview.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="no-preview">
-    <img id="preview-asset" :src="previewAsset" alt="Preview Asset">
+  <div class="preview-placeholder">
+    <img id="preview-image" :src="previewAsset" alt="Preview Asset">
     <h1>The preview is loading</h1>
     <h2>Some assets can take some time to load</h2>
 
@@ -20,29 +20,12 @@ export default {
 };
 </script>
 
+<style lang="scss" src="./preview_panel.scss" scoped />
+
 <style scoped>
-.no-preview {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 5px;
-}
-#preview-asset {
-  width: 200px;
-  padding-bottom: 150px;
-}
-
-.no-preview h1 {
-  text-align: center;
-  font-weight: bold;
-  font-size: xx-large;
-  margin-bottom: 50px;
-}
-
-.no-preview h2 {
-  text-align: center;
-  font-size: x-large;
-  margin-bottom: 50px;
-}
+  #preview-image {
+    width: 130px;
+    margin-top: 50px;
+    margin-bottom: 50px;
+  }
 </style>

--- a/src/components/inspectors/NoPreviewAvailable.vue
+++ b/src/components/inspectors/NoPreviewAvailable.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="no-preview">
-    <img :src="noPreviewImg" alt="no preview">
+  <div class="preview-placeholder">
+    <img id="preview-image" :src="noPreviewImg" alt="no preview">
     <h1>No Resource Assigned</h1>
-    <h2>This is a placeholder. Please, assign a resource to this task.</h2>
+    <h2>This is a placeholder screen. Please, assign a resource to this task.</h2>
   </div>
 </template>
 
@@ -17,31 +17,13 @@ export default {
 };
 </script>
 
+
+<style lang="scss" src="./preview_panel.scss" scoped />
+
 <style scoped>
-.no-preview {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  color: #44494E;
-  padding: 5px;
-}
-
-.no-preview img {
-  max-width: 50%;
-  width: auto;
-  padding-bottom: 150px;
-}
-
-.no-preview h1 {
-  text-align: center;
-  font-weight: bold;
-  font-size: xx-large;
-  margin-bottom: 50px;
-}
-
-.no-preview h2 {
-  text-align: center;
-  font-size: x-large;
-}
+  #preview-image {
+    width: 200px;
+    margin-top:50px;
+    margin-bottom: 50px;
+  }
 </style>

--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -75,7 +75,7 @@ $inspector-column-min-width: 200px;
 .preview-placeholder h1 {
   text-align: center;
   margin-bottom: 30px;
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   font-size: 32px;
   font-weight: 600;
   line-height: 38px;
@@ -85,11 +85,9 @@ $inspector-column-min-width: 200px;
 .preview-placeholder h2 {
   text-align: center;
   margin-bottom: 50px;
-  font-family: "Open Sans";
+  font-family: "Open Sans", sans-serif;
   font-size: 18px;
   font-weight: 400;
   line-height: 27px;
   letter-spacing: -0.02em;
-  text-align: center;
-
 }

--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -75,7 +75,7 @@ $inspector-column-min-width: 200px;
 .preview-placeholder h1 {
   text-align: center;
   margin-bottom: 30px;
-  font-family: Open Sans;
+  font-family: "Open Sans";
   font-size: 32px;
   font-weight: 600;
   line-height: 38px;
@@ -85,7 +85,7 @@ $inspector-column-min-width: 200px;
 .preview-placeholder h2 {
   text-align: center;
   margin-bottom: 50px;
-  font-family: Open Sans;
+  font-family: "Open Sans";
   font-size: 18px;
   font-weight: 400;
   line-height: 27px;

--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -15,7 +15,7 @@ $inspector-column-min-width: 200px;
   min-width: $inspector-column-min-width;
   resize: both;
   overflow:auto;
-  background-color: #F5F5F5;
+  background-color: #fff;
   border-left: 8px solid #EBEEF2;
   z-index: 2;
 }
@@ -62,4 +62,34 @@ $inspector-column-min-width: 200px;
   font-weight: bold;
   text-align: center;
   color: #6c757d;
+}
+
+.preview-placeholder {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 5px;
+}
+
+.preview-placeholder h1 {
+  text-align: center;
+  margin-bottom: 30px;
+  font-family: Open Sans;
+  font-size: 32px;
+  font-weight: 600;
+  line-height: 38px;
+  letter-spacing: -0.04em;
+}
+
+.preview-placeholder h2 {
+  text-align: center;
+  margin-bottom: 50px;
+  font-family: Open Sans;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 27px;
+  letter-spacing: -0.02em;
+  text-align: center;
+
 }


### PR DESCRIPTION
## Solution
The same font and font sizes that found in Figma now are used in the Loading and No Preview screens

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-11277
 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
