### PR TITLE
FOUR-12026: Nodes are highlighted depending on Asset Generation progress

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1895,6 +1895,34 @@ export default {
           this.assetFail = true;
         });
     },
+    highlightTaskArrays(data) {
+      if (data) {
+        this.addAiHighlights(data.tasks);
+        this.addAiHighlights(data.serviceTasks);
+        this.addAiHighlights(data.scriptTasks);
+      }
+    },
+    unhighlightTaskArrays(data) {
+      if (data) {
+        this.removeAiHighlights(data.tasks);
+        this.removeAiHighlights(data.serviceTasks);
+        this.removeAiHighlights(data.scriptTasks);
+      }
+    },
+    addAiHighlights(taskArray) {
+      let self = this;
+      taskArray.forEach(task => {
+        const taskNode = self.getElementByNodeId(task.id);
+        taskNode.component.setAiStatusHighlight(task.status);
+      });
+    },
+    removeAiHighlights(taskArray) {
+      let self = this;
+      taskArray.forEach(task => {
+        const taskNode = self.getElementByNodeId(task.id);
+        taskNode.component.unsetHighlights();
+      });
+    },
     subscribeToProgress() {
       const channel = `ProcessMaker.Models.User.${window.ProcessMaker?.modeler?.process?.user_id}`;
       const streamProgressEvent = '.ProcessMaker\\Package\\PackageAi\\Events\\GenerateArtifactsProgressEvent';
@@ -1902,52 +1930,19 @@ export default {
         streamProgressEvent,
         (response) => {
           if (response.data.promptSessionId !== this.promptSessionId) {
-            response.data?.tasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
-            response.data?.serviceTasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
-            response.data?.scriptTasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
+            this.unhighlightTaskArrays(response.data);
             return;
           }
 
           if (this.cancelledJobs.some((element) => element === response.data.nonce)) {
-            response.data?.tasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
-            response.data?.serviceTasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
-            response.data?.scriptTasks.forEach(task => {
-              const taskNode = this.getElementByNodeId(task.id);
-              taskNode.component.unsetHighlights();
-            });
+            this.unhighlightTaskArrays(response.data);
             return;
           }
 
           if (response.data) {
             if (response.data.progress.status === 'running') {
               this.loadingAI = true;
-              response.data?.tasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.setAiStatusHighlight(task.status);
-              });
-              response.data?.serviceTasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.setAiStatusHighlight(task.status);
-              });
-              response.data?.scriptTasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.setAiStatusHighlight(task.status);
-              });
+              this.highlightTaskArrays(response.data);
             } else if (response.data.progress.status === 'error') {
               this.loadingAI = false;
               window.ProcessMaker.alert(response.data.message, 'danger');
@@ -1957,19 +1952,7 @@ export default {
               this.setPromptSessions(response.data.promptSessionId);
               // Successful generation 
               this.assetsCreated = true;
-
-              response.data?.tasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.unsetHighlights();
-              });
-              response.data?.serviceTasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.unsetHighlights();
-              });
-              response.data?.scriptTasks.forEach(task => {
-                const taskNode = this.getElementByNodeId(task.id);
-                taskNode.component.unsetHighlights();
-              });
+              this.unhighlightTaskArrays(response.data);
               this.fetchHistory();
               setTimeout(() => {
                 this.loadingAI = false;

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1902,17 +1902,52 @@ export default {
         streamProgressEvent,
         (response) => {
           if (response.data.promptSessionId !== this.promptSessionId) {
+            response.data?.tasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
+            response.data?.serviceTasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
+            response.data?.scriptTasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
             return;
           }
 
           if (this.cancelledJobs.some((element) => element === response.data.nonce)) {
+            response.data?.tasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
+            response.data?.serviceTasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
+            response.data?.scriptTasks.forEach(task => {
+              const taskNode = this.getElementByNodeId(task.id);
+              taskNode.component.unsetHighlights();
+            });
             return;
           }
 
           if (response.data) {
             if (response.data.progress.status === 'running') {
               this.loadingAI = true;
-              // Blue color for nodes running
+              response.data?.tasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.setAiStatusHighlight(task.status);
+              });
+              response.data?.serviceTasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.setAiStatusHighlight(task.status);
+              });
+              response.data?.scriptTasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.setAiStatusHighlight(task.status);
+              });
             } else if (response.data.progress.status === 'error') {
               this.loadingAI = false;
               window.ProcessMaker.alert(response.data.message, 'danger');
@@ -1922,6 +1957,19 @@ export default {
               this.setPromptSessions(response.data.promptSessionId);
               // Successful generation 
               this.assetsCreated = true;
+
+              response.data?.tasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.unsetHighlights();
+              });
+              response.data?.serviceTasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.unsetHighlights();
+              });
+              response.data?.scriptTasks.forEach(task => {
+                const taskNode = this.getElementByNodeId(task.id);
+                taskNode.component.unsetHighlights();
+              });
               this.fetchHistory();
               setTimeout(() => {
                 this.loadingAI = false;

--- a/src/mixins/highlightConfig.js
+++ b/src/mixins/highlightConfig.js
@@ -143,7 +143,29 @@ export default {
       } else {
         this.shapeView.unhighlight(this.shapeBody, this.prepareCustomColorHighlighter(color));
       }
-     
+    },
+    setAiStatusHighlight(status) {
+      this.shapeView.unhighlight(this.shapeBody, completedHighlighter);
+      if (status === 'generated') {
+        this.shape.attr('body/fill', COLOR_COMPLETED_FILL);
+        this.shapeView.highlight(this.shapeBody, completedHighlighter);
+      }
+      this.shapeView.unhighlight(this.shapeBody, inProgressHighlighter);
+      if (status === 'generating') {
+        this.shape.attr('body/fill', COLOR_IN_PROGRESS_FILL);
+        this.shapeView.highlight(this.shapeBody, inProgressHighlighter);
+      }
+      this.shapeView.unhighlight(this.shapeBody, idleHighlighter);
+      if (status === 'previously generated') {
+        this.shape.attr('body/fill', COLOR_IDLE_FILL);
+        this.shapeView.highlight(this.shapeBody, idleHighlighter);
+      }
+    },
+    unsetHighlights() {
+      this.shape.attr('body/fill', '#FFFFFF');
+      this.shapeView.unhighlight(this.shapeBody, inProgressHighlighter);
+      this.shapeView.unhighlight(this.shapeBody, completedHighlighter);
+      this.shapeView.unhighlight(this.shapeBody, idleHighlighter);
     },
     setShapeHighlightForReadOnly() {
       if (!this.shapeView) {


### PR DESCRIPTION
## Description
AI Unified Project required the nodes of a process to be highlighted depending on OpenAI microservice that generates the Assets for each task in the process. All task nodes that are involved in the asset generation process are highlighted to their respective colors.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12026

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
