### PR TITLE
Observation/FOUR-15119: The STOP button, when using "Create your missing assets with AI" is displayed in any open process in modeler.

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2197,6 +2197,10 @@ export default {
       window.Echo.private(channel).listen(
         streamProgressEvent,
         (response) => {
+          if (response.data.processId !== window.ProcessMaker?.modeler?.process?.id) {
+            return;
+          }
+
           if (response.data.promptSessionId !== this.promptSessionId) {
             this.unhighlightTaskArrays(response.data);
             return;


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduced:**

- Go to process
- Create a new process from AI
- Generate a process and use model
- Complete name process and save
- Use "Create your missing assets with AI"
- Go to process
- Open any process

**Current Behavior:**

The Generating message and the STOP button are displayed.

## Solution
- Verify if callback is for current process

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-15119](https://processmaker.atlassian.net/browse/FOUR-15119)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/147)
- [modeler PR](https://github.com/ProcessMaker/modeler/pull/1816)
- [pmai microservice](https://github.com/ProcessMaker/pm4_ai/commit/3ad1c9ddf2725cfc6a0ecc43964b12f060acb55e)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next

[FOUR-15119]: https://processmaker.atlassian.net/browse/FOUR-15119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ