### PR TITLE
FOUR-12546 render lanes on page refresh in collaborative mode

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1128,6 +1128,8 @@ export default {
       const diagram = this.nodeRegistry[data.type].diagram(this.moddle);
       diagram.bounds.x = data.x;
       diagram.bounds.y = data.y;
+      diagram.bounds.width = data.width;
+      diagram.bounds.height = data.height;
       const newNode = this.createNode(data.type, definition, diagram);
       //verify if the node has a pool as a container
       if (data.poolId) {

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -59,7 +59,9 @@ export default {
       name: data.name,
     });
     // Set the position of the pool
-    pool.set('position', { x: data.poolX, y: data.poolY });
+    if (data.poolX && data.poolY) {
+      pool.set('position', { x: data.poolX, y: data.poolY });
+    }
 
     if (!pool.component.laneSet && pool.component.createLaneSet) {
       pool.component.createLaneSet([data.laneSetId]);

--- a/src/components/nodes/poolLane/index.js
+++ b/src/components/nodes/poolLane/index.js
@@ -58,6 +58,9 @@ export default {
     const definition = modeler.moddle.create('bpmn:Lane', {
       name: data.name,
     });
+    // Set the position of the pool
+    pool.set('position', { x: data.poolX, y: data.poolY });
+
     if (!pool.component.laneSet && pool.component.createLaneSet) {
       pool.component.createLaneSet([data.laneSetId]);
       /* If there are currently elements in the pool, add them to the first lane */
@@ -81,6 +84,10 @@ export default {
       definition,
       diagram,
     );
+
+    // Set the pool as the parent of the lane
+    node.pool = pool;
+
     await modeler.addNode(node, data.id, true);
     modeler.setShapeStacking(pool.component.shape);
 


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
It should not show errors when adding a poolLane.

Actual behavior: 
The error "TypeError: Cannot read properties of undefined (reading 'definition')" is displayed, this error is displayed even with imported processes.

## Solution
- Add support to render lanes on page refresh 

## How to Test
1. Create a process
2. Add to pool
3. Add task
4. Add to pool Lane
5. Publish
6. Reload page

## Related Tickets & Packages
[FOUR-12546](https://processmaker.atlassian.net/browse/FOUR-12546)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12546]: https://processmaker.atlassian.net/browse/FOUR-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ