### PR TITLE
FOUR-12481: Set as default flow option is not being reflected in Collaborative Modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -497,6 +497,14 @@ export default {
       if (source.default && source.default.id === flow.id) {
         flow = null;
       }
+      window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', [
+        {
+          id: source.id,
+          properties: {
+            default: flow?.id || null,
+          },
+        },
+      ]);
       source.set('default', flow);
     },
     cloneElement(node, copyCount) {
@@ -1219,6 +1227,7 @@ export default {
             messageRef: null,
             signalRef: null,
             extras: {},
+            default: null,
           };
           if (node?.pool?.component) {
             defaultData['poolId'] = node.pool.component.id;

--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -19,13 +19,22 @@ export class NodeMigrator {
       const shape = this._graph.getLinks().find(element => {
         return element.component && element.component.node.definition === definition;
       });
-      shape.component.node._modelerId += '_replaced';
+      const { node } = shape.component;
+      node._modelerId += '_replaced';
+      const waypoint = [];
+      node.diagram.waypoint?.forEach(point => {
+        waypoint.push({
+          x: point.x,
+          y: point.y,
+        });
+      });
       flowNodes.push({
-        id: shape.component.node.definition.id,
-        type: shape.component.node.type,
-        name: shape.component.node.definition.name,
-        sourceRefId: shape.component.node.definition.sourceRef.id,
-        targetRefId: shape.component.node.definition.targetRef.id,
+        id: node.definition.id,
+        type: node.type,
+        name: node.definition.name,
+        waypoint,
+        sourceRefId: node.definition.sourceRef.id,
+        targetRefId: node.definition.targetRef.id,
       });
     };
 

--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -633,28 +633,31 @@ export default {
     getConnectedLinkProperties(links) {
       let changed = [];
       links.forEach((linkView) => {
-        const waypoint = [];
-        const { node } =  linkView.model.component;
-        node.diagram.waypoint?.forEach(point => {
-          waypoint.push({
-            x: point.x,
-            y: point.y,
+        const vertices = linkView.model.component.shape.vertices();
+        if (vertices?.length) {
+          const waypoint = [];
+          const { node } =  linkView.model.component;
+
+          node.diagram.waypoint?.forEach(point => {
+            waypoint.push({
+              x: point.x,
+              y: point.y,
+            });
           });
-        });
-        const sourceRefId = linkView.sourceView.model.component.node.definition.id;
-        const targetRefId = linkView.targetView.model.component.node.definition.id;
-        const nodeType = linkView.model.component.node.type;
-        changed.push(
-          {
-            id: node.definition.id,
-            properties: {
-              type: nodeType,
-              waypoint,
-              sourceRefId,
-              targetRefId,
-            },
-          });
-      
+          const sourceRefId = linkView.sourceView.model.component.node.definition.id;
+          const targetRefId = linkView.targetView.model.component.node.definition.id;
+          const nodeType = linkView.model.component.node.type;
+          changed.push(
+            {
+              id: node.definition.id,
+              properties: {
+                type: nodeType,
+                waypoint,
+                sourceRefId,
+                targetRefId,
+              },
+            });
+        }
       });
       return changed;
     },

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -360,7 +360,7 @@ export default class Multiplayer {
 
     if (this.modeler.flowTypes.includes(data.type)) {
       if ('waypoint' in data) {
-        this.updateMovedWaypoints();
+        this.updateMovedWaypoint(element, data);
       } else {
         const node = this.getNodeById(data.id);
         store.commit('updateNodeProp', { node, key: 'color', value: data.color });
@@ -398,7 +398,7 @@ export default class Multiplayer {
    * @param {Object} element
    * @param {Object} data
    */
-  updateMovedWaypoints(element, data ) {
+  updateMovedWaypoint(element, data ) {
     const { waypoint } = data;
     const { paper } = this.modeler;
     // Update the element's waypoints
@@ -698,7 +698,7 @@ export default class Multiplayer {
     }
   }
   /**
-   * Refresh the node Waypoint data
+   * Refresh the node waypoint data
    * @param {Object} element
    */
   refreshNodeWaypoint(element) {

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -165,7 +165,9 @@ export default class Multiplayer {
     });
 
     window.ProcessMaker.EventBus.$on('multiplayer-updateNodes', ( data ) => {
-      this.updateNodes(data);
+      if (this.modeler.isMultiplayer) {
+        this.updateNodes(data);
+      }
     });
 
     window.ProcessMaker.EventBus.$on('multiplayer-replaceNode', ({ nodeData, newControl }) => {
@@ -409,7 +411,7 @@ export default class Multiplayer {
   updateGatewayDefaultFlow(element, data){
     if (Object.hasOwn(data, 'default')) {
       const node = this.getNodeById(data.default);
-      element.component.node.definition.set('default', node);
+      element.component.node.definition.set('default', node || null);
     }
   }
   /**

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -366,17 +366,25 @@ export default class Multiplayer {
         store.commit('updateNodeProp', { node, key: 'color', value: data.color });
       }
     } else {
+      // updata gateway default folow
+      this.updateGatewayDefaultFlow(element, data);
+      if (typeof element.resize === 'function' && data.width && data.height) {
+        element.resize(
+          /* Add labelWidth to ensure elements don't overlap with the pool label */
+          data.width,
+          data.height,
+        );
+      }
       // Update the element's position attribute
-      element.resize(
-        /* Add labelWidth to ensure elements don't overlap with the pool label */
-        data.width,
-        data.height,
-      );
-      element.set('position', { x: data.x, y: data.y });
-
-      const node = this.getNodeById(data.id);
-      store.commit('updateNodeProp', { node, key: 'color', value: data.color });
-
+      if (data.x && data.y) {
+        element.set('position', { x: data.x, y: data.y });
+      }
+      // udpdate the element's color
+      if (data.color) {
+        const node = this.getNodeById(data.id);
+        store.commit('updateNodeProp', { node, key: 'color', value: data.color });
+        return;
+      }
       // boundary type
       if (element.component.node.definition.$type === 'bpmn:BoundaryEvent') {
         this.attachBoundaryEventToNode(element, data);
@@ -391,6 +399,17 @@ export default class Multiplayer {
         element.component.node.pool.component.moveElementRemote(element, newPool);
       }
       this.modeler.updateLasso();
+    }
+  }
+  /**
+   * Update default Flow property
+   * @param {Object} element
+   * @param {Object} data
+   */
+  updateGatewayDefaultFlow(element, data){
+    if (Object.hasOwn(data, 'default')) {
+      const node = this.getNodeById(data.default);
+      element.component.node.definition.set('default', node);
     }
   }
   /**


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Set as default flow option should be reflected in Collaborative Modeler
Actual behavior: 
Set as default flow option is not being reflected in Collaborative Modeler
## Solution
- add support for default flow in collaborative mode

[defaultFlow.webm](https://github.com/ProcessMaker/modeler/assets/1401911/2b7f9f49-5f70-4846-b7a4-6c610fa084ee)


## How to Test
Test the steps above

2. Create a process 
3. Open the process with two users with different session 
4. With one user 
5. Add elements
6. Connect the elements 
7. Select the flow 
8. Click on the “Set as Default Flow“ option
9. Go to the other user
10. Verify if the changes are reflected



## Bloqued by
- https://processmaker.atlassian.net/browse/FOUR-11955
- 
## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12481

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
