### PR TITLE
FOUR-12297: Elements are copied out of the pool in collaborative modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1106,6 +1106,12 @@ export default {
       diagram.bounds.x = data.x;
       diagram.bounds.y = data.y;
       const newNode = this.createNode(data.type, definition, diagram);
+      //verify if the node has a pool as a container
+      if (data.poolId) {
+        const pool = this.getElementByNodeId(data.poolId);
+        this.poolTarget = pool;
+
+      }
       await this.addNode(newNode, data.id, true);
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1110,7 +1110,6 @@ export default {
       if (data.poolId) {
         const pool = this.getElementByNodeId(data.poolId);
         this.poolTarget = pool;
-
       }
       await this.addNode(newNode, data.id, true);
       await this.$nextTick();

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -598,8 +598,10 @@ export default {
       shapes.filter(shape => !shapesToNotTranslate.includes(shape.model.get('type')))
         .forEach(shape => {
           if (shape.model.get('type') === 'processmaker.modeler.bpmn.pool') {
-            const children = shape.model.component.getElementsUnderArea(shape.model, this.graph);
-            changed = [...changed, ...this.getContainerProperties(children, changed)];
+            const childrens = shape.model.component.getElementsUnderArea(shape.model, this.graph)
+              .filter((element) => element.component);
+
+            changed = [...changed, ...this.getContainerProperties(childrens, changed)];
           } else {
             const { node } = shape.model.component;
             const defaultData = {
@@ -655,9 +657,9 @@ export default {
       });
       return boundariesChanged;
     },
-    getContainerProperties(children) {
+    getContainerProperties(childrens) {
       const changed = [];
-      children.forEach(model => {
+      childrens.forEach(model => {
         changed.push({
           id: model.component.node.definition.id,
           properties: {

--- a/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
+++ b/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-avatar-group class="container" v-if="!isMultiplayer">
+  <b-avatar-group class="container" v-show="!isMultiplayer">
     <template v-for="item in filteredPlayers" >
       <Avatar :badgeBackgroundColor="item.color" :imgSrc="item.avatar" :userName="item.name" :key="item.key"/>
     </template>

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -245,7 +245,6 @@ export default class Multiplayer {
   removeNode(data) {
     const index =  this.getIndex(data.definition.id);
     if (index >= 0) {
-      this.removeShape(data);
       this.yArray.delete(index, 1); // delete one element
       // Encode the state as an update and send it to the server
       const stateUpdate = Y.encodeStateAsUpdate(this.yDoc);

--- a/tests/e2e/specs/BoundaryTimerEvent.cy.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.cy.js
@@ -196,8 +196,8 @@ describe('Boundary Timer Event', { scrollBehavior: false }, () => {
           .trigger('mouseup')
           .then(waitToRenderAllShapes)
           .then(() => {
-            const task2Xml = '<bpmn:task id="node_13" name="Form Task" pm:assignment="requester" />';
-            const boundaryEventOnTask2Xml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_13">';
+            const task2Xml = '<bpmn:task id="node_12" name="Form Task" pm:assignment="requester" />';
+            const boundaryEventOnTask2Xml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_12">';
 
             assertDownloadedXmlContainsExpected(task2Xml, boundaryEventOnTask2Xml);
             assertDownloadedXmlDoesNotContainExpected(boundaryEventOnTaskXml);

--- a/tests/e2e/specs/MessageFlows.cy.js
+++ b/tests/e2e/specs/MessageFlows.cy.js
@@ -259,7 +259,7 @@ describe('Message Flows', { scrollBehavior: false }, () => {
     const boundaryEventId = 'node_18';
     const endEventXml = `<bpmn:endEvent id="${endEventId}" name="Message End Event">`;
     const boundaryEventXml = `<bpmn:boundaryEvent id="${boundaryEventId}" name="Boundary Message Event" attachedToRef="node_12">`;
-    const messageFlowXml = `<bpmn:messageFlow id="node_20" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
+    const messageFlowXml = `<bpmn:messageFlow id="node_19" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
 
     assertDownloadedXmlContainsExpected(endEventXml, boundaryEventXml, messageFlowXml);
   });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The elements should not copied out of the pool with collaborative modeler

Actual behavior: 
Elements are copied out of the pool in collaborative modeler 
## Solution
- Validation was added to verify if the node has a pool as a container.
- remove an unnecessary method
[FOUR-12297.webm](https://github.com/ProcessMaker/modeler/assets/1401911/b84e0077-926a-4486-8689-307ccf5a3a84)

## How to Test
1. Create a process.
2. Open the process with two users different.
3. With one user 
4. Add one element. 
5. Add a pool.
6. With another user
7. Select the element and copy the element many times.


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12297

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
