### PR TITLE
FOUR-14067: Pan Tool in overview should be disabled.

### DIFF
--- a/src/components/railBottom/RailBottom.vue
+++ b/src/components/railBottom/RailBottom.vue
@@ -18,7 +18,7 @@
       
       <PanControl
         @set-pan-mode="$emit('set-pan-mode', $event)"
-        :class="{'hidden-opacity': showComponent === false}"
+        v-show="showComponent"
         :pan-mode="panMode"
       />
     </div>

--- a/src/components/railBottom/RailBottom.vue
+++ b/src/components/railBottom/RailBottom.vue
@@ -18,6 +18,7 @@
       
       <PanControl
         @set-pan-mode="$emit('set-pan-mode', $event)"
+        :class="{'hidden-opacity': showComponent === false}"
         :pan-mode="panMode"
       />
     </div>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
- The PanTool should not be enabled for the Overview, and this should not affect the display of the padding

Actual behavior: 
- The entire process can be modified.

## Solution
- Since by default we can only move the paper and not the elements, the 'Pan Tool' button has been hidden when the Modeler is in 'inflight' mode.

https://github.com/ProcessMaker/modeler/assets/90741874/80deedb7-20f0-4f53-8cb9-fadb2c0f5173

## How to Test
1. Go to request
2. Open a completed request
3. Go to overview
4. Click on PanTool and move the process components

## Related Tickets & Packages
- [FOUR-14067](https://processmaker.atlassian.net/browse/FOUR-14067)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-14067]: https://processmaker.atlassian.net/browse/FOUR-14067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ