### PR TITLE
FOUR-12379: The configuration of loop activity is not being reflected in sub-process Collaborative modeler

### DIFF
--- a/src/components/nodes/subProcess/index.js
+++ b/src/components/nodes/subProcess/index.js
@@ -5,6 +5,7 @@ import { taskHeight, taskWidth } from '@/components/nodes/task/taskConfig';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
 import defaultNames from '@/components/nodes/task/defaultNames';
+import { loopCharacteristicsHandler } from '@/components/inspectors/LoopCharacteristics';
 
 export const id = 'processmaker-modeler-call-activity';
 
@@ -86,4 +87,5 @@ export default {
       ],
     },
   ],
+  loopCharacteristicsHandler,
 };

--- a/src/setup/addLoopCharacteristics.js
+++ b/src/setup/addLoopCharacteristics.js
@@ -28,10 +28,10 @@ export default (node) => {
   const originalInspectorData = node.inspectorData || null;
 
   // Override the inspector handler to add loop props
-  node.inspectorHandler = (value, node, setNodeProp, moddle, definitions, defaultInspectorHandler) => {
+  node.inspectorHandler = (value, node, setNodeProp, moddle, definitions, defaultInspectorHandler, isMultiplayer) => {
     originalInspectorHandler(value, node, setNodeProp, moddle, definitions, defaultInspectorHandler);
-    value = loopCharacteristicsHandler(value, node, setNodeProp, moddle, definitions);
-    defaultInspectorHandler(value);
+    value = loopCharacteristicsHandler(value, node, setNodeProp, moddle, definitions, isMultiplayer);
+    defaultInspectorHandler(value, isMultiplayer);
   };
 
   // Override the data handler to load loop config into the inspector


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The configuration of loop activity should be reflected in sub-process Collaborative modeler 
Actual behavior: 
The configuration of loop activity is not being reflected in sub-process Collaborative modeler 
## Solution
- added loop support to subprocess

[subprocess-loop.webm](https://github.com/ProcessMaker/modeler/assets/1401911/96e0c566-0f82-4b8d-8dc4-7728db9e117c)

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12379

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
