### PR TITLE
Observation/FOUR-14945: Pan tool is not enabled with the space button

### DIFF
--- a/src/components/hotkeys/main.js
+++ b/src/components/hotkeys/main.js
@@ -17,6 +17,10 @@ export default {
     document.addEventListener('keyup', this.keyupListener);
   },
   methods: {
+    startPanEventHandlers() {
+      document.addEventListener('keydown', this.keydownListener);
+    },
+    
     handleHotkeys(event, options) {
       // Pass event to all handlers
       this.zoomInOutHandler(event, options);


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduced:**

- Go to process
- Open any process
- Click on the space button and move with the mouse

**Current Behavior:**
The space button stopped working for "Pan Tool"

**Expected Behavior:**
In previous versions the "pan tool" is enabled and can be moved in the modeler.

## Solution
- Added a keydown eventlistener to the alternatives iframes for AB testing

**Working video**

https://github.com/ProcessMaker/modeler/assets/90727999/b88348a6-df51-4402-b97d-896ec0fac488

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-14945](https://processmaker.atlassian.net/browse/FOUR-14945)
- [package-ab-testing pr](https://github.com/ProcessMaker/package-ab-testing/pull/41)
- modeler pr

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next