### PR TITLE
FOUR-12827: Generating message now shows instantly when generating assets

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1875,6 +1875,9 @@ export default {
     generateAssets() {
       this.getNonce();
 
+      // Show Generating message
+      this.loadingAI = true;
+
       this.fetchHistory();
 
       const params = {


### PR DESCRIPTION
## Description
AI Unified project requires that upon pressing the **Generate Assets** button, a popup will instantly show on the bottom center of the screen replacing the Bottom Rail.

## Solution
- Changed the timing of when the Generating message appears to appear on the first request.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12827

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
