### PR TITLE
FOUR-12263: The selection box leaves the elements in collaborative modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1633,6 +1633,12 @@ export default {
         this.players.splice(playerIndex, 1);
       }
     },
+    /**
+     * Update the lasso tool
+     */
+    updateLasso(){
+      this.$refs.selector.updateSelectionBox();
+    },
   },
   created() {
     if (runningInCypressTest()) {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -410,6 +410,7 @@ export default class Multiplayer {
       if (newPool && element.component.node.pool && element.component.node.pool.component.id !== data.poolId) {
         element.component.node.pool.component.moveElementRemote(element, newPool);
       }
+      this.modeler.updateLasso();
     }
   }
   attachBoundaryEventToNode(element, data) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The selection box should not leaves the elements selected if the other users move the same selection 
Actual behavior: 
The selection box leaves the elements in collaborative modeler 
## Solution
- Create update selectionBox method
[selectionbox(1).webm](https://github.com/ProcessMaker/modeler/assets/1401911/26911a24-192b-40e8-9932-a5649b6654a7)

## How to Test
Test the steps above

1. Create a process 
2. Add some element
3. Start Event → Task → End Event 
4. Open the process with two users different
5. With one user select the element 
6. With the other users select the same elements
7. With the same user move the selection 
8. Check the selection with the other users

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12263

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
