### PR TITLE
FOUR-14799: Improve error messaging for AI

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2113,7 +2113,7 @@ export default {
             this.promptSessionId = '';
             this.fetchHistory();
           } else {
-            console.log(errorMsg, 'danger');
+            console.error(errorMsg, 'danger');
           }
         });
     },

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2113,7 +2113,7 @@ export default {
             this.promptSessionId = '';
             this.fetchHistory();
           } else {
-            window.ProcessMaker.alert(errorMsg, 'danger');
+            console.log(errorMsg, 'danger');
           }
         });
     },
@@ -2146,8 +2146,8 @@ export default {
             }
           }
         })
-        .catch((error) => {
-          const errorMsg = error.response?.data?.message || error.message;
+        .catch(() => {
+          const errorMsg = this.$t('ProcessMaker AI is currently offline. Please try again later.');
           window.ProcessMaker.alert(errorMsg, 'danger');
           this.assetFail = true;
           this.loadingAI = false;

--- a/src/components/welcome/WelcomeMessage.vue
+++ b/src/components/welcome/WelcomeMessage.vue
@@ -125,7 +125,7 @@ export default {
         }).catch((error) => {
           const errorMsg = error.response?.data?.message || error.message;
           this.loading = false;
-          window.ProcessMaker.alert(errorMsg, 'danger');
+          console.error(errorMsg, 'danger');
         });
     },
     formatDateTime(value) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Descripción

In sync with @Claudia Iriarte some modifications in the error messages are required:

Instead of showing the Server error alert message in all the pages all time when AI micro service is down, show the message in the console as error.

We need to show a more user friendly alert message ProcessMaker AI is currently offline. Please try again later. just when the user performs an specific AI action like:

- Clicks on generate process from text button
- Clicks on generate process from image button
- Clicks on generate script from text button
- Clicks on document script button
- Clicks on clean script button
- Clicks on explain script button
- Clicks on generate process assets button in modeler
- Clicks on generate form button in screen builder


By the other hand we need an informational tooltip message in the AI modeler component, similar to the following screen (This is an AI feature and can provide …):

![image (1)](https://github.com/ProcessMaker/modeler/assets/90727999/1f127e8e-3aa2-498c-b0e0-74bcab387200)


## Related Tickets and PRS
[FOUR-14799](https://processmaker.atlassian.net/browse/FOUR-14799)
- [core PR](https://github.com/ProcessMaker/processmaker/pull/6579)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/139)
- [modeler PR](https://github.com/ProcessMaker/modeler/pull/1807)



[FOUR-14799]: https://processmaker.atlassian.net/browse/FOUR-14799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ