### PR TITLE
FOUR-12458: Flows are moved in different position in Collaborative modeler

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -585,6 +585,7 @@ export default {
       this.updateSelectionBox();
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getProperties(this.selected));
+        window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getConectedLinkProperties(this.conectedLinks));
       }
     },
 
@@ -600,7 +601,6 @@ export default {
           if (shape.model.get('type') === 'processmaker.modeler.bpmn.pool') {
             const childrens = shape.model.component.getElementsUnderArea(shape.model, this.graph)
               .filter((element) => element.component);
-
             changed = [...changed, ...this.getContainerProperties(childrens, changed)];
           } else {
             const { node } = shape.model.component;
@@ -624,6 +624,38 @@ export default {
           changed = changed.concat(boundariesChanges);
         });
         
+      return changed;
+    },
+    /**
+     * Get connected link properties
+     * @param {Array} links 
+     */
+    getConectedLinkProperties(links) {
+      let changed = [];
+      links.forEach((linkView) => {
+        const waypoint = [];
+        const { node } =  linkView.model.component;
+        node.diagram.waypoint?.forEach(point => {
+          waypoint.push({
+            x: point.x,
+            y: point.y,
+          });
+        });
+        const sourceRefId = linkView.sourceView.model.component.node.definition.id;
+        const targetRefId = linkView.targetView.model.component.node.definition.id;
+        const nodeType = linkView.model.component.node.type;
+        changed.push(
+          {
+            id: node.definition.id,
+            properties: {
+              type: nodeType,
+              waypoint,
+              sourceRefId,
+              targetRefId,
+            },
+          });
+      
+      });
       return changed;
     },
     /**

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -347,7 +347,7 @@ export default {
      */
     prepareConectedLinks(shapes){
       const { paper } = this.paperManager;
-      this.conectedLinks = [];
+      this.connectedLinks = [];
       this.isValidSelectionLinks = true;
       shapes.forEach((shape) => {
         let conectedLinks = this.graph.getConnectedLinks(shape.model);
@@ -368,8 +368,8 @@ export default {
         }
         conectedLinks.forEach((link) => {
           const linkView = paper.findViewByModel(link);
-          if (!this.conectedLinks.some(obj => obj.id === linkView.id)) {
-            this.conectedLinks.push(linkView);
+          if (!this.connectedLinks.some(obj => obj.id === linkView.id)) {
+            this.connectedLinks.push(linkView);
             this.validateSelectionLinks(linkView);
           }
         });
@@ -585,7 +585,7 @@ export default {
       this.updateSelectionBox();
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getProperties(this.selected));
-        window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getConnectedLinkProperties(this.conectedLinks));
+        window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getConnectedLinkProperties(this.connectedLinks));
       }
     },
 
@@ -709,7 +709,7 @@ export default {
      * Selector will update the waypoints of the related flows
      */
     updateFlowsWaypoint(){
-      this.conectedLinks.forEach((link)=> {
+      this.connectedLinks.forEach((link)=> {
         if (link.model.component && link.model.get('type') === 'standard.Link'){
           const start = link.sourceAnchor;
           const end = link.targetAnchor;
@@ -917,7 +917,7 @@ export default {
         if (this.newPool){
           /* Remove the shape from its current pool */
           this.moveElements(this.selected, this.oldPool, this.newPool);
-          this.moveConectedLinks(this.conectedLinks, this.oldPool, this.newPool);
+          this.moveConnectedLinks(this.connectedLinks, this.oldPool, this.newPool);
           this.newPool = null;
           this.oldPool = null;
           this.updateLaneChildren(this.selected);
@@ -1057,7 +1057,7 @@ export default {
           oldPool.model.component.moveElement(shape.model, newPool.model);
         });
     },
-    moveConectedLinks(links, oldPool, newPool){
+    moveConnectedLinks(links, oldPool, newPool){
       links.forEach(link => {
         oldPool.model.component.moveFlow(link.model, newPool.model);
       });

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -585,7 +585,7 @@ export default {
       this.updateSelectionBox();
       if (this.isMultiplayer) {
         window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getProperties(this.selected));
-        window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getConectedLinkProperties(this.conectedLinks));
+        window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', this.getConnectedLinkProperties(this.conectedLinks));
       }
     },
 
@@ -630,7 +630,7 @@ export default {
      * Get connected link properties
      * @param {Array} links 
      */
-    getConectedLinkProperties(links) {
+    getConnectedLinkProperties(links) {
       let changed = [];
       links.forEach((linkView) => {
         const waypoint = [];


### PR DESCRIPTION

## Issue & Reproduction Steps

Expected behavior: 
If Flows are moved their positions should be reflected same for all Collaborative users
Actual behavior: 
Flows are moved in different position in Collaborative modeler 
## Solution
- add support for update flow waypoint in collaborative mode

[pool-flow-waypoint.webm](https://github.com/ProcessMaker/modeler/assets/1401911/77c7115f-58a6-4b2a-88ff-01e5aae479b6)

## How to Test
Test the steps above

1. Create a process
2. Add pool
3. Add elements 
4. Connect the elements with flows
5. Open the process with two user with different session 
6. With one user
7. Click on flow 
8. Move the flow
9. Select the pool 
10. Move the pool
11. Check the flows with the other user 


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12458

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
