### PR TITLE
FOUR-16688 inconsistency between labels for dashboard option in element destination field

### DIFF
--- a/src/components/inspectors/endEventElementDestination.js
+++ b/src/components/inspectors/endEventElementDestination.js
@@ -13,7 +13,7 @@ export default {
       { value: 'taskList', content: 'Task List' },
       { value: 'processLaunchpad', content: 'Process Launchpad' },
       { value: 'homepageDashboard', content: 'Welcome Screen' },
-      { value: 'customDashboard', content: 'Dashboard' },
+      { value: 'customDashboard', content: 'Custom Dashboard' },
       { value: 'externalURL', content: 'External URL' },
       { value: 'anotherProcess', content: 'Another Process' },
     ],


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Both cases redirect to a dashboard, they should have the same name

## Solution
- Update the Custom Dashboard label for the End Event Element

## How to Test
1. Create a process
2. First scenario: Task
   1. Add form task control to the modeler
   2. Click on Task 
   3. Go to configure
   4. Go to the Element destination field
3. Second scenario: End Event
   1. Add end event control to the modeler
   2. Click on the end event
   3. Go to configure
   4. Go to the Element destination field

## Related Tickets & Packages
[FOUR-16688](https://processmaker.atlassian.net/browse/FOUR-16688)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16688]: https://processmaker.atlassian.net/browse/FOUR-16688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ