### PR TITLE
FOUR-11608 | Error: Cannot Read Properties of Undefined Reading ‘Label’ When Changing the Task Type in Modeler

### DIFF
--- a/src/components/nodes/subProcess/subProcess.vue
+++ b/src/components/nodes/subProcess/subProcess.vue
@@ -41,6 +41,7 @@
 </template>
 
 <script>
+import debounce from 'lodash/debounce';
 import { util } from 'jointjs';
 import portsConfig from '@/mixins/portsConfig';
 import TaskShape from '@/components/nodes/task/shape';
@@ -128,7 +129,7 @@ export default {
     },
   },
   watch: {
-    'node.definition.name'(name) {
+    'node.definition.name': debounce(function(name) {
       const { width } = this.node.diagram.bounds;
       this.shape.attr('label/text', util.breakText(name, { width }));
 
@@ -142,7 +143,7 @@ export default {
         this.shape.resize(width, newHeight);
         this.recalcMarkersAlignment();
       }
-    },
+    }, 300),
     'node.definition.config'(config) {
       store.commit('updateNodeProp', {
         node: this.node,

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -23,6 +23,7 @@
 </template>
 
 <script>
+import debounce from 'lodash/debounce';
 import { util } from 'jointjs';
 import highlightConfig from '@/mixins/highlightConfig';
 import portsConfig from '@/mixins/portsConfig';
@@ -97,7 +98,7 @@ export default {
     },
   },
   watch: {
-    'node.definition.name'(name) {
+    'node.definition.name': debounce(function(name) {
       const { width } = this.node.diagram.bounds;
       this.shape.attr('label/text', util.breakText(name, { width }));
       const { height } = this.shape.size();
@@ -109,7 +110,7 @@ export default {
         this.shape.resize(width, newHeight);
         this.recalcMarkersAlignment();
       }
-    },
+    }, 300),
     'node.definition.isForCompensation'() {
       setupCompensationMarker(this.node.definition, this.markers, this.$set, this.$delete);
     },


### PR DESCRIPTION
# Issue
Ticket: [FOUR-11608](https://processmaker.atlassian.net/browse/FOUR-11608)

When modifying a task's type in the Process Modeler, an error occurred:

`("Cannot read properties of undefined (reading 'label')")`. 

This issue stemmed from `node.definition.name` watchers in `task.vue` and `subProcess.vue`. These watchers accessed data from the shapeView computed property (defined in `highlightConfig.js`) before it was fully available, leading to errors.

# Solution
A debounce was implemented on the watchers, ensuring that the shapeView property updated before accessing its data. This adjustment prevented premature access attempts to `this.shapeView.selectors.label`, resolving the error related to task type modifications.

# How to Test
1. Go to branch `observation/FOUR-11608` in `modeler`.
2. Go to Designer → Processes. Open or create a Process.
3. Add a task to the Process Modeler. You can also use a pre-existing task.
4. Open your console.
5. Change the task type. Test changing to each task type.
6. No console errors should appear as a result of changing the task type.

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-11608]: https://processmaker.atlassian.net/browse/FOUR-11608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ