### PR TITLE
FOUR-12663: Inspector button appears quite distant if you preview a task

### DIFF
--- a/src/components/inspectors/PreviewPanel.vue
+++ b/src/components/inspectors/PreviewPanel.vue
@@ -112,7 +112,6 @@ export default {
     },
     displayPreviewIframe() {
       const result = !!this.previewUrl && !this.showSpinner;
-      console.log('mostrar iframe', result);
       return result ? 'visible' : 'hidden';
     },
   },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -716,7 +716,9 @@ export default {
       }
 
       if (this.isOpenPreview && !this.isOpenInspector) {
-        this.inspectorButtonRight = 65 + this.previewPanelWidth;
+        // the scaling is optimized for 1920px width. Other resolutions will be adjusted accordingly
+        const delta = screen.width / 1920;
+        this.inspectorButtonRight = 65 * delta + this.previewPanelWidth;
       }
 
       if (!this.isOpenPreview && !this.isOpenInspector) {


### PR DESCRIPTION
## Issue & Reproduction Steps

1.Create a process
2.Add different tasks
3.Click on preview of any of the tasks

Expected behavior: 
This button should be better positioned if you have a preview of a task.
Actual behavior: 
The Inspector button changes location, it is shown quite far from the task preview.

## Solution
- Scale inspector button position taking into account the screen width resolution

## How to Test
Test the steps above

## Related Tickets & Packages
[- ](https://processmaker.atlassian.net/browse/FOUR-11982)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
