### PR TITLE
It shows us errors in the console, when we add a block in a process, that the icon has been edited

### DIFF
--- a/src/components/iconColors.js
+++ b/src/components/iconColors.js
@@ -50,7 +50,9 @@ const coloredIcon = (iconString, node) => {
     library.add(fas, fab);
 
     const [prefix ] = iconString.split(' ');
-    const [, iconName] = iconString.split('-');
+    let name = iconString.split('-');
+    name.shift();
+    const iconName = name.join('-');
     const iconDefinition = findIconDefinition({ prefix, iconName });
     const svg = icon(iconDefinition).html;
     iconString = svg[0];


### PR DESCRIPTION
## Issue & Reproduction Steps
The icon was not found by the name providing
steps in issue

Expected behavior: 
The PMBlock icon should be displayed.

Actual behavior: 
the PMBlock icon is not displayed.
## Solution
- re-form the icon name.

## How to Test
- Create several PMBLocks with different icons.
- Create a new process and add the Blocks created previously, and review the icons.

## Related Tickets & Packages
- [https://processmaker.atlassian.net/browse/FOUR-14042](FOUR-14042)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
