### PR TITLE
FOUR-14917: Check if package-ab-testing is present to move inspector btn

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -88,7 +88,7 @@
         v-show="showComponent && showInspectorButton"
         :showInspector="isOpenInspector"
         @toggleInspector="[handleToggleInspector($event), setInspectorButtonPosition($event)]"
-        :style="{ right: inspectorButtonRight + 'px' }"
+        :style="{ right: inspectorButtonRight + 'px', top: inspectorButtonTopHeight + 'px' }"
       />
 
       <PreviewPanel ref="preview-panel"
@@ -397,6 +397,7 @@ export default {
       players: [],
       showInspectorButton: true,
       inspectorButtonRight: 65,
+      inspectorButtonTopHeight: 95,
       previewConfigs: [],
       isResizingPreview: false,
       currentCursorPosition: 0,
@@ -734,6 +735,10 @@ export default {
     setInspectorButtonPosition() {
       if (this.isOpenInspector) {
         return;
+      }
+
+      if (window.ProcessMaker.AbTesting) {
+        this.inspectorButtonTopHeight = 30;
       }
 
       if (this.isOpenPreview && !this.isOpenInspector) {


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Go to process
2.Open any process

### Expected Behavior:
In previous versions "inspector button" is better positioned.
### Current Behavior:
The "inspector button" appears quite far from Publish controls

## Solution
- Made a check to see if package-ab-testing is present to move the button accordingly

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-14917

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
