### PR TITLE
FOUR-12825: Generation panel from AI button now hides when generating

### DIFF
--- a/src/components/aiMessages/AiGenerateButton.vue
+++ b/src/components/aiMessages/AiGenerateButton.vue
@@ -46,6 +46,7 @@ export default {
   },
   methods: {
     onGenerateAssets() {
+      this.showPopover = false;
       this.$emit('onGenerateAssets');
     },
   },


### PR DESCRIPTION
## Description
AI Unified project on Modeler requires that the panel containing the Generate Assets button disappears whenever the button is pushed so that the main focus for the user is to watch how the process generates the assets in real time. 

## Solution
- Added the toggle for the panel upon pressing the Generate button.

## How to Test
Test the steps above

## Related Tickets & Packages
- 

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
