### PR TITLE
Observation/FOUR-15378: A/B Assets generator not working on alternative B

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -681,9 +681,11 @@ export default {
         }
         this.promptSessionId = this.getPromptSessionForUser();
         this.fetchHistory();
-        this.subscribeToProgress();
-        this.subscribeToGenerationCompleted();
-        this.subscribeToErrors();
+        this.$nextTick(() => {
+          this.subscribeToProgress();
+          this.subscribeToGenerationCompleted();
+          this.subscribeToErrors();
+        });
       }
     },
     onNodeDefinitionChanged() {
@@ -2199,7 +2201,6 @@ export default {
       });
     },
     subscribeToProgress() {
-      const alternative = window.ProcessMaker.AbTesting?.alternative || 'A';
       const channel = `ProcessMaker.Models.User.${window.ProcessMaker?.user?.id}`;
       const streamProgressEvent = '.ProcessMaker\\Package\\PackageAi\\Events\\GenerateArtifactsProgressEvent';
       if (!window.Echo) {
@@ -2208,7 +2209,7 @@ export default {
       window.Echo.private(channel).listen(
         streamProgressEvent,
         (response) => {
-          
+          const alternative = window.ProcessMaker.AbTesting?.alternative || 'A';
           if (this.shouldOmitEvent(response, alternative, true)) {
             return;
           }
@@ -2265,12 +2266,12 @@ export default {
       return false;
     },
     subscribeToGenerationCompleted() {
-      const alternative = window.ProcessMaker.AbTesting?.alternative || 'A';
       const channel = `ProcessMaker.Models.User.${window.ProcessMaker?.user?.id}`;
       const streamCompletedEvent = '.ProcessMaker\\Package\\PackageAi\\Events\\GenerateArtifactsCompletedEvent';
       window.Echo.private(channel).listen(
         streamCompletedEvent,
         (response) => {
+          const alternative = window.ProcessMaker.AbTesting?.alternative || 'A';
           if (this.shouldOmitEvent(response, alternative)) {
             return;
           }


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to reproduced:**

- Go to process
- Open a simple process
- Create alternative B
- Use Continue AI session for process creation
- Generate a process and use the model
- Go to alternative B
- Click on "Create your missing assets with AI"

**Current Behavior:**
"Generating" message is displayed but never completes

**Expected Behavior:**
Asset generation should complete.

## Solution
- Add alternative parameter when generating assets with AI
- Fix subscription to events to correct alternative

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-15378](https://processmaker.atlassian.net/browse/FOUR-15378)
- [modeler PR](https://github.com/ProcessMaker/modeler/pull/1824)
- [package-ai PR](https://github.com/ProcessMaker/package-ai/pull/159)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next

[FOUR-15378]: https://processmaker.atlassian.net/browse/FOUR-15378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ