### PR TITLE
FOUR-14958: First time "auto validate" not working

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -170,9 +170,10 @@ export default new Vuex.Store({
         const { data } = await window.ProcessMaker.apiClient.get('processes', {
           params: {
             order_direction: 'asc',
-            per_page: 1000,
+            per_page: 10000,
             status: 'all',
             include: 'events,category',
+            simplified_data: true,
           },
         });
         commit('setGlobalProcesses', data.data);


### PR DESCRIPTION
## Issue & Reproduction Steps
- Go to process
- Open any process that does not have all screens assigned
- Click on "auto validate"

**Current Behavior:**

The first time auto validate doesn't work.


**Expected behavior:**

As in previous versions it should work the first time.

## Solution
Added a request parameter to improve the speed of returning the list of processes

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14958

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

