### PR TITLE
FOUR-15457 issue when user opens two modelers in the same browser

### DIFF
--- a/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
+++ b/src/components/rails/explorer-rail/nodeTypesLoop/nodeTypesLoop.vue
@@ -29,7 +29,10 @@ export default {
       this.bc.onmessage = (event) => {
         const { data } = event;
 
-        if (data.alternative !== window.ProcessMaker.modeler.alternative) { // Ignore messages from the same alternative
+        if (data.processId &&
+          (data.alternative !== window.ProcessMaker.modeler.alternative ||
+            data.processId !== window.ProcessMaker.modeler.process.id)
+        ) { // Ignore messages from the same alternative
           const { action, object } = data;
 
           if (action === 'add-pin') {
@@ -52,7 +55,12 @@ export default {
     unPin(object) {
       // If the action is coming from an alternative, don't send a message to other alternatives
       if (this.isAbTestingInstalled && !object.fromAlternative) {
-        this.bc.postMessage({ action: 'remove-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+        this.bc.postMessage({
+          action: 'remove-pin',
+          processId: window.ProcessMaker.modeler.process.id,
+          object,
+          alternative: window.ProcessMaker.modeler.alternative,
+        });
       }
 
       this.deselect();
@@ -61,7 +69,12 @@ export default {
     addPin(object) {
       // If the action is coming from an alternative, don't send a message to other alternatives
       if (this.isAbTestingInstalled && !object.fromAlternative) {
-        this.bc.postMessage({ action: 'add-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+        this.bc.postMessage({
+          action: 'add-pin',
+          processId: window.ProcessMaker.modeler.process.id,
+          object,
+          alternative: window.ProcessMaker.modeler.alternative,
+        });
       }
 
       this.deselect();

--- a/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
+++ b/src/components/rails/explorer-rail/pmBlocksLoop/pmBlocksLoop.vue
@@ -29,14 +29,17 @@ export default {
       this.bc.onmessage = (event) => {
         const { data } = event;
 
-        if (data.alternative !== window.ProcessMaker.modeler.alternative) { // Ignore messages from the same alternative
+        if (data.processId &&
+          (data.alternative !== window.ProcessMaker.modeler.alternative ||
+            data.processId !== window.ProcessMaker.modeler.process.id)
+        ) { // Ignore messages from the same alternative
           const { action, object } = data;
 
-          if (action === 'add-pin') {
+          if (action === 'add-pmb-pin') {
             object.fromAlternative = true;
             // Add pin to the store without sending a message to other alternatives
             this.addPin(object);
-          } else if (action === 'remove-pin') {
+          } else if (action === 'remove-pmb-pin') {
             object.fromAlternative = true;
             // Remove pin from the store without sending a message to other alternatives
             this.unPin(object);
@@ -52,7 +55,12 @@ export default {
     unPin(object) {
       // If the action is coming from an alternative, don't send a message to other alternatives
       if (this.isAbTestingInstalled && !object.fromAlternative) {
-        this.bc.postMessage({ action: 'remove-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+        this.bc.postMessage({
+          action: 'remove-pmb-pin',
+          processId: window.ProcessMaker.modeler.process.id,
+          object,
+          alternative: window.ProcessMaker.modeler.alternative,
+        });
       }
 
       this.deselect();
@@ -61,7 +69,12 @@ export default {
     addPin(object) {
       // If the action is coming from an alternative, don't send a message to other alternatives
       if (this.isAbTestingInstalled && !object.fromAlternative) {
-        this.bc.postMessage({ action: 'add-pin', object, alternative: window.ProcessMaker.modeler.alternative });
+        this.bc.postMessage({
+          action: 'add-pmb-pin',
+          processId: window.ProcessMaker.modeler.process.id,
+          object,
+          alternative: window.ProcessMaker.modeler.alternative,
+        });
       }
 
       this.deselect();
@@ -77,7 +90,7 @@ export default {
         return obj.type?.includes('processmaker-pm-block');
       });
 
-      return filteredPinnedNodeTypes; 
+      return filteredPinnedNodeTypes;
     },
     unpinnedBlocks() {
       const objects = this.pmBlockNodeTypes;


### PR DESCRIPTION
## Issue & Reproduction Steps
Issue when a user opens two modelers in the same browser

## Solution
- Add the process ID to add-pin and remove-pin BroadcastChannel events

## How to Test
1. Open a process with modeler
2. Open a new browser tab, in this tab open another process with modeler
3. Save the first process
4. Note that the other process wasn't also saved

## Related Tickets & Packages
[FOUR-15457](https://processmaker.atlassian.net/browse/FOUR-15457)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-15457]: https://processmaker.atlassian.net/browse/FOUR-15457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ