### PR TITLE
FOUR-13911: Collaborative modeler is working in different servers and…

### DIFF
--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -31,7 +31,8 @@ export default class Multiplayer {
     this.#nodeIdGenerator = getNodeIdGenerator(this.modeler.definitions);
     // Get the room name from the process id
     const processId = window.ProcessMaker.modeler.process.uuid ?? window.ProcessMaker.modeler.process.id;
-    this.room = new Room(`room-${processId}`);
+    const appUrl = window.ProcessMaker.app?.url || '';
+    this.room = new Room(`room-${appUrl}-${processId}`);
     this.inspector = new InspectorUtils(this.modeler, store);
 
     // Connect to websocket server


### PR DESCRIPTION
… same process


## Issue & Reproduction Steps

Expected behavior: 
The collaborative modeler should work between users in the same process and server.
Actual behavior: 
Both users are displaying in both processes (collaborative modeler). However, Those users are in different servers.

## Solution
- Server Url in windows.Processmaker.app.url was added to a room name

## How to Test
Test the steps above

1. Login in the server https://next-qa.processmaker.net/
2. Import a process
3. Open the process imported
4. Login in the server https://ci-3ad848237b.engk8s.processmaker.net/ (different user to Admin)
5. Import the same process
6. Open the process imported


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13911

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy