### PR TITLE
FOUR-12934: `Cannot read properties of undefined (reading 'component')` message is displayed when a element is deleted in the modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1771,10 +1771,12 @@ export default {
      */
     unhightligtNodes(clientId) {
       const player = this.players.find(player => player.id === clientId);
-      
+
       player?.selectedNodes?.forEach((nodeId) => {
         const element = this.getElementByNodeId(nodeId);
-        element.component.setHighlightColor(false, player.color);
+        if (element) {
+          element.component.setHighlightColor(false, player.color);
+        }
       });
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to Reproduce:

   - login in the server https://ci-28b9bd38ec.eng.processmaker.net/
   - Create a process with the userA
   - Open the same process with the userB (in a different browser)
   - Create a BPMN element with the userA
   - Delete that created BPMN element with the userB 


Expected behavior: 
When a BPMN element is deleted by other user, any error message should not be displayed.

Actual behavior: 
A message is displayed Cannot read properties of undefined (reading 'component') 

## Solution
-  Now highlight color  when the element exists

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-12934

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
