### PR TITLE
FOUR-13350: Controls that move in the modeler remain transparent in collaborative mode

### DIFF
--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -465,6 +465,7 @@ export default class Multiplayer {
     const { paper } = this.modeler;
     const element = this.modeler.getElementByNodeId(data.id);
     const newPool = this.modeler.getElementByNodeId(data.poolId);
+    const node = this.getNodeById(data.id);
 
     if (this.modeler.flowTypes.includes(data.type)) {
       if ('waypoint' in data) {
@@ -489,7 +490,6 @@ export default class Multiplayer {
       }
       // udpdate the element's color
       if (data.color) {
-        const node = this.getNodeById(data.id);
         store.commit('updateNodeProp', { node, key: 'color', value: data.color });
         return;
       }
@@ -507,6 +507,10 @@ export default class Multiplayer {
         element.component.node.pool.component.moveElementRemote(element, newPool);
       }
       this.modeler.updateLasso();
+    }
+    if (node) {
+      // Remove transparency
+      this.modeler.$emit('node-added', node);
     }
   }
   /**


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Controls that were moved should not remain transparent in collaborative modeler
Actual behavior: 
Controls that move in the modeler remain transparent in collaborative mode
## Solution
- emmit the event add-node that remove transparent mode

## How to Test
Test the steps above

1. Create a process with some elements
2. Log in to PM with two users' differents
3. With one user moving some controls 
4. Check the controls that were moved with the other user

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-13350

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:processmaker:next
ci:deploy
.