### PR TITLE
FOUR-14905 explorer rail is not working as expected with A B Alternatives

### DIFF
--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -10,6 +10,9 @@ export default {
   mixins: [clickAndDrop, iconHelper],
   data() {
     return {
+      /** @type {BroadcastChannel} */
+      bc: null,
+      isAbTestingInstalled: !!window.ProcessMaker?.modeler.abPublish,
       pinIcon,
       pinFillIcon,
       showPin: false,
@@ -17,16 +20,50 @@ export default {
   },
   created() {
     nodeTypesStore.dispatch('getUserPinnedObjects');
+
+    // Create BroadcastChannel to communicate with other alternatives
+    this.bc = new BroadcastChannel('package-ab-testing');
+
+    if (this.isAbTestingInstalled) {
+      // Listen for messages from other alternatives
+      this.bc.onmessage = (event) => {
+        const { data } = event;
+
+        if (data.alternative !== window.ProcessMaker.modeler.alternative) { // Ignore messages from the same alternative
+          const { action, object } = data;
+
+          if (action === 'add-pin') {
+            object.fromAlternative = true;
+            // Add pin to the store without sending a message to other alternatives
+            this.addPin(object);
+          } else if (action === 'remove-pin') {
+            object.fromAlternative = true;
+            // Remove pin from the store without sending a message to other alternatives
+            this.unPin(object);
+          }
+        }
+      };
+    }
   },
   methods: {
     nodeTypeAlreadyPinned(object, type) {
       return !!this.pinnedObjects.find(obj => obj.type === type);
     },
     unPin(object) {
+      // If the action is coming from an alternative, don't send a message to other alternatives
+      if (this.isAbTestingInstalled && !object.fromAlternative) {
+        this.bc.postMessage({ action: 'remove-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+      }
+
       this.deselect();
       return nodeTypesStore.dispatch('removeUserPinnedObject', object);
     },
     addPin(object) {
+      // If the action is coming from an alternative, don't send a message to other alternatives
+      if (this.isAbTestingInstalled && !object.fromAlternative) {
+        this.bc.postMessage({ action: 'add-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+      }
+
       this.deselect();
       return nodeTypesStore.dispatch('addUserPinnedObject', object);
     },
@@ -40,7 +77,7 @@ export default {
         return !obj.type?.includes('processmaker-pm-block');
       });
 
-      return filteredPinnedNodeTypes; 
+      return filteredPinnedNodeTypes;
     },
     objects() {
       return nodeTypesStore.getters.getNodeTypes;

--- a/src/nodeTypesStore.js
+++ b/src/nodeTypesStore.js
@@ -50,7 +50,8 @@ export default new Vuex.Store({
       state.pinnedNodeTypes.sort((node1, node2) => node1.rank - node2.rank);
     },
     setUnpinNode(state, payload) {
-      state.pinnedNodeTypes = state.pinnedNodeTypes.filter(node => node !== payload);
+      const nodeIndex = state.pinnedNodeTypes.findIndex(node => node.type === payload.type);
+      state.pinnedNodeTypes.splice(nodeIndex, 1);
     },
     setFilteredNodeTypes(state, searchTerm) {
       const pinnedNodeTypes = state.pinnedNodeTypes;
@@ -134,7 +135,9 @@ export default new Vuex.Store({
           console.error(e);
         });
     },
-    addUserPinnedObject({ commit, state }, pinnedNode) {
+    addUserPinnedObject({ commit, state }, payload) {
+      const { fromAlternative, ...pinnedNode } = payload;
+
       commit('setPinnedNodes', pinnedNode);
       const pinnedNodes = state.pinnedNodeTypes;
       if (window.ProcessMaker?.user?.id === 'standalone') {
@@ -142,14 +145,19 @@ export default new Vuex.Store({
         localStorage.pinnedNodes = JSON.stringify(pinnedNodes);
         return;
       }
-      const user = window.ProcessMaker.user ? window.ProcessMaker.user.id : '';
-      window.ProcessMaker.apiClient.put(`/users/${user}/update_pinned_controls`, { pinnedNodes })
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error(e);
-        });
+
+      if (!fromAlternative) {
+        const user = window.ProcessMaker.user ? window.ProcessMaker.user.id : '';
+        window.ProcessMaker.apiClient.put(`/users/${user}/update_pinned_controls`, { pinnedNodes })
+          .catch((e) => {
+            // eslint-disable-next-line no-console
+            console.error(e);
+          });
+      }
     },
-    removeUserPinnedObject({ commit, state }, nodeToUnpin) {
+    removeUserPinnedObject({ commit, state }, payload) {
+      const { fromAlternative, ...nodeToUnpin } = payload;
+
       commit('setUnpinNode', nodeToUnpin);
       const pinnedNodes = state.pinnedNodeTypes;
       if (window.ProcessMaker?.user?.id === 'standalone') {
@@ -157,12 +165,15 @@ export default new Vuex.Store({
         localStorage.pinnedNodes = JSON.stringify(pinnedNodes);
         return;
       }
-      const user = window.ProcessMaker.user ? window.ProcessMaker.user.id : '';
-      window.ProcessMaker.apiClient.put(`/users/${user}/update_pinned_controls`, { pinnedNodes })
-        .catch((e) => {
-          // eslint-disable-next-line no-console
-          console.error(e);
-        });
+
+      if (!fromAlternative) {
+        const user = window.ProcessMaker.user ? window.ProcessMaker.user.id : '';
+        window.ProcessMaker.apiClient.put(`/users/${user}/update_pinned_controls`, { pinnedNodes })
+          .catch((e) => {
+            // eslint-disable-next-line no-console
+            console.error(e);
+          });
+      }
     },
   },
 });


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
According to the documentation the bottom rail is per user. So both alternatives should have the same element pinned and unpinned

Actual behavior: 
The PIN/UNPIN controls in the bottom controls are not the same in both alternatives. 

## Solution
- Add a broadcast channel to sync the bottom rail between alternatives

## How to Test
1. Create a process
2. Add alternative
3. In A alternative pin some elements from Explorer rail
4. In B alternative unpin some elements from Explorer rail

## Related Tickets & Packages
[FOUR-14905](https://processmaker.atlassian.net/browse/FOUR-14905)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next



[FOUR-14905]: https://processmaker.atlassian.net/browse/FOUR-14905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ