### PR TITLE
Observation/FOUR-15248: The STOP button does not work in assets with AI

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2256,7 +2256,7 @@ export default {
         return true;
       }
 
-      if (this.cancelledJobs.some((element) => element === response.data.nonce)) {
+      if (this.cancelledJobs.some((element) => element === parseInt(response.data.nonce))) {
         if (unhighlightTasks) {
           this.unhighlightTaskArrays(response.data);
         }


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduced:**

- Go to process
- Create a new process for AI assistant
- Use model
- Use Assets Generated
- Click on the STOP button

**Current Behavior:**
The button does not stop the generation of Assets

**Expected Behavior:**
The button should stop the generation of Assets

## Solution
- Parse nonce to int to correctly compare values

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-15248](https://processmaker.atlassian.net/browse/FOUR-15248)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-15248]: https://processmaker.atlassian.net/browse/FOUR-15248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ