### PR TITLE
FOUR-14184: Elements leave the pool when moved in Collaborative modeler

### DIFF
--- a/src/components/modeler/Selection.vue
+++ b/src/components/modeler/Selection.vue
@@ -1040,6 +1040,7 @@ export default {
                 node: laneShape.component.node,
                 bounds: laneShape.getBBox(),
               });
+              this.fitElementMultiplayerMode(laneShape.component.node);
             });
           }
           pool.component.updateAnchorPointPosition();
@@ -1047,8 +1048,21 @@ export default {
             node: pool.component.node,
             bounds: pool.getBBox(),
           });
+          this.fitElementMultiplayerMode(pool.component.node);
         }
       }
+    },
+    fitElementMultiplayerMode(node) {
+      const properties = {
+        id: node.definition.id,
+        properties: {
+          x: node.diagram.bounds?.x,
+          y: node.diagram.bounds?.y,
+          height: node.diagram.bounds?.height,
+          width: node.diagram.bounds?.width,
+        },
+      };
+      window.ProcessMaker.EventBus.$emit('multiplayer-updateNodes', [properties]);
     },
     /**
      * Updates the lane children when a element is moved into the pool

--- a/src/multiplayer/multiplayer.js
+++ b/src/multiplayer/multiplayer.js
@@ -507,11 +507,13 @@ export default class Multiplayer {
     // Resize element if width and height provided
     if (typeof element.resize === 'function' && data.width && data.height) {
       element.resize(data.width, data.height);
+      this.updateBounds(element);
     }
   
     // Update element's position
     if (data.x && data.y) {
       element.set('position', { x: data.x, y: data.y });
+      this.updateBounds(element);
     }
   
     // Update element's color
@@ -535,6 +537,12 @@ export default class Multiplayer {
       element.component.node.pool.component.moveElementRemote(element, newPool);
     }
     this.modeler.updateLasso();
+  }
+  updateBounds(element) {
+    store.commit('updateNodeBounds', {
+      node: element.component.node,
+      bounds: element.getBBox(),
+    });
   }
   /**
    * Removes transparency


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The elements should not left out the pool in Collaborative modeler 

Actual behavior: 
The elements left out the pool when these are moved

## Solution
-  improve update bounds in collaborative client

[poolFixBounds.webm](https://github.com/ProcessMaker/modeler/assets/1401911/340b8a01-faf4-42e2-974b-bac408b6ddea)


## How to Test
Test the steps above

1. Create a process 
2. Add pool and some elements inside
3. Open the process with two users different 
4. With one user move to elements so that the pool becomes larger
5. Check the process with the other user


## Related Tickets & Packages
-
- https://processmaker.atlassian.net/browse/FOUR-14184

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
