### PR TITLE
FOUR-12391 configuration of boundaries events is not reflected in collaborative mode

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1181,7 +1181,7 @@ export default {
         'processmaker-modeler-boundary-timer-event',
         'processmaker-modeler-boundary-error-event',
         'processmaker-modeler-boundary-signal-event',
-        'processmaker-modeler-boundary-conditional-even',
+        'processmaker-modeler-boundary-conditional-event',
         'processmaker-modeler-boundary-message-event',
       ];
       if (!this.isMultiplayer) {

--- a/src/components/nodes/boundaryEvent/boundaryEvent.vue
+++ b/src/components/nodes/boundaryEvent/boundaryEvent.vue
@@ -210,6 +210,16 @@ export default {
         attachedToRef: this.node.definition.get('attachedToRef'),
       };
 
+      const eventDefinition = this.node.definition.get('eventDefinitions')[0];
+      const eventDefinitionType = Object.keys(eventDefinition).reduce((acc, key) => {
+        if (key.startsWith('time')) {
+          acc[key] = eventDefinition[key];
+        }
+        return acc;
+      }, {});
+
+      const type = Object.keys(eventDefinitionType)[0];
+
       window.ProcessMaker.EventBus.$emit('multiplayer-addBoundaryEvent', {
         x: this.node.diagram.bounds.x,
         y: this.node.diagram.bounds.y,
@@ -220,6 +230,11 @@ export default {
         type: this.node.type,
         id: this.node.definition.id,
         color: this.node.definition.get('color'),
+        cancelActivity: this.node.definition.get('cancelActivity'),
+        eventTimerDefinition: {
+          type,
+          body: eventDefinitionType[type]?.body,
+        },
       });
     },
   },
@@ -234,9 +249,9 @@ export default {
     const task = this.getTaskUnderShape();
     this.attachBoundaryEventToTask(task);
     this.updateShapePosition(task);
-    
+
     if (this.node.fromCrown) {
-      this.addMultiplayerBoundaryEvent();  
+      this.addMultiplayerBoundaryEvent();
     }
   },
 };

--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -10,6 +10,20 @@ import { defaultDurationTimerEvent } from '@/constants';
 
 export const id = 'processmaker-modeler-boundary-timer-event';
 
+export const setEventTimerDefinition = (moddle, node, type, body) => {
+  const eventDefinition = {
+    [type]: moddle.create('bpmn:Expression', { body }),
+  };
+
+  const eventDefinitions = [
+    moddle.create('bpmn:TimerEventDefinition', eventDefinition),
+  ];
+
+  eventDefinitions[0].id = node.definition.get('eventDefinitions')[0].id;
+
+  return eventDefinitions;
+};
+
 export default merge(cloneDeep(boundaryEventConfig), {
   id,
   component,
@@ -58,17 +72,18 @@ export default merge(cloneDeep(boundaryEventConfig), {
           continue;
         }
 
-        const eventDefinition = {
-          [type]: moddle.create('bpmn:Expression', { body }),
-        };
-
-        const eventDefinitions = [
-          moddle.create('bpmn:TimerEventDefinition', eventDefinition),
-        ];
-
-        eventDefinitions[0].id = node.definition.get('eventDefinitions')[0].id;
+        const eventDefinitions = setEventTimerDefinition(moddle, node, type, body);
 
         setNodeProp(node, 'eventDefinitions', eventDefinitions);
+
+        window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+          id: node.definition.id,
+          key: 'eventTimerDefinition',
+          value: {
+            type,
+            body,
+          },
+        });
       } else {
         window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
           id: node.definition.id , key, value: value[key],

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -4,6 +4,7 @@ import { getNodeIdGenerator } from '../NodeIdGenerator';
 import { getDefaultAnchorPoint } from '@/portsUtils';
 import Room from './room';
 import store from '@/store';
+import { setEventTimerDefinition } from '@/components/nodes/boundaryTimerEvent';
 
 export default class Multiplayer {
   clientIO = null;
@@ -558,8 +559,8 @@ export default class Multiplayer {
         return;
       }
       const keys = Object.keys(data).filter((key) => key !== 'id');
-      const key = keys[0];
-      const value = data[key];
+      let key = keys[0];
+      let value = data[key];
 
       if (key === 'condition') {
         node.definition.get('eventDefinitions')[0].get('condition').body = value;
@@ -603,6 +604,15 @@ export default class Multiplayer {
         }
 
         node.definition.get('eventDefinitions')[0].signalRef = signal;
+      }
+
+      if (key === 'eventTimerDefinition') {
+        const { type, body } = value;
+
+        const eventDefinitions = setEventTimerDefinition(this.modeler.moddle, node, type, body);
+
+        key = 'eventDefinitions';
+        value = eventDefinitions;
       }
 
       const specialProperties = [


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The configuration of boundary events should be reflected in the collaborative modeler

Actual behavior: 
The configuration of boundary events is not reflected in the collaborative modeler 

## Solution
Add support for the configuration of all boundary events in collaborative mode

## How to Test
1. Create a process 
2. Open the process with two users with different session
3. With one user 
4. Add boundary Events like
      a. Boundary Timer Event
      b. Boundary Signal Event
      c. Boundary Conditional Event
      d. Boundary Message Event
5. Change the configuration of the event
6. GO to the other users
7.  The changes must be displayed in the boundary events

Current Behavior 
The configuration of boundary events is not reflected in the collaborative modeler 

## Related Tickets & Packages
[FOUR-12391](https://processmaker.atlassian.net/browse/FOUR-12391)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12391]: https://processmaker.atlassian.net/browse/FOUR-12391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

ci:deploy