### PR TITLE
FOUR-12008: Added the Generating assets card to Modeler

### DIFF
--- a/src/components/aiMessages/GeneratingAssetsCard.vue
+++ b/src/components/aiMessages/GeneratingAssetsCard.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="message mt-3">
+    <b-card no-body class="h-100 w-100" style="border-radius: 8px;">
+      <div class="h-100 d-flex p-3 justify-content-between align-items-center">
+        <div>
+          <div class="text-left">
+            <inline-svg :src="proceC2Icon" class="ml-0 mr-2 my-auto ai-icon" />
+            <span style="color: #556271; font-weight: 400;">{{ $t("Generating...") }}</span>
+          </div>
+        </div>
+        <div class="p-0">
+          <button
+            class="h-100 px-3 cancelBtn btn btn-secondary"
+            @click="onClose()"
+          >
+            {{ $t("STOP") }}
+          </button>
+        </div>
+      </div>
+    </b-card>
+  </div>
+</template>
+<script>
+import InlineSvg from 'vue-inline-svg';
+
+export default {
+  name: 'GeneratingAssetsCard',
+  components: {
+    InlineSvg,
+  },
+  data() {
+    return {
+      proceC2Icon: require('@/assets/proceC2.svg'),
+    };
+  },
+  methods: {
+    onClose() {
+      this.$emit('stopAssetGeneration');
+    },
+  },
+};
+</script>
+<style scoped>
+.message {
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.10);
+  line-height: 27px;
+  word-wrap: break-word;
+  position: absolute;
+  display: flex;
+  align-items: center;
+  bottom: 35px; 
+  left: 35%;
+  z-index: 1;
+  font-size: 100%;
+  height: 60px;
+  width: 450px;
+}
+
+.ai-icon {
+  width: 22px;
+  height: 22px;
+}
+
+.cancelBtn {
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+
+</style>

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -61,6 +61,11 @@
         v-if="isAiGenerated"
         @closeCreateAssets="onCloseCreateAssets()"
       />
+
+      <GeneratingAssetsCard
+        ref="generatingAssetsCard"
+        v-if="generatingAi"
+      />
       
       <AssetsCreatedCard
         ref="assetsCreatedCard"
@@ -160,6 +165,7 @@
       />
 
       <RailBottom
+        v-if="!generatingAi"
         :nodeTypes="nodeTypes"
         :paper-manager="paperManager"
         :graph="graph"
@@ -196,6 +202,7 @@ import BpmnModdle from 'bpmn-moddle';
 import ExplorerRail from '../rails/explorer-rail/explorer';
 import WelcomeMessage from '../welcome/WelcomeMessage.vue';
 import CreateAssetsCard from '../aiMessages/CreateAssetsCard.vue';
+import GeneratingAssetsCard from '../aiMessages/GeneratingAssetsCard.vue';
 import AssetsCreatedCard from '../aiMessages/AssetsCreatedCard.vue';
 import CreateAssetsFailCard from '../aiMessages/CreateAssetsFailCard.vue';
 import { isJSON } from 'lodash-contrib';
@@ -272,6 +279,7 @@ export default {
     RailBottom,
     WelcomeMessage,
     CreateAssetsCard,
+    GeneratingAssetsCard,
     AssetsCreatedCard,
     CreateAssetsFailCard,
     RemoteCursor,
@@ -372,6 +380,7 @@ export default {
       currentCursorPosition: 0,
       previewPanelWidth: 600,
       isAiGenerated: window.ProcessMaker?.modeler?.isAiGenerated,
+      generatingAi: false,
       assetsCreated: false,
       // ^ TODO: To be changed depending on microservice response
       flowTypes: [


### PR DESCRIPTION
## Description
Unified AI project requires a card that indicates that our microservice is generating the Assets for the selected nodes on a given process in the Modeler project. This card replaces the BottomRail component while the microservice is running and upon completion, the BottomRail is shown again.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12008

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
