### PR TITLE
FOUR-12028: Added Asset Generation to FE and Stop feature

### DIFF
--- a/src/components/aiMessages/CreateAssetsFailCard.vue
+++ b/src/components/aiMessages/CreateAssetsFailCard.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="customAlert mx-auto mt-2">
-    <b-alert show dismissible variant="warning">
+    <b-alert
+      show
+      dismissible
+      variant="warning"
+      @dismissed="onDismiss()"
+    >
       {{ $t("Generation of assets was not able to complete. Try again") }}
     </b-alert>
   </div>
@@ -10,6 +15,11 @@ export default {
   name: 'CreateAssetsFailCard',
   data() {
     return {};
+  },
+  methods: {
+    onDismiss() {
+      this.$emit('onDismiss');
+    },
   },
 };
 </script>

--- a/src/components/aiMessages/GeneratingAssetsCard.vue
+++ b/src/components/aiMessages/GeneratingAssetsCard.vue
@@ -11,7 +11,7 @@
         <div class="p-0">
           <button
             class="h-100 px-3 cancel-btn btn btn-secondary"
-            @click="onClose()"
+            @click="onStop()"
           >
             {{ $t("STOP") }}
           </button>
@@ -34,7 +34,7 @@ export default {
     };
   },
   methods: {
-    onClose() {
+    onStop() {
       this.$emit('stopAssetGeneration');
     },
   },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1886,8 +1886,8 @@ export default {
       const url = '/package-ai/generateProcessArtifacts';
 
       window.ProcessMaker.apiClient.post(url, params)
-        .then((response) => {
-          console.log('generate', response);
+        .then(() => {
+          // Response
         })
         .catch((error) => {
           const errorMsg = error.response?.data?.message || error.message;
@@ -1901,7 +1901,6 @@ export default {
       window.Echo.private(channel).listen(
         streamProgressEvent,
         (response) => {
-          console.log('subscribe', response);
           if (response.data.promptSessionId !== this.promptSessionId) {
             return;
           }
@@ -1913,15 +1912,15 @@ export default {
           if (response.data) {
             if (response.data.progress.status === 'running') {
               this.loadingAI = true;
-              console.log('running', response);
+              // Blue color for nodes running
             } else if (response.data.progress.status === 'error') {
               this.loadingAI = false;
               window.ProcessMaker.alert(response.data.message, 'danger');
-              console.log('error', response);
+              // Stop and show error
               this.assetFail = true;
             } else {
               this.setPromptSessions(response.data.promptSessionId);
-              console.log('success', response);
+              // Successful generation 
               this.assetsCreated = true;
               this.fetchHistory();
               setTimeout(() => {

--- a/src/components/toolbar/ToolBar.vue
+++ b/src/components/toolbar/ToolBar.vue
@@ -9,6 +9,7 @@
           :validation-errors="validationErrors"
           :warnings="warnings"
           :players="players"
+          v-on="$listeners"
         >
           <component
             :is="component.button"

--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -7,7 +7,9 @@
       @openPanel="handleOpenPanel"
     />
 
-    <AiGenerateButton/>
+    <AiGenerateButton
+      v-on="$listeners"
+    />
 
     <ValidateButton @openIssue="handleOpenIssue" />
 


### PR DESCRIPTION
## Description
AI Unified Project requires the endpoint generateProcessArtifacts to generate the assets for a process in Modeler. It also requires that there is a button that can halt the request to generate those assets, which both are included in this branch.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12028

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
