### PR TITLE
FOUR-16365: Element Destination field is empty by default

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -53,20 +53,13 @@
       :helper="$t('Determine de URL where the request will end')"
       data-test="external-url"
     />
-    <process-form-select
-      v-if="destinationType === 'anotherProcess'"
-      @input="onProcessInput"
-      :value="anotherProcess"
-    />
   </div>
 </template>
 
 <script>
-import ProcessFormSelect from '@/components/inspectors/ProcessFormSelect';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 export default {
-  components: { ProcessFormSelect },
   props: {
     options: {
       type: Array,
@@ -80,13 +73,11 @@ export default {
   
   data() {
     return {
-      loading: false,
       validation: '',
       destinationType: null,
       dashboards: [],
       customDashboard: null,
-      elementDestination: null,
-      anotherProcess: '{}',
+      elementDestination: this.options[0] || null,
       defaultValues: {
         summaryScreen: null,
         customDashboard: null,
@@ -95,7 +86,6 @@ export default {
         homepageDashboard: '/process-browser',
         taskList: '/tasks',
         taskSource: null,
-        anotherProcess: '{}',
       },
       urlModel: null,
       local: null,
@@ -107,7 +97,7 @@ export default {
   watch: {
     elementDestination: {
       handler(newValue, oldValue) {
-        if (!isEqual(newValue, oldValue)) {
+        if (newValue && !isEqual(newValue, oldValue)) {
           this.destinationTypeChange(newValue.value);
         }
       },
@@ -126,9 +116,6 @@ export default {
     },
     externalURL() {
       this.setBpmnValues(this.externalURL);
-    },
-    anotherProcess() {
-      this.setBpmnValues(this.anotherProcess);
     },
   },
   computed: {
@@ -175,9 +162,6 @@ export default {
         } 
         if (this.destinationType  === 'externalURL'){
           this.externalURL = this.getDestinationValue();
-        }
-        if (this.destinationType  === 'anotherProcess'){
-          this.anotherProcess = this.getDestinationValue();
         }
       }
     },
@@ -241,10 +225,6 @@ export default {
         value,
       });
       this.$emit('input', data);
-    },
-    onProcessInput(event) {
-      this.anotherProcess = event;
-      this.setBpmnValues(event);
     },
   },
 };

--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -73,6 +73,7 @@ export default {
   
   data() {
     return {
+      loading: false,
       validation: '',
       destinationType: null,
       dashboards: [],

--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -54,12 +54,19 @@
       data-test="external-url"
     />
   </div>
+  <process-form-select
+    v-if="destinationType === 'anotherProcess'"
+    @input="onProcessInput"
+    :value="anotherProcess"
+  />
 </template>
 
 <script>
+import ProcessFormSelect from '@/components/inspectors/ProcessFormSelect';
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
 export default {
+  components: { ProcessFormSelect },
   props: {
     options: {
       type: Array,
@@ -79,6 +86,7 @@ export default {
       dashboards: [],
       customDashboard: null,
       elementDestination: this.options[0] || null,
+      anotherProcess: '{}',
       defaultValues: {
         summaryScreen: null,
         customDashboard: null,
@@ -87,6 +95,7 @@ export default {
         homepageDashboard: '/process-browser',
         taskList: '/tasks',
         taskSource: null,
+        anotherProcess: '{}',
       },
       urlModel: null,
       local: null,
@@ -117,6 +126,9 @@ export default {
     },
     externalURL() {
       this.setBpmnValues(this.externalURL);
+    },
+    anotherProcess() {
+      this.setBpmnValues(this.anotherProcess);
     },
   },
   computed: {
@@ -163,6 +175,9 @@ export default {
         } 
         if (this.destinationType  === 'externalURL'){
           this.externalURL = this.getDestinationValue();
+        }
+        if (this.destinationType  === 'anotherProcess'){
+          this.anotherProcess = this.getDestinationValue();
         }
       }
     },
@@ -226,6 +241,10 @@ export default {
         value,
       });
       this.$emit('input', data);
+    },
+    onProcessInput(event) {
+      this.anotherProcess = event;
+      this.setBpmnValues(event);
     },
   },
 };

--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -53,12 +53,12 @@
       :helper="$t('Determine de URL where the request will end')"
       data-test="external-url"
     />
+    <process-form-select
+      v-if="destinationType === 'anotherProcess'"
+      @input="onProcessInput"
+      :value="anotherProcess"
+    />
   </div>
-  <process-form-select
-    v-if="destinationType === 'anotherProcess'"
-    @input="onProcessInput"
-    :value="anotherProcess"
-  />
 </template>
 
 <script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Element Destination field is empty by default
Expected behavior: 
Task Source should be displayed by default in Element Destination field
Actual behavior: 
Element Destination field is empty by default
## Solution
- add as a default the first option


https://github.com/ProcessMaker/modeler/assets/1401911/a93646cb-2a21-4886-aa25-91702c54288f


## How to Test
Test the steps above

1. Log in
2. Create a new process
3. Search process and edit
4. Add form task to modeler

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-16365

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
