### PR TITLE
FOUR-11525 Undo/Redo and avatars to be hidden in the meanwhile

### DIFF
--- a/src/components/railBottom/RailBottom.vue
+++ b/src/components/railBottom/RailBottom.vue
@@ -22,6 +22,7 @@
       :style="[overlap ? { width: 'auto'} : { width: '100%'}]"
     >
       <UndoRedoControl
+        v-if="!isMultiplayer"
         v-show="showComponent"
         :is-rendering="isRendering"
         @load-xml="$emit('load-xml')"
@@ -117,6 +118,7 @@ export default {
     showComponent() {
       return store.getters.showComponent;
     },
+    isMultiplayer: () => store.getters.isMultiplayer,
   },
   async mounted() {
     await nextTick();

--- a/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
+++ b/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-avatar-group class="container">
+  <b-avatar-group class="container" v-if="!isMultiplayer">
     <template v-for="item in filteredPlayers" >
       <Avatar :badgeBackgroundColor="item.color" :imgSrc="item.avatar" :userName="item.name" :key="item.key"/>
     </template>
@@ -9,6 +9,8 @@
 <script>
 import { uniqBy } from 'lodash';
 import Avatar from '@/components/topRail/multiplayerViewUsers/avatar/Avatar';
+import store from '@/store';
+
 export default {
   components:{
     Avatar,
@@ -26,6 +28,7 @@ export default {
         return player.name.toLowerCase() !== window.ProcessMaker.user?.fullName.toLowerCase();
       });
     },
+    isMultiplayer: () => store.getters.isMultiplayer,
   },
 };
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Undo/redo and Avatar container should be hidden

## Solution
- using the store `isMultiplayer` getter to check


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11525

ci:deploy
ci:next
.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
