### PR TITLE
Observation/FOUR-13274: Improve assets assignment without need of reload page

### DIFF
--- a/src/components/inspectors/InspectorPanel.vue
+++ b/src/components/inspectors/InspectorPanel.vue
@@ -104,6 +104,8 @@ export default {
     'highlightedNode.definition.assignmentRules'(current, previous) { this.handleAssignmentChanges(current, previous); },
     'highlightedNode.definition.allowInterstitial'(current, previous) { this.handleAssignmentChanges(current, previous); },
     'highlightedNode.definition.interstitialScreenRef'(current, previous) { this.handleAssignmentChanges(current, previous); },
+    'highlightedNode.definition.screenRef'(current, previous) { this.handleAssignmentChanges(current, previous); },
+    'highlightedNode.definition.scriptRef'(current, previous) { this.handleAssignmentChanges(current, previous); },
   },
   computed: {
     inspectorHeaderTitle() {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2215,9 +2215,8 @@ export default {
         streamCompletedEvent,
         (response) => {
           if (response.data) {
-            setTimeout(() => {
-              window.location.replace(window.location.href.split('?')[0]);
-            }, 1500);
+            this.updateScreenRefs(response.data.screenIds);
+            this.updateScriptRefs(response.data.scriptIds);
           }
         },
       );
@@ -2240,6 +2239,30 @@ export default {
         localStorage.setItem('cancelledJobs', JSON.stringify(this.cancelledJobs));
         this.loadingAI = false;
       }
+    },
+    updateScreenRefs(elements) {
+      elements.forEach(el => {
+        const node = this.nodes.find(n => n.definition.id === el.node_id);
+        let definition = node.definition;
+
+        if (node.type === 'processmaker-modeler-task') {
+          definition.screenRef = el.screen_id;
+          store.commit('updateNodeProp', { node, key: 'definition', value: definition });
+          this.$emit('save-state');
+        }
+      });
+    },
+    updateScriptRefs(elements) {
+      elements.forEach(el => {
+        const node = this.nodes.find(n => n.definition.id === el.node_id);
+        let definition = node.definition;
+
+        if (node.type === 'processmaker-modeler-script-task') {
+          definition.scriptRef = el.script_id;
+          store.commit('updateNodeProp', { node, key: 'definition', value: definition });
+          this.$emit('save-state');
+        }
+      });
     },
   },
   created() {


### PR DESCRIPTION
## Descripción

When assigning the assets we need to reload modeler to see the new assigned assets. 
An improvement is to assign the assets created using the subscribe method without the need of reload the page.

## Related tickets and PR's
- [FOUR-13274](https://processmaker.atlassian.net/browse/FOUR-13274)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/73)

ci:next
ci:deploy
ci:package-ai:observation/FOUR-13274

[FOUR-13274]: https://processmaker.atlassian.net/browse/FOUR-13274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ