### PR TITLE
Observation/FOUR-15096: AI assistant loads twice when using "Continue AI session"

### DIFF
--- a/src/components/welcome/WelcomeMessage.vue
+++ b/src/components/welcome/WelcomeMessage.vue
@@ -105,7 +105,11 @@ export default {
       const processId = window.ProcessMaker.modeler.process.id ?? null;
       if (processId) {
         const url = `/package-ai/processes/create/${processId}/${processId}`;
-        window.location = url;
+        if (window.ProcessMaker.AbTesting) {
+          window.parent.location = url;
+        } else {
+          window.location = url;
+        }
       }
     },
     getLastSharedHistory() {


### PR DESCRIPTION
## Issue & Reproduction Steps
**Steps to reproduced:**

- Go to process.
- Create a new process
- Use "Continue AI session"

**Current Behavior:**

When the page is redirected it loads twice.


## Solution
- Fix redirect for package AB testing using window.**parent**

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-15096](https://processmaker.atlassian.net/browse/FOUR-15096)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15096]: https://processmaker.atlassian.net/browse/FOUR-15096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ