### PR TITLE
FOUR-14091:   deleting a task also deletes sequence flows that were previously, but no longer, attached to it

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -6,6 +6,9 @@ import { getDefaultAnchorPoint } from '@/portsUtils';
 import resetShapeColor from '@/components/resetShapeColor';
 import store from '@/store';
 import {
+  removeOutgoingAndIncomingRefsToFlow,
+} from '@/components/crown/utils';
+import {
   COLOR_IDLE,
   COLOR_COMPLETED,
 } from '@/components/highlightColors.js';
@@ -235,6 +238,7 @@ export default {
         });
         // If the flow is valid, update the target and related information.
         if (isValid) {
+          removeOutgoingAndIncomingRefsToFlow(this.node);
           this.setTarget(this.currentTarget);
           this.target = this.currentTarget;
           // Optionally update definition links.
@@ -244,6 +248,23 @@ export default {
           this.listeningToMouseleave = true;
           // Store waypoints asynchronously.
           await this.storeWaypoints();
+          const waypoint = [];
+          this.node.diagram.waypoint?.forEach(point => {
+            waypoint.push({
+              x: point.x,
+              y: point.y,
+            });
+          });
+          window.ProcessMaker.EventBus.$emit('multiplayer-updateFlows', [
+            {
+              id: this.node.definition.id,
+              type: this.node.type,
+              name: this.node.definition.name,
+              waypoint,
+              sourceRefId: this.node.definition.sourceRef.id,
+              targetRefId: this.node.definition.targetRef.id,
+            },
+          ]);
         } else {
           // If the flow is not valid, revert to the previous target.
           this.setTarget(this.target);

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -8,6 +8,9 @@ import { getBoundaryEventData } from '@/components/nodes/boundaryEvent/boundaryE
 import { InspectorUtils } from './inspector.utils';
 import ColorUtil from '../colorUtil';
 import { debounce } from 'lodash';
+import {
+  removeOutgoingAndIncomingRefsToFlow,
+} from '@/components/crown/utils';
 export default class Multiplayer {
   clientIO = null;
   yDoc = null;
@@ -741,7 +744,9 @@ export default class Multiplayer {
   updateFlowClient(data) {
     let remount = false;
     const flow = this.getNodeById(data.id);
+    const flowElem = this.modeler.getElementByNodeId(data.id);
     if (flow && data.sourceRefId) {
+      removeOutgoingAndIncomingRefsToFlow(flow);
       const sourceRef = this.getNodeById(data.sourceRefId);
 
       const outgoing = sourceRef.definition.get('outgoing')

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -744,7 +744,6 @@ export default class Multiplayer {
   updateFlowClient(data) {
     let remount = false;
     const flow = this.getNodeById(data.id);
-    const flowElem = this.modeler.getElementByNodeId(data.id);
     if (flow && data.sourceRefId) {
       removeOutgoingAndIncomingRefsToFlow(flow);
       const sourceRef = this.getNodeById(data.sourceRefId);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
deleting a task must not delete the sequence flow that were previously.
Actual behavior: 
deleting a task also deletes sequence flows that were previously, but no longer, attached to it
## Solution
- clean  previous target references 

[remove_task.webm](https://github.com/ProcessMaker/modeler/assets/1401911/048b6134-d7d0-4ec1-bc62-5b954a0855b1)


## How to Test
Test the steps above
1. create a event1
2. create a task1 
3. create a endEvent1
4. create a task2
5. connect event1 -> task1->endEvent1 
6. move the flow target that arrives to the task1 to task2
7. remove task1


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14091

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
