### PR TITLE
FOUR-15387 TypeError: Cannot read properties of undefined (reading 'toLowerCase'), when adding a version name when saving a process

### DIFF
--- a/src/components/hotkeys/copyPaste.js
+++ b/src/components/hotkeys/copyPaste.js
@@ -1,6 +1,11 @@
 export default {
   methods: {
     copyPasteHandler(event, options) {
+      // Checking if the `key` property exists in the `event` object.
+      if (!event.key) {
+        return;
+      }
+
       const node = event.target.nodeName.toLowerCase();
       const isBody = node === 'body';
       const key = event.key.toLowerCase();

--- a/src/components/hotkeys/undoRedo.js
+++ b/src/components/hotkeys/undoRedo.js
@@ -1,6 +1,11 @@
 export default {
   methods: {
     undoRedoHandler(event, options) {
+      // Checking if the `key` property exists in the `event` object.
+      if (!event.key) {
+        return;
+      }
+
       const key = event.key.toLowerCase();
       const isRedo = key === 'y';
       const isUndo= key === 'z';


### PR DESCRIPTION
## Issue & Reproduction Steps
TypeError: Cannot read properties of undefined (reading 'toLowerCase'), when adding a version name when saving a process

## Solution
- Add a null check for `event.key` in undo redo and copy paste handlers

## How to Test
1. Log in 
2. Go to Designer 
3. Click on process
4. Create a new process
5. Click on Publish 
6. Add  a new version name 

## Related Tickets & Packages
[FOUR-15387](https://processmaker.atlassian.net/browse/FOUR-15387)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-15387]: https://processmaker.atlassian.net/browse/FOUR-15387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ