### PR TITLE
FOUR-16537 the selected dashboard is lost when changing the configuration in element destination

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -44,7 +44,7 @@
       data-test="dashboard"
     />
     <form-input
-      v-if="destinationType === 'externalURL'" 
+      v-if="destinationType === 'externalURL'"
       :label="$t('URL')"
       v-model="externalURL"
       :error="getValidationErrorForURL(externalURL)"
@@ -77,7 +77,7 @@ export default {
     },
   },
   name: 'ElementDestination',
-  
+
   data() {
     return {
       loading: false,
@@ -102,7 +102,7 @@ export default {
       loadDashboardsDebounced: null,
       urlPlaceholder: 'https://ci-ba427360a6.engk8s.processmaker.net/processes',
       externalURL: '',
-    };  
+    };
   },
   watch: {
     elementDestination: {
@@ -148,7 +148,6 @@ export default {
   mounted() {
     this.urlModel = { ...this.defaultValues };
     this.loadData();
-    
   },
   methods: {
     getValidationErrorForURL(url) {
@@ -165,14 +164,14 @@ export default {
         return false;
       }
     },
-    loadData() {  
+    loadData() {
       if (this.value) {
         this.local = JSON.parse(this.value);
         this.elementDestination = this.getElementDestination();
         this.destinationType = this.getDestinationType();
         if (this.destinationType  === 'customDashboard'){
           this.customDashboard = this.getDestinationValue();
-        } 
+        }
         if (this.destinationType  === 'externalURL'){
           this.externalURL = this.getDestinationValue();
         }
@@ -193,9 +192,9 @@ export default {
       if (!this.local?.value) return null;
       return this.local?.value;
     },
-    destinationTypeChange(newType){
+    destinationTypeChange(newType) {
       this.destinationType = newType;
-      this.resetProperties(); 
+      this.resetProperties();
       const data =  JSON.stringify({
         type: this.destinationType,
         value: this.urlModel[this.destinationType],
@@ -204,7 +203,11 @@ export default {
     },
 
     resetProperties() {
-      this.urlModel = { ...this.defaultValues };
+      this.urlModel = {
+        ...this.defaultValues,
+        customDashboard: this.customDashboard,
+        anotherProcess: this.anotherProcess,
+      };
     },
     searchChange(filter) {
       this.loadDashboardsDebounced(filter);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
- The request should redirect to the custom panel.
- The selected board should be kept when changing the settings in Item Destination

Actual behavior: 
- The request redirects to the screen summary, not to the custom dashboard 
- The selected dashboard is lost when changing the configuration in the Element destination

## Solution
- Keep the configuration of the Custom Dashboard and the Process when Element destination is changed

## How to Test
1. Import attached process
2. Search process and edit
3. Select Dashboard in Element destination
4. Select a dashboard in Dashboard field
5. Click on publish button
6. Select  Summary Screen in Element destination
7. Select Dashboard in Element destination
8. Click on publish button
9. Create a request
10. Search process and edit
11. Click on End Event
12. Review configuration of end event

## Related Tickets & Packages
[FOUR-16537](https://processmaker.atlassian.net/browse/FOUR-16537)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next