### PR TITLE
FOUR-12244 null reference error in waypoints

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -632,7 +632,7 @@ export default {
      */
     getConnectedLinkProperties(links) {
       let changed = [];
-      links.forEach((linkView) => {
+      links?.forEach((linkView) => {
         const vertices = linkView.model.component.shape.vertices();
         if (vertices?.length) {
           const waypoint = [];
@@ -719,7 +719,7 @@ export default {
      * Selector will update the waypoints of the related flows
      */
     updateFlowsWaypoint(){
-      this.connectedLinks.forEach((link)=> {
+      this.connectedLinks?.forEach((link)=> {
         if (link.model.component && link.model.get('type') === 'standard.Link'){
           const start = link.sourceAnchor;
           const end = link.targetAnchor;


### PR DESCRIPTION
## Issue & Reproduction Steps

Actual behavior: 
After reloading and moving the process, the error "Cannot read properties of undefined (reading 'forEach')" is displayed

## Solution
- Validate flow waypoints on page movement

## How to Test
Test the steps above

## Related Tickets & Packages
[FOUR-12546](https://processmaker.atlassian.net/browse/FOUR-12546?focusedCommentId=372434)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-12546]: https://processmaker.atlassian.net/browse/FOUR-12546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ