### PR TITLE
FOUR-15386: The windows pane preview is placed above the configuration inspector

### DIFF
--- a/src/components/inspectors/inspector.scss
+++ b/src/components/inspectors/inspector.scss
@@ -5,7 +5,7 @@ $inspector-column-max-width: 330px;
 }
 
 .inspector {
-  z-index: 2;
+  z-index: 3;
 
   &-container {
     text-align: left;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
in windows pane frame, it should not override the configuration inspector
Actual behavior: 
The Windows Pane preview is placed above the Configuration inspector when both are open.
## Solution
- update inspector z-index

## How to Test

1. Log in 
2. Go to Designer 
3. Click on Processes
4. Create  a  new process
5. Add  controls  with  contains  windows  pane  ( Decision Table) 
6. click on a task decision table
7. click on the configuration inspector
8. click on windows pane preview

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-15386

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next