### PR TITLE
FOUR-12495: Lanes separate from the pool

### DIFF
--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -81,8 +81,9 @@ export default {
       definition,
       diagram,
     );
+    // link the parent pool to the lane
+    node.pool = pool;
     await modeler.addNode(node, data.id, true);
     modeler.setShapeStacking(pool.component.shape);
-
   },
 };


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The lanes must not be separated from the pool
Actual behavior: 
The lanes are separated from the pool
## Solution
- add pool link to the lanes

## How to Test
Test the steps above

1. Create a process
2. Add Two pool
3. One of them added a lane
4. Add task form(Boundary) → End Event
5. Connect the boundary with the end event
6. Select the selection 
7. Copy the selection on the next lane or other pool 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12495

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
