### PR TITLE
FOUR-15336: The pinned icons overlap on the Windows Pane preview screen

### DIFF
--- a/src/components/inspectors/preview_panel.scss
+++ b/src/components/inspectors/preview_panel.scss
@@ -5,7 +5,7 @@ $inspector-column-min-width: 200px;
   resize: both;
   overflow:auto;
   background-color: #fff;
-  z-index: 2;
+  z-index: 3;
 }
 
 .preview-iframe {
@@ -29,6 +29,7 @@ $inspector-column-min-width: 200px;
   cursor:ew-resize;
   width:5px;
   background-color:#EBEEF2;
+  z-index: 3;
 }
 
 .preview-column .control-bar .actions {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to Designer
2. Click on Processes
3. Create a new process
4. Create a screen 
5. Click on Preview

Expected behavior: 
- Pinned controls in the Modeler should not be placed above the screen preview.

## Solution
- The z-index value of the preview panel has been updated to be higher than that of the Rail Container.

https://github.com/ProcessMaker/modeler/assets/90741874/4647eb35-3b0f-4ea0-be11-32b2aba0ba70

## How to Test
Please follow the reproduction steps of above.

ci:deploy
ci:next

## Related Tickets & Packages
- [FOUR-15336](https://processmaker.atlassian.net/browse/FOUR-15336)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-15336]: https://processmaker.atlassian.net/browse/FOUR-15336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ