### PR TITLE
FOUR-14934: Windows Pane could make preview of Pool control

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -279,6 +279,7 @@ import Selection from './Selection';
 import RemoteCursor from '@/components/multiplayer/remoteCursor/RemoteCursor.vue';
 import Multiplayer from '@/multiplayer/multiplayer';
 import { getBoundaryEventData } from '../nodes/boundaryEvent/boundaryEventUtils';
+import validPreviewElements from '@/components/crown/crownButtons/validPreviewElements';
 
 export default {
   components: {
@@ -421,6 +422,7 @@ export default {
         'processmaker-modeler-boundary-conditional-event',
         'processmaker-modeler-boundary-message-event',
       ],
+      validPreviewElements,
     };
   },
   watch: {
@@ -462,6 +464,7 @@ export default {
       this.paperManager.scale = canvasScale;
     },
     highlightedNodes() {
+      this.applyPreviewVisibilityForSelection();
       if (window.ProcessMaker?.EventBus) {
         window.ProcessMaker.EventBus.$emit('modeler:highlightedNodes', this.highlightedNodes);
       }
@@ -2282,6 +2285,15 @@ export default {
           this.$emit('save-state');
         }
       });
+    },
+    applyPreviewVisibilityForSelection() {
+      if (this.highlightedNodes.length !== 1) {
+        this.isOpenPreview = false;
+      }
+      else {
+        const nodeType =  this.highlightedNodes[0].definition?.$type;
+        this.isOpenPreview = this.isOpenPreview && this.validPreviewElements.includes(nodeType);
+      }
     },
   },
   created() {


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce**

- Create a process
- Add some control like PDF Generator
- Add Pool control
- Click on PDF Generator
- Click on Preview
- Press SHIFT key + Click on POOL control
- Check the Windows pane

**Current Behavior**

Windows pane can preview pool control 

**Expected Behavior**

The Windows pane only should preview the controls that have PREVIEW option in the crown menu. So the pool should not be preview with Windows pane


## Solution
- Added code to check windo pane visibility when the selected items change


## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14934

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
ci:next