### PR TITLE
FOUR-14286: Add a variable to hide AI for Fall and Winter

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -401,8 +401,11 @@ export default {
     },
   },
   computed: {
+    isPackageAiInstalled() {
+      return window.ProcessMaker?.modeler?.isPackageAiInstalled;
+    },
     showWelcomeMessage() {
-      return !this.selectedNode && !this.nodes.length && !store.getters.isReadOnly && this.isLoaded;
+      return !this.selectedNode && !this.nodes.length && !store.getters.isReadOnly && this.isLoaded && this.isPackageAiInstalled;
     },
     noElementsSelected() {
       return this.highlightedNodes.filter(node => !node.isType('processmaker-modeler-process')).length === 0;


### PR DESCRIPTION
## Issue & Reproduction Steps
Hide all AI features when the package-ai is uninstalled
Add an extra env variable `OPEN_AI_PROCESS_TRANSLATIONS_ENABLED=false` to hide process translations

## Related PRs and Tickets
- [Modeler PR](https://github.com/ProcessMaker/modeler/pull/1801)
- https://processmaker.atlassian.net/browse/FOUR-14286

ci:1.42.3
ci:processmaker:FOUR-14286