### PR TITLE
FOUR-10597: Message in Descion task is not correct when any Descion table is assigned

### DIFF
--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -161,9 +161,7 @@ export default {
         return;
       }
 
-      const previewConfig = this.previewConfigs.find(config => {
-        return config.matcher(this.data);
-      });
+      const previewConfig = this.getConfig(this.data);
 
       let clone = {};
       for (let prop in this.data) {
@@ -176,7 +174,11 @@ export default {
 
       // if the node has the configurations (for example screenRef for a task in a task)
       const nodeHasConfigParams = Object.keys(clone).length > 0;
-      this.previewUrl = previewConfig &&  nodeHasConfigParams ? `${previewConfig.url}?node=${nodeData}` : null;
+      const nodeHasConfiguredAssets = !!previewConfig.assetUrl(this.data);
+      this.previewUrl = nodeHasConfiguredAssets && previewConfig &&  nodeHasConfigParams
+        ? `${previewConfig.url}?node=${nodeData}`
+        : null;
+
       this.taskTitle = this.highlightedNode?.definition?.name;
     },
     onClose() {

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -174,7 +174,7 @@ export default {
 
       // if the node has the configurations (for example screenRef for a task in a task)
       const nodeHasConfigParams = Object.keys(clone).length > 0;
-      const nodeHasConfiguredAssets = !!previewConfig.assetUrl(this.data);
+      const nodeHasConfiguredAssets = !!previewConfig?.assetUrl(this.data);
 
       this.previewUrl = nodeHasConfiguredAssets && previewConfig &&  nodeHasConfigParams
         ? `${previewConfig.url}?node=${nodeData}`

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -175,7 +175,6 @@ export default {
       // if the node has the configurations (for example screenRef for a task in a task)
       const nodeHasConfigParams = Object.keys(clone).length > 0;
       const nodeHasConfiguredAssets = !!previewConfig.assetUrl(this.data);
-
       this.previewUrl = nodeHasConfiguredAssets && previewConfig &&  nodeHasConfigParams
         ? `${previewConfig.url}?node=${nodeData}`
         : null;

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -175,6 +175,7 @@ export default {
       // if the node has the configurations (for example screenRef for a task in a task)
       const nodeHasConfigParams = Object.keys(clone).length > 0;
       const nodeHasConfiguredAssets = !!previewConfig.assetUrl(this.data);
+
       this.previewUrl = nodeHasConfiguredAssets && previewConfig &&  nodeHasConfigParams
         ? `${previewConfig.url}?node=${nodeData}`
         : null;

--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -41,15 +41,16 @@ $inspector-column-min-width: 200px;
   width: 100%;
 }
 
-.preview-column .control-bar .actions div {
+.preview-column .control-bar .actions {
   width: 100%;
-  padding-right: 15px;
+  padding-right: 45px;
   text-align: right;
 }
 
-.preview-column .control-bar .actions div i {
+.preview-column .control-bar .actions i {
   width: 20px;
   cursor: pointer;
+  margin-left: 5px;
 }
 
 .task-title {


### PR DESCRIPTION
## Issue & Reproduction Steps
    Create a process
    Add Descion task
    No Decision table must be assigned in the control
    Click on the “Preview“ button
    Check the message that appears in the Preview Pane 

Expected behavior: 
It should show a message like other controls 
![image](https://github.com/ProcessMaker/modeler/assets/14875032/3ac09cf6-4111-4b14-8f5e-b9fbb2aa9f22)

Actual behavior: 
empty screen is shown when no table decision is assigned
## Solution
-Now modeler verifies if the decision table has a table assigned to show the preview.

## How to Test
Test the steps above

## Related Tickets & Packages
Fixes
- https://processmaker.atlassian.net/browse/FOUR-10597
- https://processmaker.atlassian.net/browse/FOUR-12387

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
