### PR TITLE
FOUR-15090 Sync pinned PM Blocks between alternative tabs

### DIFF
--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -12,7 +12,7 @@ export default {
     return {
       /** @type {BroadcastChannel} */
       bc: null,
-      isAbTestingInstalled: !!window.ProcessMaker?.modeler.abPublish,
+      isAbTestingInstalled: !!window.ProcessMaker?.AbTesting,
       pinIcon,
       pinFillIcon,
       showPin: false,

--- a/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
+++ b/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
@@ -10,6 +10,9 @@ export default {
   mixins: [clickAndDrop, iconHelper],
   data() {
     return {
+      /** @type {BroadcastChannel} */
+      bc: null,
+      isAbTestingInstalled: !!window.ProcessMaker?.AbTesting,
       pinIcon,
       pinFillIcon,
       showPin: false,
@@ -17,16 +20,50 @@ export default {
   },
   created() {
     nodeTypesStore.dispatch('getUserPinnedObjects');
+
+    // Create BroadcastChannel to communicate with other alternatives
+    this.bc = new BroadcastChannel('package-ab-testing');
+
+    if (this.isAbTestingInstalled) {
+      // Listen for messages from other alternatives
+      this.bc.onmessage = (event) => {
+        const { data } = event;
+
+        if (data.alternative !== window.ProcessMaker.modeler.alternative) { // Ignore messages from the same alternative
+          const { action, object } = data;
+
+          if (action === 'add-pin') {
+            object.fromAlternative = true;
+            // Add pin to the store without sending a message to other alternatives
+            this.addPin(object);
+          } else if (action === 'remove-pin') {
+            object.fromAlternative = true;
+            // Remove pin from the store without sending a message to other alternatives
+            this.unPin(object);
+          }
+        }
+      };
+    }
   },
   methods: {
     blockAlreadyPinned(object, type) {
       return !!this.pinnedBlocks.find(obj => obj.type === type);
     },
     unPin(object) {
+      // If the action is coming from an alternative, don't send a message to other alternatives
+      if (this.isAbTestingInstalled && !object.fromAlternative) {
+        this.bc.postMessage({ action: 'remove-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+      }
+
       this.deselect();
       return nodeTypesStore.dispatch('removeUserPinnedObject', object);
     },
     addPin(object) {
+      // If the action is coming from an alternative, don't send a message to other alternatives
+      if (this.isAbTestingInstalled && !object.fromAlternative) {
+        this.bc.postMessage({ action: 'add-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+      }
+
       this.deselect();
       return nodeTypesStore.dispatch('addUserPinnedObject', object);
     },


### PR DESCRIPTION
## Sync pinned PM Blocks between alternative tabs

## How to Test
- Pin/Unpin PM Blocks

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15090

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
