### PR TITLE
FOUR-12262: Avatar icon does not appear when two users are editing the process

### DIFF
--- a/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
+++ b/src/components/topRail/multiplayerViewUsers/MultiplayerViewUsers.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-avatar-group class="container" v-show="!isMultiplayer">
+  <b-avatar-group class="container" v-show="isMultiplayer">
     <template v-for="item in filteredPlayers" >
       <Avatar :badgeBackgroundColor="item.color" :imgSrc="item.avatar" :userName="item.name" :key="item.key"/>
     </template>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
It appears for a few seconds when the process is refreshed. The avatar icon appears permanently when the other user goes to another page as a designer.
Actual behavior: 
The avatar icon does not appears with two users editing the same process 
## Solution
- Multiplayer avatar was enabled
![image](https://github.com/ProcessMaker/modeler/assets/1401911/a00089c2-239b-4f05-9988-579fe30c8fc7)

## How to Test
Test the steps above

1. Create a process 
2. Open the process with two users with different
3. Doing some changes with the first users 
4. Check the avatar icon. 
5. Refresh the page
6. Check the avatar icon 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12262

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
