### PR TITLE
FOUR-14111: The task information in overview is not displayed.

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -549,9 +549,12 @@ export default {
         this.pointerUpHandler(event);
       }, this);
       this.paperManager.addEventHandler('cell:pointerup', (cellView, event) => {
+        // If panMode is true, stop panning. But do not return if we are in read-only mode.
         if (this.panMode) {
           this.stopPanning();
-          return;
+          if (!this.isReadOnly) {
+            return;
+          }
         }
         this.activeNode = null;
         this.pointerUpHandler(event, cellView);
@@ -582,8 +585,8 @@ export default {
           return;
         }
 
-        // ignore click event if the user is Grabbing the paper
-        if (this.panMode) {
+        // Ignore click event if the user is Grabbing the paper, only when isReadOnly is false.
+        if (!this.isReadOnly && this.panMode) {
           return;
         }
 
@@ -598,10 +601,12 @@ export default {
         if (!this.isBpmnNode(shape)) {
           return;
         }
-        // If the user is panning
+        // If panMode is true, start panning. But do not return if we are in read-only mode.
         if (this.panMode) {
           this.startPanning();
-          return;
+          if (!this.isReadOnly) {
+            return;
+          }
         }
         this.setShapeStacking(shape);
         this.activeNode = shape.component.node;


### PR DESCRIPTION
## Issue & Reproduction Steps
The task information popup in Overview tab is not displayed.

Expected behavior: 
- As in previous versions it should be shown.

Actual behavior: 
- The task information is not displayed.

## Solution
- Added small adjustments to enable the tooltip in the Process Map.

https://github.com/ProcessMaker/modeler/assets/90741874/cdbfd733-ba45-4ba2-a4ac-7013390bef7f

## How to Test
Build and link.
1. Go to Requests
2. Open any request
3. Click on Overview tab
4. Click on a task.

## Related Tickets & Packages
- [FOUR-14111](https://processmaker.atlassian.net/browse/FOUR-14111)

ci:next
ci:deploy

[FOUR-14111]: https://processmaker.atlassian.net/browse/FOUR-14111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ