### PR TITLE
Bugfix/FOUR-12405: Interstitial option selected is cleared after assigning a new screen in task form

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -102,6 +102,8 @@ export default {
     'highlightedNode.definition.assignedUsers'(current, previous) { this.handleAssignmentChanges(current, previous); },
     'highlightedNode.definition.assignedGroups'(current, previous) { this.handleAssignmentChanges(current, previous); },
     'highlightedNode.definition.assignmentRules'(current, previous) { this.handleAssignmentChanges(current, previous); },
+    'highlightedNode.definition.allowInterstitial'(current, previous) { this.handleAssignmentChanges(current, previous); },
+    'highlightedNode.definition.interstitialScreenRef'(current, previous) { this.handleAssignmentChanges(current, previous); },
   },
   computed: {
     inspectorHeaderTitle() {


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce**
- Create a process 
- Add task form 
- Select the task form 
- Enable Interstitial option
- Assign screen in Screen for Input
- Check the interstitial configuration

Expected behavior: 
Interstitial option selected should not be cleared after assigning a new screen in task form
Actual behavior: 
Interstitial option selected is cleared after assigning a new screen in task form 

## Solution
- Update inspector with interstitial values

**Working video**

https://github.com/ProcessMaker/modeler/assets/90727999/82655f85-221c-4ea6-a7ab-936057017de0


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-12405](https://processmaker.atlassian.net/browse/FOUR-12405)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12405]: https://processmaker.atlassian.net/browse/FOUR-12405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ