### PR TITLE
FOUR-14232: When package ai is not installed the feature is showing in modeler and scripts

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -478,7 +478,12 @@ export default {
       });
     },
     showWelcomeMessage() {
-      return !this.selectedNode && !this.nodes.length && !this.isReadOnly && this.isLoaded && !undoRedoStore.getters.isRunning;
+      return !this.selectedNode && 
+        !this.nodes.length && 
+        !this.isReadOnly && 
+        this.isLoaded && 
+        !undoRedoStore.getters.isRunning &&
+        this.isPackageAiInstalled;
     },
     noElementsSelected() {
       return this.highlightedNodes.filter(node => !node.isType('processmaker-modeler-process')).length === 0;


### PR DESCRIPTION
## Issue & Reproduction Steps
When package ai is not installed the feature is showing in modeler and scripts:

![Screenshot 2024-02-23 at 10 09 28](https://github.com/ProcessMaker/processmaker/assets/90727999/6e83430f-d222-4166-99d8-7df70dbcf62a)

![Screenshot 2024-02-23 at 10 07 44](https://github.com/ProcessMaker/processmaker/assets/90727999/7666d8d8-5ad1-483b-b4bf-5cda6c986b05)


## Solution
- Check if package ai is installed

## How to Test
- Install and uninstall package-ai and verify the ai features are correctly shown hidden

## Related Tickets & Packages
- [FOUR-14232](https://processmaker.atlassian.net/browse/FOUR-14232)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/6277)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-14232]: https://processmaker.atlassian.net/browse/FOUR-14232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ