### PR TITLE
FOUR-11839 | Add Custom PM Block Icons to Modeler Task

### DIFF
--- a/src/mixins/clickAndDrop.js
+++ b/src/mixins/clickAndDrop.js
@@ -87,6 +87,8 @@ export default {
       } else {
         tempGhost.setAttribute('class', control.icon);
         tempGhost.style.fontSize = '42px';
+        tempGhost.style.width = '42px';
+        tempGhost.style.height = '42px';
       }
 
       document.body.appendChild(tempGhost);

--- a/src/mixins/clickAndDrop.js
+++ b/src/mixins/clickAndDrop.js
@@ -86,6 +86,7 @@ export default {
         tempGhost.src = control.icon;
       } else {
         tempGhost.setAttribute('class', control.icon);
+        tempGhost.style.fontSize = '42px';
       }
 
       document.body.appendChild(tempGhost);


### PR DESCRIPTION
# Issue
Ticket: [FOUR-11839](https://processmaker.atlassian.net/browse/FOUR-11839)

This PR introduces a new feature that enables designers to view their custom PM Block icons in the Process Modeler upon adding a PM Block to a Process.

# How to Test
1. Go to branch `feature/FOUR-11839` in `package-pm-blocks`.
2. Go to branch `feature/FOUR-11839` in `modeler`.
3. Have a PM Block created with a custom icon set.
4. Go to Designer → Processes. Open a Process.
5. Go to the PM Blocks tab. Add a PM Block to the canvas.
6. When a PM Block is clicked, its custom ghost icon should appear (before the element is dropped on the canvas).
7. When a PM Block is dropped, the custom icon should appear on the PM Block element.

ci:next
ci:package-pm-blocks:feature/FOUR-11839

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-11839]: https://processmaker.atlassian.net/browse/FOUR-11839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ