### PR TITLE
FOUR-13923: REPLUG: As a user, I want to have the ability to replug a…

### DIFF
--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -49,7 +49,7 @@ export default {
   },
   computed: {
     isValidConnection() {
-      return SequenceFlow.isValid({
+      return this.isValid({
         sourceShape: this.sourceShape,
         targetShape: this.target,
         targetConfig: this.targetConfig,
@@ -94,6 +94,9 @@ export default {
     },
   },
   methods: {
+    isValid(params) {
+      return SequenceFlow.isValid(params);
+    },
     setDefaultMarker(value) {
       this.shape.attr('line', {
         sourceMarker: {

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -228,7 +228,7 @@ export default {
         const targetNode = get(this.currentTarget, 'component.node');
         const targetConfig = targetNode && this.nodeRegistry[targetNode.type];
         // Validate the flow with the new target node.
-        const isValid = this.isValid && this.isValid({
+        const isValid = this.isValid?.({
           sourceShape: this.sourceShape,
           targetShape: this.currentTarget,
           targetConfig,

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -30,6 +30,7 @@ export default {
       listeningToMouseleave: false,
       vertices: null,
       anchorPointFunction: getDefaultAnchorPoint,
+      onChangeWasFired: false,
     };
   },
   watch: {
@@ -159,6 +160,9 @@ export default {
       this.shape.listenTo(targetShape, 'change:position', this.updateWaypoints);
 
       this.shape.listenTo(this.paper, 'link:mouseleave', this.storeWaypoints);
+      // Listens to the 'pointerup' event when a link is interacted with on the shape.
+      // When the event occurs, the 'pointerUpHandler' method is invoked to handle the pointer up action.
+      this.shape.listenTo(this.paper, 'link:pointerup', this.pointerUpHandler);
 
       const sourceShape = this.shape.getSourceElement();
       sourceShape.embed(this.shape);
@@ -200,23 +204,97 @@ export default {
 
           window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', changes);
         }
-
         this.listeningToMouseleave = true;
         this.$emit('save-state');
       }
     },
+
     /**
-      * On Change vertices handler
-      * @param {Object} link
-      * @param {Array} vertices
-      * @param {Object} options
-      */
-    async onChangeTargets(link, vertices, options){
-      if (options?.ui) {
-        await this.$nextTick();
-        await this.waitForUpdateWaypoints();
-        this.listeningToMouseleave = false;
-        await this.storeWaypoints();
+     * Handles the pointer up event.
+     * Performs actions based on changes in the target shape.
+     * @async
+     */
+    async pointerUpHandler() {
+      // Check if the 'onChange' event was fired. If not, exit the method.
+      if (!this.onChangeWasFired) {
+        return;
+      }
+      // Check if the target shape has changed.
+      const targetChanged = this.target.id !== this.currentTarget.id;
+      if (targetChanged) {
+        // Disable the 'onChange' event to prevent redundant processing.
+        this.onChangeWasFired = false;
+        // Extract information about the new target shape
+        const targetNode = get(this.currentTarget, 'component.node');
+        const targetConfig = targetNode && this.nodeRegistry[targetNode.type];
+        // Validate the flow with the new target node.
+        const isValid = this.isValid && this.isValid({
+          sourceShape: this.sourceShape,
+          targetShape: this.currentTarget,
+          targetConfig,
+        });
+        // If the flow is valid, update the target and related information.
+        if (isValid) {
+          this.setTarget(this.currentTarget);
+          this.target = this.currentTarget;
+          // Optionally update definition links.
+          if (this.updateDefinitionLinks) {
+            this.updateDefinitionLinks();
+          }
+          this.listeningToMouseleave = true;
+          // Store waypoints asynchronously.
+          await this.storeWaypoints();
+        } else {
+          // If the flow is not valid, revert to the previous target.
+          this.setTarget(this.target);
+        }
+      } else {
+        // the target was not changed, set the target with the anchor offset.
+        this.setTarget(this.target, this.getAnchorOffset());
+      }
+    },
+
+    /**
+     * Calculates the offset between the target anchor point and the position of the target element.
+     *
+     * @returns {Object} An object representing the offset with 'x' and 'y' properties.
+     */
+    getAnchorOffset() {
+      // Get the waypoints of the sequence flow
+      const sequenceFlowWaypoints = this.node.diagram.waypoint;
+      // Get the last waypoint, which is the target anchor point
+      const targetAnchorPoint = sequenceFlowWaypoints[sequenceFlowWaypoints.length - 1];
+      // Get the position (x, y) of the target element
+      const { x: targetX, y: targetY } = this.target.position();
+      // Calculate and return the offset between the target anchor point and the target element position
+      return {
+        x: targetAnchorPoint.x - targetX,
+        y: targetAnchorPoint.y - targetY,
+      };
+    },
+
+    /**
+     * Handles changes in target shapes for a link.
+     * @async
+     * @param {Link} link - The link whose target is being changed.
+     * @param {Vertices} vertices - The new vertices information.
+     * @param {Object} options - Additional options.
+     */
+    async onChangeTargets(link, vertices, options) {
+      this.onChangeWasFired = true;
+      if (options?.ui && vertices.id) {
+        const newTarget = this.paper.getModelById(vertices.id);
+        if (this.currentTarget.id !== newTarget.id) {
+          // Change the target if it's different from the current target
+          this.currentTarget = newTarget;
+          this.listeningToMouseleave = true;
+        } else {
+          // If the target is the same, wait for the next update and store waypoints
+          await this.$nextTick();
+          await this.waitForUpdateWaypoints();
+          this.listeningToMouseleave = false;
+          await this.storeWaypoints();
+        }
       }
     },
     async onChangeVertices(link, vertices, options){
@@ -319,10 +397,15 @@ export default {
 
       const sourceAnchorTool = new linkTools.SourceAnchor({ snap: this.getAnchorPointFunction('source') });
       const targetAnchorTool = new linkTools.TargetAnchor({ snap: this.getAnchorPointFunction('target') });
-      const toolsView = new dia.ToolsView({
+      let toolsView = new dia.ToolsView({
         tools: [verticesTool, sourceAnchorTool, targetAnchorTool],
       });
-
+      if (this.shape.component.node.type === 'processmaker-modeler-sequence-flow') {
+        toolsView = new dia.ToolsView({
+          tools: [verticesTool, sourceAnchorTool, targetAnchorTool, new linkTools.TargetArrowhead()],
+        });
+      }
+      this.currentTarget = this.shape.getTargetElement();
       this.shapeView.addTools(toolsView);
       this.shapeView.hideTools();
     },

--- a/tests/e2e/specs/SequenceFlows.cy.js
+++ b/tests/e2e/specs/SequenceFlows.cy.js
@@ -121,7 +121,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
 
         /* Move anchor to top */
         cy.get(anchorSelector).trigger('mousedown');
-        cy.get(anchorSelector).trigger('mousemove', 1, -200, { force: true });
+        cy.get(anchorSelector).trigger('mousemove', 1, -10, { force: true });
         cy.get(anchorSelector).trigger('mouseup', { force: true });
         cy.get(anchorSelector).should(() => {
           const { top: newTop } = $anchor.position();


### PR DESCRIPTION
…n object from a sequence flow to effectively separate it from the current flow so users will be able to easily manage the flow of tasks in the system

## Issue & Reproduction Steps

Expected behavior: 
As a user, I want to have the ability to replug an object from a sequence flow to effectively separate it from the current flow so users will be able to easily manage the flow of tasks in the system

Actual behavior: 
n/a
## Solution
- Implement pointerUpHandler method 
- Enable TargetArrowhead Joint.js tool

[replug.webm](https://github.com/ProcessMaker/modeler/assets/1401911/33bc4c78-f111-4d97-9d4e-b9a7f85b2eec)


## How to Test
Test the steps above

## Related Tickets & 
Packages
- https://processmaker.atlassian.net/browse/FOUR-13923


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next