### PR TITLE
FOUR-13068: Asset generation UI is toggled off on generation error

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1928,6 +1928,7 @@ export default {
           if (response.data) {
             if (response.data?.error) {
               this.assetFail = true;
+              this.loadingAI = false;
             }
           }
         })
@@ -1935,6 +1936,7 @@ export default {
           const errorMsg = error.response?.data?.message || error.message;
           window.ProcessMaker.alert(errorMsg, 'danger');
           this.assetFail = true;
+          this.loadingAI = false;
         });
     },
     highlightTaskArrays(data) {
@@ -1990,6 +1992,7 @@ export default {
               window.ProcessMaker.alert(response.data.message, 'danger');
               // Stop and show error
               this.assetFail = true;
+              this.loadingAI = false;
             } else {
               this.setPromptSessions(response.data.promptSessionId);
               // Successful generation 
@@ -2026,6 +2029,7 @@ export default {
         () => {
           // Output error
           this.assetFail = true;
+          this.loadingAI = false;
         },
       );
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
"Generating..." message does not disappear when error is thrown in AI Asset Generation in Modeler.

Expected behavior: 
Whenever an error is shown on the asset generation, the "Generating..." popup that replaces the bottom rail with BPMN controls should also disappear.

Actual behavior: 
On error, the "Generating..." popup is still being shown.

## Solution
- Change the variable that toggles the component to false on error.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13068

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
