### PR TITLE
FOUR-12378: The auto save is not enough for the screen change to be updated in Windows Pane

### DIFF
--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -56,7 +56,7 @@
 
       <iframe
         title="Preview"
-        v-show="!!previewUrl && !showSpinner"
+        :style="{visibility: displayPreviewIframe}"
         :src="previewUrl"
         class="preview-iframe"
         @load="loading"
@@ -109,6 +109,11 @@ export default {
   computed: {
     highlightedNode() {
       return store.getters.highlightedNodes[0];
+    },
+    displayPreviewIframe() {
+      const result = !!this.previewUrl && !this.showSpinner;
+      console.log('mostrar iframe', result);
+      return result ? 'visible' : 'hidden';
     },
   },
   methods: {

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -96,14 +96,8 @@ export default {
     },
     highlightedNode() {
       document.activeElement.blur();
-      this.prepareData();
+      this.previewNode();
     },
-    'highlightedNode.definition'(current, previous) { this.handleAssignmentChanges(current, previous); },
-    'highlightedNode.definition.assignmentLock'(current, previous) { this.handleAssignmentChanges(current, previous); },
-    'highlightedNode.definition.allowReassignment'(current, previous) { this.handleAssignmentChanges(current, previous); },
-    'highlightedNode.definition.assignedUsers'(current, previous) { this.handleAssignmentChanges(current, previous); },
-    'highlightedNode.definition.assignedGroups'(current, previous) { this.handleAssignmentChanges(current, previous); },
-    'highlightedNode.definition.assignmentRules'(current, previous) { this.handleAssignmentChanges(current, previous); },
   },
   computed: {
     highlightedNode() {
@@ -137,21 +131,6 @@ export default {
       this.taskTitle = this.data?.name;
 
       this.taskTitle = this?.highlightedNode?.definition?.name;
-      this.previewNode();
-    },
-
-    handleAssignmentChanges(currentValue, previousValue) {
-      if (currentValue === previousValue) {
-        return;
-      }
-
-      const nodeConfig = this.getConfig(this.data);
-
-      if (nodeConfig) {
-        this.prepareData();
-      } else {
-        this.$emit('togglePreview', false);
-      }
     },
     onSelectedPreview(item) {
       this.selectedPreview = item;
@@ -160,7 +139,7 @@ export default {
       if (!this.highlightedNode || (!this.visible && !force)) {
         return;
       }
-
+      this.prepareData();
       const previewConfig = this.getConfig(this.data);
 
       let clone = {};
@@ -179,7 +158,6 @@ export default {
       this.previewUrl = nodeHasConfiguredAssets && previewConfig &&  nodeHasConfigParams
         ? `${previewConfig.url}?node=${nodeData}`
         : null;
-
       this.taskTitle = this.highlightedNode?.definition?.name;
     },
     onClose() {

--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -95,6 +95,13 @@ export default {
       }
     },
     highlightedNode() {
+      // If there isn't preview configuration hide the panel
+      const nodeConfig = this.getConfig(this.data);
+      if (!nodeConfig) {
+        this.$emit('togglePreview', false);
+        return;
+      }
+
       document.activeElement.blur();
       this.previewNode();
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -422,7 +422,10 @@ export default {
   },
   methods: {
     onNodeDefinitionChanged() {
-      this.handlePreview();
+      // re-render the preview just if the preview pane is open
+      if (this.isOpenPreview) {
+        this.handlePreview();
+      }
     },
     onStartPreviewResize(event) {
       this.isResizingPreview = true;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -139,6 +139,7 @@
         @clone-selection="cloneSelection"
         @default-flow="toggleDefaultFlow"
         @shape-resize="shapeResize"
+        @definition-changed="onNodeDefinitionChanged"
       />
 
       <RailBottom
@@ -420,6 +421,9 @@ export default {
     isMultiplayer: () => store.getters.isMultiplayer,
   },
   methods: {
+    onNodeDefinitionChanged( definition) {
+      this.handlePreview();
+    },
     onStartPreviewResize(event) {
       this.isResizingPreview = true;
       this.currentCursorPosition = event.x;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -421,7 +421,7 @@ export default {
     isMultiplayer: () => store.getters.isMultiplayer,
   },
   methods: {
-    onNodeDefinitionChanged( definition) {
+    onNodeDefinitionChanged() {
       this.handlePreview();
     },
     onStartPreviewResize(event) {

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -118,6 +118,7 @@ export default {
       deep: true,
       handler() {
         setupLoopCharacteristicsMarkers(this.node.definition, this.markers, this.$set, this.$delete);
+        this.$emit('definition-changed', this.node.definition);
       },
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps

Steps to Reproduce:

    Log in 
    create a process
    add a screen
    click on preview
    change the screen of the form task
    wait for autosave

Current Behavior: 

The Windows Pane preview is not updated until you click somewhere else in the modeler or save Publish

## Solution
When a task node configuration changes an event is sent. This event is processed by the preview pane to update its content.

## How to Test
Test the steps above

## Related Tickets & Packages
Resolves
https://processmaker.atlassian.net/browse/FOUR-12378
https://processmaker.atlassian.net/browse/FOUR-12374

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:deploy
ci:modeler:FOUR-12378