### PR TITLE
FOUR-11955_B: fix waypoint updates in collaborative mode

### DIFF
--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -19,13 +19,22 @@ export class NodeMigrator {
       const shape = this._graph.getLinks().find(element => {
         return element.component && element.component.node.definition === definition;
       });
-      shape.component.node._modelerId += '_replaced';
+      const { node } = shape.component;
+      node._modelerId += '_replaced';
+      const waypoint = [];
+      node.diagram.waypoint?.forEach(point => {
+        waypoint.push({
+          x: point.x,
+          y: point.y,
+        });
+      });
       flowNodes.push({
-        id: shape.component.node.definition.id,
-        type: shape.component.node.type,
-        name: shape.component.node.definition.name,
-        sourceRefId: shape.component.node.definition.sourceRef.id,
-        targetRefId: shape.component.node.definition.targetRef.id,
+        id: node.definition.id,
+        type: node.type,
+        name: node.definition.name,
+        waypoint,
+        sourceRefId: node.definition.sourceRef.id,
+        targetRefId: node.definition.targetRef.id,
       });
     };
 

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -633,28 +633,31 @@ export default {
     getConnectedLinkProperties(links) {
       let changed = [];
       links.forEach((linkView) => {
-        const waypoint = [];
-        const { node } =  linkView.model.component;
-        node.diagram.waypoint?.forEach(point => {
-          waypoint.push({
-            x: point.x,
-            y: point.y,
+        const vertices = linkView.model.component.shape.vertices();
+        if (vertices?.length) {
+          const waypoint = [];
+          const { node } =  linkView.model.component;
+
+          node.diagram.waypoint?.forEach(point => {
+            waypoint.push({
+              x: point.x,
+              y: point.y,
+            });
           });
-        });
-        const sourceRefId = linkView.sourceView.model.component.node.definition.id;
-        const targetRefId = linkView.targetView.model.component.node.definition.id;
-        const nodeType = linkView.model.component.node.type;
-        changed.push(
-          {
-            id: node.definition.id,
-            properties: {
-              type: nodeType,
-              waypoint,
-              sourceRefId,
-              targetRefId,
-            },
-          });
-      
+          const sourceRefId = linkView.sourceView.model.component.node.definition.id;
+          const targetRefId = linkView.targetView.model.component.node.definition.id;
+          const nodeType = linkView.model.component.node.type;
+          changed.push(
+            {
+              id: node.definition.id,
+              properties: {
+                type: nodeType,
+                waypoint,
+                sourceRefId,
+                targetRefId,
+              },
+            });
+        }
       });
       return changed;
     },

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -360,7 +360,7 @@ export default class Multiplayer {
 
     if (this.modeler.flowTypes.includes(data.type)) {
       if ('waypoint' in data) {
-        this.updateMovedWaypoints();
+        this.updateMovedWaypoint(element, data);
       } else {
         const node = this.getNodeById(data.id);
         store.commit('updateNodeProp', { node, key: 'color', value: data.color });
@@ -398,7 +398,7 @@ export default class Multiplayer {
    * @param {Object} element
    * @param {Object} data
    */
-  updateMovedWaypoints(element, data ) {
+  updateMovedWaypoint(element, data ) {
     const { waypoint } = data;
     const { paper } = this.modeler;
     // Update the element's waypoints
@@ -698,7 +698,7 @@ export default class Multiplayer {
     }
   }
   /**
-   * Refresh the node Waypoint data
+   * Refresh the node waypoint data
    * @param {Object} element
    */
   refreshNodeWaypoint(element) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
the flow vertices must not disappear if the user changes the task to another type.
Actual behavior: 
the flow vertices disappears if the user changes the task to another type.
## Solution
- Vertices issue was fixed to support multiplayer
`
[waypoint-issues.webm](https://github.com/ProcessMaker/modeler/assets/1401911/fb2a5cba-d839-4275-afaf-7875129f06d9)


## How to Test
Test the steps above

1. Create a process 
2. Add form task
3. Add End Event
4. Connect the form task with the end event 
5. Create flow vertices
6. Open the process with two users to enable the collaborative mode
7. Change the type of form task to manual task

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11955

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
