### PR TITLE
FOUR-11975: The flows of the Data Store & Object are not reflected ater cloned them in collaborative modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1177,7 +1177,6 @@ export default {
         'processmaker-modeler-sequence-flow',
         'processmaker-modeler-association',
         'processmaker-modeler-data-input-association',
-        'processmaker-modeler-data-input-association',
         'processmaker-modeler-boundary-timer-event',
         'processmaker-modeler-boundary-error-event',
         'processmaker-modeler-boundary-signal-event',

--- a/src/mixins/cloneSelection.js
+++ b/src/mixins/cloneSelection.js
@@ -128,7 +128,7 @@ export default {
         const originalTargetElement = this.getDataInputOutputAssociationTargetRef(originalAssociation.definition);
         const clonedElement = clonedNodes.find(node => node.cloneOf === originalTargetElement.id);
         const clonedDataInput = getOrFindDataInput(this.moddle, clonedElement, srcClone.definition);
-
+        clonedDataInput.$parent.$parent = clonedElement.definition;
         clonedAssociation.definition.set('sourceRef', [srcClone.definition]);
         clonedAssociation.definition.set('targetRef', clonedDataInput);
         clonedElement.definition.set('dataInputAssociations', [clonedAssociation.definition]);


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
The flows of the Data store and object should be cloned in a collaborative modeler
Actual behavior: 
The flows of the Data store and object are not cloned in the collaborative modeler
## Solution
- Fix an old bug data **targetRef** $parent property  was missed during the clone procedure

[data-object-input.webm](https://github.com/ProcessMaker/modeler/assets/1401911/4b95c37f-460f-4a07-9113-30c30019d5a9)


## How to Test
Test the steps above

1. Create a process with:
2. Data Store → Task form
3. Open the process with two different users
4. With one user selecting the elements 
5. Clone the selection

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11975

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
