### PR TITLE
FOUR-12477: The changes in sub-process name is not reflected in collaborative modeler

### DIFF
--- a/src/components/nodes/subProcess/index.js
+++ b/src/components/nodes/subProcess/index.js
@@ -35,10 +35,18 @@ export default {
     });
   },
   inspectorHandler(value, node, setNodeProp) {
-
-    setNodeProp(node, 'id', value.id);
-    setNodeProp(node, 'name', value.name);
-
+    if (node.definition.get('id') !== value['id']) {
+      window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+        id: node.definition.id, key: 'id', value: value.id,
+      });
+      setNodeProp(node, 'id', value.id);
+    }
+    if (node.definition.get('name') !== value['name']) {
+      window.ProcessMaker.EventBus.$emit('multiplayer-updateInspectorProperty', {
+        id: node.definition.id, key: 'name', value: value.name,
+      });
+      setNodeProp(node, 'name', value.name);
+    }
     const currentConfig = JSON.parse(value.config);
 
     value['calledElement'] = currentConfig.calledElement;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The changes in name sub-process is not reflected in collaborative modeler
Actual behavior: 
The name process is not reflected in collaborative modeler
## Solution
- fix name and id to collaborative inspector handler 
[subprocessname.webm](https://github.com/ProcessMaker/modeler/assets/1401911/996900f2-398f-4a22-9d06-4006c9d1e685)


## How to Test
Test the steps above

1. Create a Process
2. Open the process with two users with different session  
3. Add sub-process
4. Change the name of sub-process
5. Verify if the changed were reflected in the other user

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12477

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
