### PR TITLE
FOUR-11955: Flow disappears if changing the component type to another

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1193,14 +1193,20 @@ export default {
             sourceRefId = Array.isArray(node.definition.sourceRef) && node.definition.sourceRef[0]?.id;
             targetRefId = node.definition.targetRef?.$parent?.$parent?.get('id');
           }
-
+          const waypoint = [];
+          node.diagram.waypoint.forEach(point => {
+            waypoint.push({
+              x: point.x,
+              y: point.y,
+            });
+          });
           if (sourceRefId && targetRefId) {
             const flowData = {
               id: node.definition.id,
               type: node.type,
               sourceRefId,
               targetRefId,
-              waypoint: node.diagram.waypoint,
+              waypoint,
               name: node.definition.name,
               conditionExpression: null,
             };

--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -31,7 +31,6 @@ export class NodeMigrator {
 
     const incoming = this._nodeThatWillBeReplaced.definition.get('incoming');
     const outgoing = this._nodeThatWillBeReplaced.definition.get('outgoing');
-
     this._definition.get('incoming').push(...incoming);
     this._definition.get('outgoing').push(...outgoing);
 

--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -14,12 +14,19 @@ export class NodeMigrator {
     if (keepOriginalName(this._nodeThatWillBeReplaced)) {
       this._definition.name = this._nodeThatWillBeReplaced.definition.name;
     }
-
+    const flowNodes = [];
     const forceNodeToRemount = definition => {
       const shape = this._graph.getLinks().find(element => {
         return element.component && element.component.node.definition === definition;
       });
       shape.component.node._modelerId += '_replaced';
+      flowNodes.push({
+        id: shape.component.node.definition.id,
+        type: shape.component.node.type,
+        name: shape.component.node.definition.name,
+        sourceRefId: shape.component.node.definition.sourceRef.id,
+        targetRefId: shape.component.node.definition.targetRef.id,
+      });
     };
 
     const incoming = this._nodeThatWillBeReplaced.definition.get('incoming');
@@ -62,6 +69,8 @@ export class NodeMigrator {
           forceNodeToRemount(flow);
         });
     }
+    // multiplayer hook to update the flows
+    window.ProcessMaker.EventBus.$emit('multiplayer-updateFlows', flowNodes);
   }
 
   _handleSequenceFlowForGateway(ref) {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -135,12 +135,10 @@ export default class Multiplayer {
     });
     this.clientIO.on('updateFlows', (payload) => {
       const { updateDoc, updatedNodes } = payload;
-
       // Update the elements in the process
       updatedNodes.forEach((data) => {
         this.updateFlowClient(data);
       });
-
       // Update the element in the shared array
       Y.applyUpdate(this.yDoc, new Uint8Array(updateDoc));
     });

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -609,7 +609,7 @@ export default class Multiplayer {
       const sourceRef = this.getNodeById(data.sourceRefId);
       flow.definition.set('sourceRef', sourceRef.definition);
       const outgoing = sourceRef.definition.get('outgoing')
-        .find((element) => element.id == flow.definition.id);
+        .find((element) => element.id === flow.definition.id);
       if (!outgoing) {
         sourceRef.definition.get('outgoing').push(...[flow.definition]);
       }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -133,7 +133,17 @@ export default class Multiplayer {
       // Update the element in the shared array
       Y.applyUpdate(this.yDoc, new Uint8Array(updateDoc));
     });
+    this.clientIO.on('updateFlows', (payload) => {
+      const { updateDoc, updatedNodes } = payload;
 
+      // Update the elements in the process
+      updatedNodes.forEach((data) => {
+        this.updateFlowClient(data);
+      });
+
+      // Update the element in the shared array
+      Y.applyUpdate(this.yDoc, new Uint8Array(updateDoc));
+    });
 
     window.ProcessMaker.EventBus.$on('multiplayer-addNode', ( data ) => {
       this.addNode(data);
@@ -164,6 +174,11 @@ export default class Multiplayer {
     window.ProcessMaker.EventBus.$on('multiplayer-updateInspectorProperty', ( data ) => {
       if (this.modeler.isMultiplayer) {
         this.updateInspectorProperty(data);
+      }
+    });
+    window.ProcessMaker.EventBus.$on('multiplayer-updateFlows', ( data ) => {
+      if (this.modeler.isMultiplayer) {
+        this.updateFlows(data);
       }
     });
   }
@@ -245,7 +260,7 @@ export default class Multiplayer {
     return node;
   }
   removeShape(node) {
-    this.modeler.removeNodeProcedure(node, true);
+    this.modeler.removeNodeProcedure(node,  { removeRelationships: false });
   }
   getRemovedNodes(array1, array2) {
     return array1.filter(object1 => {
@@ -563,6 +578,40 @@ export default class Multiplayer {
       if (!['messageRef', 'gatewayDirection', 'condition', 'allowedUsers', 'allowedGroups'].includes(key)) {
         store.commit('updateNodeProp', { node, key, value });
       }
+    }
+  }
+  updateFlows(data){
+    data.forEach((value) => {
+      const index = this.getIndex(value.id);
+      const nodeToUpdate =  this.yArray.get(index);
+      this.yDoc.transact(() => {
+        for (const key in value) {
+          if (Object.hasOwn(value, key)) {
+            nodeToUpdate.set(key, value[key]);
+          }
+        }
+      });
+    });
+    // Encode the state as an update and send it to the server
+    const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
+    this.clientIO.emit('updateFlows', { updateDoc: stateUpdate, isReplaced: false });
+  }
+  updateFlowClient(data) {
+    let remount = false;
+    const flow = this.getNodeById(data.id);
+    if (flow && data.sourceRefId) {
+      const sourceRef = this.getNodeById(data.sourceRefId);
+      flow.definition.set('sourceRef', sourceRef.definition);
+      remount = true;
+    }
+    if (flow && data.targetRefId) {
+      const targetRef = this.getNodeById(data.targetRefId);
+      flow.definition.set('targetRef', targetRef.definition);
+      remount = true;
+    }
+    if (remount) {
+      // Force Remount Flow
+      flow._modelerId += '_replaced';
     }
   }
 }

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -580,6 +580,10 @@ export default class Multiplayer {
       }
     }
   }
+  /**
+   * Update the shared document and emit socket sign to update the flows
+   * @param {Object} data
+   */
   updateFlows(data){
     data.forEach((value) => {
       const index = this.getIndex(value.id);
@@ -596,17 +600,31 @@ export default class Multiplayer {
     const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);
     this.clientIO.emit('updateFlows', { updateDoc: stateUpdate, isReplaced: false });
   }
+  /**
+   * Update the flow client, All node refs will be updated and forced to remount
+   * @param {Object} data
+   */
   updateFlowClient(data) {
     let remount = false;
     const flow = this.getNodeById(data.id);
     if (flow && data.sourceRefId) {
       const sourceRef = this.getNodeById(data.sourceRefId);
       flow.definition.set('sourceRef', sourceRef.definition);
+      const outgoing = sourceRef.definition.get('outgoing')
+        .find((element) => element.id == flow.definition.id);
+      if (!outgoing) {
+        sourceRef.definition.get('outgoing').push(...[flow.definition]);
+      }
       remount = true;
     }
     if (flow && data.targetRefId) {
       const targetRef = this.getNodeById(data.targetRefId);
       flow.definition.set('targetRef', targetRef.definition);
+      const incoming = targetRef.definition.get('incoming')
+        .find((element) => element.id === flow.definition.id);
+      if (!incoming) {
+        targetRef.definition.get('incoming').push(...[flow.definition]);
+      }
       remount = true;
     }
     if (remount) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The flow should not disappear 
Actual behavior: 
The flow disappears after changing the typo of the component 
## Solution
- Created service "update Flows" (microservice-Realtime)
- Parse waypoint because produce inconsistency with properties
- update node migrator to support Realtime edition
- add update Flows client 
- add update flows microservice client consumer

[flow-shapeMutations.webm](https://github.com/ProcessMaker/modeler/assets/1401911/3fa6e890-1542-414b-b8f5-f883dfac7b87)

## How to Test


1. Test the steps above
2. Create a process 
3. Add form task
4. Add End Event
5. Connect the form task with the end event 
6. Open the process with two users to enable the collaborative mode
7. Change the type of form task to manual task

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11955

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
