### PR TITLE
FOUR-12839: Backend errors are now handled with a subscribe

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1920,7 +1920,7 @@ export default {
       window.ProcessMaker.apiClient.post(url, params)
         .then((response) => {
           if (response.data) {
-            if (response.data.error) {
+            if (response.data?.error) {
               this.assetFail = true;
             }
           }
@@ -2003,8 +2003,7 @@ export default {
       const streamProgressEvent = '.ProcessMaker\\Package\\PackageAi\\Events\\GenerateArtifactsErrorEvent';
       window.Echo.private(channel).listen(
         streamProgressEvent,
-        (response) => {
-          console.log(response);
+        () => {
           // Output error
           this.assetFail = true;
         },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1918,8 +1918,12 @@ export default {
       const url = '/package-ai/generateProcessArtifacts';
 
       window.ProcessMaker.apiClient.post(url, params)
-        .then(() => {
-          // Response
+        .then((response) => {
+          if (response.data) {
+            if (response.data.error) {
+              this.assetFail = true;
+            }
+          }
         })
         .catch((error) => {
           const errorMsg = error.response?.data?.message || error.message;
@@ -1991,6 +1995,18 @@ export default {
               }, 500);
             }
           }
+        },
+      );
+    },
+    subscribeToErrors() {
+      const channel = `ProcessMaker.Models.User.${window.ProcessMaker?.modeler?.process?.user_id}`;
+      const streamProgressEvent = '.ProcessMaker\\Package\\PackageAi\\Events\\GenerateArtifactsErrorEvent';
+      window.Echo.private(channel).listen(
+        streamProgressEvent,
+        (response) => {
+          console.log(response);
+          // Output error
+          this.assetFail = true;
         },
       );
     },
@@ -2203,6 +2219,7 @@ export default {
     this.promptSessionId = this.getPromptSessionForUser();
     this.fetchHistory();
     this.subscribeToProgress();
+    this.subscribeToErrors();
   },
 };
 </script>


### PR DESCRIPTION
## Description
AI Unified project requires any error that backend could experience to be handled and communicated to frontend via listeners.

## Solution
- A subscribe function has been added to listen to the GenerateArtifactsErrorEvent on frontend so that backend errors can be notified to the user.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12828

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
