### PR TITLE
Observation/FOUR-13215: ProceC2 Icon has a different color than the Figma in the Modeler

### DIFF
--- a/src/components/aiMessages/AiGenerateButton.vue
+++ b/src/components/aiMessages/AiGenerateButton.vue
@@ -82,3 +82,8 @@ export default {
   background-color: #104a75;
 }
 </style>
+<style>
+.top-rail-container svg.ai-icon path {
+  fill: #212529;
+}
+</style>


### PR DESCRIPTION
**Descripción**
ProceC2 Icon has a different color than the Figma in the Modeler

Fixes observation [FOUR-13215](https://processmaker.atlassian.net/browse/FOUR-13215)


[FOUR-13215]: https://processmaker.atlassian.net/browse/FOUR-13215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

..