### PR TITLE
FOUR-12376 signal reference is not reflected in collaborative mode

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1218,6 +1218,7 @@ export default {
             gatewayDirection: null,
             messageRef: null,
             signalRef: null,
+            signalPayload: null,
             extras: {},
           };
           if (node?.pool?.component) {

--- a/src/multiplayer/inspector.utils.js
+++ b/src/multiplayer/inspector.utils.js
@@ -1,0 +1,99 @@
+import { setEventTimerDefinition } from '@/components/nodes/boundaryTimerEvent';
+
+export class InspectorUtils {
+  constructor(modeler, store) {
+    this.modeler = modeler;
+    this.store = store;
+  }
+
+  isSpecialProperty(key) {
+    const specialProperties = [
+      'messageRef', 'signalRef', 'signalPayload', 'gatewayDirection', 'condition', 'allowedUsers', 'allowedGroups',
+    ];
+    return specialProperties.includes(key);
+  }
+
+  updateNodeId(oldNodeId, newId) {
+    const index = this.getIndex(oldNodeId);
+    const yNode = this.yArray.get(index);
+    yNode.set('id', newId);
+    const node = this.getNodeById(oldNodeId);
+    this.store.commit('updateNodeProp', { node, key: 'id', value: newId });
+  }
+
+  handleLoopCharacteristics(node, loopCharacteristics) {
+    const parsedLoopCharacteristics = JSON.parse(loopCharacteristics);
+    this.modeler.nodeRegistry[node.type].loopCharacteristicsHandler({
+      type: node.definition.type,
+      '$loopCharactetistics': {
+        id: node.id,
+        loopCharacteristics: parsedLoopCharacteristics,
+      },
+    }, node, this.setNodeProp, this.modeler.moddle, this.modeler.definitions, false);
+  }
+
+  updateEventCondition(definition, value) {
+    definition.get('eventDefinitions')[0].get('condition').body = value;
+  }
+
+  updateGatewayDirection(definition, value) {
+    definition.set('gatewayDirection', value);
+  }
+
+  updateNodeProperty(node, key, value) {
+    this.store.commit('updateNodeProp', { node, key, value });
+  }
+
+  updateMessageRef(node, value, extras) {
+    let message = this.modeler.definitions.rootElements.find(element => element.id === value);
+
+    if (!message) {
+      message = this.modeler.moddle.create('bpmn:Message', {
+        id: value,
+        name: extras?.messageName || value,
+      });
+      this.modeler.definitions.rootElements.push(message);
+    }
+
+    node.definition.get('eventDefinitions')[0].messageRef = message;
+
+    if (extras?.allowedUsers) {
+      node.definition.set('allowedUsers', extras.allowedUsers);
+    }
+
+    if (extras?.allowedGroups) {
+      node.definition.set('allowedGroups', extras.allowedGroups);
+    }
+  }
+
+  updateSignalRef(node, value, extras) {
+    let signal = this.modeler.definitions.rootElements.find(element => element.id === value);
+
+    if (!signal) {
+      signal = this.modeler.moddle.create('bpmn:Signal', {
+        id: value,
+        name: extras?.signalName || value,
+      });
+      this.modeler.definitions.rootElements.push(signal);
+    }
+
+    node.definition.get('eventDefinitions')[0].signalRef = signal;
+  }
+
+  updateSignalPayload(node, value) {
+    const eventDefinitions = node.definition.get('eventDefinitions');
+    const SIGNAL_EVENT_DEFINITION_TYPE = 'bpmn:SignalEventDefinition';
+
+    eventDefinitions.forEach(definition => {
+      if (definition.$type === SIGNAL_EVENT_DEFINITION_TYPE) {
+        definition.config = value;
+      }
+    });
+  }
+
+  updateEventTimerDefinition(node, value) {
+    const { type, body } = value;
+    const eventDefinitions = setEventTimerDefinition(this.modeler.moddle, node, type, body);
+    this.store.commit('updateNodeProp', { node, key: 'eventDefinitions', value: eventDefinitions });
+  }
+}

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -614,6 +614,17 @@ export default class Multiplayer {
         node.definition.get('eventDefinitions')[0].signalRef = signal;
       }
 
+      if (key === 'signalPayload') {
+        const eventDefinitions = node.definition.get('eventDefinitions');
+        const SIGNAL_EVENT_DEFINITION_TYPE = 'bpmn:SignalEventDefinition';
+
+        eventDefinitions.forEach(definition => {
+          if (definition.$type === SIGNAL_EVENT_DEFINITION_TYPE) {
+            definition.config = value;
+          }
+        });
+      }
+
       if (key === 'eventTimerDefinition') {
         const { type, body } = value;
 
@@ -624,7 +635,7 @@ export default class Multiplayer {
       }
 
       const specialProperties = [
-        'messageRef', 'signalRef', 'gatewayDirection', 'condition', 'allowedUsers', 'allowedGroups',
+        'messageRef', 'signalRef', 'signalPayload', 'gatewayDirection', 'condition', 'allowedUsers', 'allowedGroups',
       ];
 
       if (!specialProperties.includes(key)) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
All changes related to the signal events should be reflected in the other users in collaborative mode

Actual behavior: 
The assignation of the signal reference is not reflected in the other user in collaborative mode 

## Solution
- Add support to the Signal Payload in collaborative mode

## How to Test
Test the steps above
1. Create a process
2. Open the process with two users with different session
3. With one user 
4. Add signal intermediate event
5. Assign a signal reference
6. Saved the changes
7. Go to the modeler of the other users
8. The signal reference must be assigned

## Related Tickets & Packages
[FOUR-12376](https://processmaker.atlassian.net/browse/FOUR-12376)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12376]: https://processmaker.atlassian.net/browse/FOUR-12376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ