### PR TITLE
FOUR-12474 boundary events are left out of the pool

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -599,9 +599,9 @@ export default {
       shapes.filter(shape => !shapesToNotTranslate.includes(shape.model.get('type')))
         .forEach(shape => {
           if (shape.model.get('type') === 'processmaker.modeler.bpmn.pool') {
-            const childrens = shape.model.component.getElementsUnderArea(shape.model, this.graph)
+            const children = shape.model.component.getElementsUnderArea(shape.model, this.graph)
               .filter((element) => element.component);
-            changed = [...changed, ...this.getContainerProperties(childrens, changed)];
+            changed = [...changed, ...this.getContainerProperties(children, changed)];
           } else {
             const { node } = shape.model.component;
             const defaultData = {
@@ -623,12 +623,12 @@ export default {
           const boundariesChanges = this.getBoundariesChangesForShape(shape);
           changed = changed.concat(boundariesChanges);
         });
-        
+
       return changed;
     },
     /**
      * Get connected link properties
-     * @param {Array} links 
+     * @param {Array} links
      */
     getConnectedLinkProperties(links) {
       let changed = [];
@@ -692,10 +692,11 @@ export default {
       });
       return boundariesChanged;
     },
-    getContainerProperties(childrens) {
+    getContainerProperties(children) {
       const changed = [];
-      childrens.forEach(model => {
-        changed.push({
+
+      children.forEach(model => {
+        const defaultData = {
           id: model.component.node.definition.id,
           properties: {
             x: model.get('position').x,
@@ -704,7 +705,13 @@ export default {
             width: model.get('size').width,
             color: model.get('color'),
           },
-        });
+        };
+
+        if (model.component.node.definition.$type === 'bpmn:BoundaryEvent') {
+          defaultData.properties.attachedToRefId = model.component.node.definition.get('attachedToRef')?.id ?? null;
+        }
+
+        changed.push(defaultData);
       });
       return changed;
     },

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -636,7 +636,7 @@ export default class Multiplayer {
     const flow = this.getNodeById(data.id);
     if (flow && data.sourceRefId) {
       const sourceRef = this.getNodeById(data.sourceRefId);
-    
+
       const outgoing = sourceRef.definition.get('outgoing')
         .find((element) => element.id === flow.definition.id);
       if (!outgoing) {
@@ -647,7 +647,7 @@ export default class Multiplayer {
     }
     if (flow && data.targetRefId) {
       const targetRef = this.getNodeById(data.targetRefId);
-     
+
       const incoming = targetRef.definition.get('incoming')
         .find((element) => element.id === flow.definition.id);
       if (!incoming) {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Boundary Events should not be left out of the pool

Actual behavior: 
Boundary Events are left out of the pool

## How to Test
1. Create a process
2. Open the process with two users in a different session
3. Add task with boundary event
4. Add an end event
5. Connect the elements
6. With user 2 
7. Move the pool
8. The boundary must be attached to the task

## Related Tickets & Packages
[FOUR-12474](https://processmaker.atlassian.net/browse/FOUR-12474)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12474]: https://processmaker.atlassian.net/browse/FOUR-12474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ