### PR TITLE
FOUR-11972 Getting the correct value assigned for eventDefinitions

### DIFF
--- a/src/components/nodes/boundaryTimerEvent/index.js
+++ b/src/components/nodes/boundaryTimerEvent/index.js
@@ -1,12 +1,11 @@
 import component from './boundaryTimerEvent.vue';
 import IntermediateTimer from '../../inspectors/IntermediateTimer.vue';
 import boundaryEventConfig from '../boundaryEvent';
-import merge from 'lodash/merge';
-import cloneDeep from 'lodash/cloneDeep';
 import interruptingToggleConfig from '../boundaryEvent/interruptingToggleInspector';
 import advancedAccordionConfig from '@/components/inspectors/advancedAccordionConfig';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
 import { defaultDurationTimerEvent } from '@/constants';
+import { omit, cloneDeep, merge } from 'lodash';
 
 export const id = 'processmaker-modeler-boundary-timer-event';
 
@@ -42,7 +41,7 @@ export default merge(cloneDeep(boundaryEventConfig), {
   inspectorData(node) {
     return Object.entries(node.definition).reduce((data, [key, value]) => {
       if (key === 'eventDefinitions') {
-        const type = Object.keys(value[0])[1];
+        const type = Object.keys(omit(value[0], ['id', '$type', 'get', 'set', '$instanceOf']))[0];
         const body = value[0][type].body;
         data[key] = { type, body };
       } else {


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Boundary Timer Event should keep and show the value previously set or default in reload

Actual behavior: 
Boundary Timer Event wasn't getting the correct value previously set or default since we were assuming that in index 1, the `timeDefinition` was going to be there. 

## Solution
- Getting the correct eventDefinitions type. Using the `omit` from lodash to omit all the objects except the possibilities of timer objects. There could be an argument to use `pick` instead.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-11972
- https://processmaker.atlassian.net/browse/FOUR-12517

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy