### PR TITLE
FOUR-16813 A user not assigned to the next task is not redirected to the source from which the task was accessed

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -85,7 +85,7 @@ export default {
       destinationType: null,
       dashboards: [],
       customDashboard: null,
-      elementDestination: this.options[0] || null,
+      elementDestination: null,
       anotherProcess: '{}',
       defaultValues: {
         summaryScreen: null,
@@ -165,6 +165,8 @@ export default {
       }
     },
     loadData() {
+      this.elementDestination = this.options?.[0] ?? null;
+
       if (this.value) {
         this.local = JSON.parse(this.value);
         this.elementDestination = this.getElementDestination();

--- a/tests/e2e/specs/BoundaryConditionalEvent.cy.js
+++ b/tests/e2e/specs/BoundaryConditionalEvent.cy.js
@@ -27,7 +27,7 @@ describe('Boundary Conditional Event', () => {
   it('set condition on Boundary Conditional Events', () => {
     toggleInspector();
 
-    const expectedBpmn = '<bpmn:boundaryEvent id="node_11" name="Boundary Conditional Event" attachedToRef="node_2"><bpmn:conditionalEventDefinition><bpmn:condition xsi:type="bpmn:tFormalExpression">form_input_1=="one"</bpmn:condition></bpmn:conditionalEventDefinition></bpmn:boundaryEvent>';
+    const expectedBpmn = '<bpmn:boundaryEvent id="node_12" name="Boundary Conditional Event" attachedToRef="node_2"><bpmn:conditionalEventDefinition><bpmn:condition xsi:type="bpmn:tFormalExpression">form_input_1=="one"</bpmn:condition></bpmn:conditionalEventDefinition></bpmn:boundaryEvent>';
     const condition = '[name=condition]';
     cy.get(condition).clear().type('form_input_1=="one"');
     cy.get('[data-test=downloadXMLBtn]').click();

--- a/tests/e2e/specs/BoundaryMessageEvent.cy.js
+++ b/tests/e2e/specs/BoundaryMessageEvent.cy.js
@@ -18,7 +18,7 @@ describe('Boundary Message Event', () => {
   it('Render an interrupting boundary message event', () => {
     setBoundaryEvent(nodeTypes.boundaryMessageEvent, taskPosition, nodeTypes.subProcess);
 
-    const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_14" name="Boundary Message Event" attachedToRef="node_8"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
+    const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_15" name="Boundary Message Event" attachedToRef="node_9"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
 
     cy.get('[data-test=downloadXMLBtn]').click();
     waitToRenderAllShapes();
@@ -38,7 +38,7 @@ describe('Boundary Message Event', () => {
 
     const interrupting = '[name=cancelActivity]';
     cy.get(interrupting).click();
-    const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_14" name="Boundary Message Event" cancelActivity="false" attachedToRef="node_8"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
+    const boundaryMessageEventXML = '<bpmn:boundaryEvent id="node_15" name="Boundary Message Event" cancelActivity="false" attachedToRef="node_9"><bpmn:messageEventDefinition /></bpmn:boundaryEvent>';
 
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()

--- a/tests/e2e/specs/BoundarySignalEvent.cy.js
+++ b/tests/e2e/specs/BoundarySignalEvent.cy.js
@@ -36,7 +36,7 @@ describe('Boundary Signal Event', () => {
     selectOptionByName('[data-test="signalRef:select"]', signalName);
 
     assertDownloadedXmlContainsExpected(`
-      <bpmn:boundaryEvent id="node_11" name="${name}" attachedToRef="node_2">
+      <bpmn:boundaryEvent id="node_12" name="${name}" attachedToRef="node_2">
         <bpmn:signalEventDefinition signalRef="${signalRef}" />
       </bpmn:boundaryEvent>
     `);

--- a/tests/e2e/specs/BoundaryTimerEvent.cy.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.cy.js
@@ -173,7 +173,7 @@ describe('Boundary Timer Event', { scrollBehavior: false }, () => {
     waitToRenderAllShapes();
 
     const taskXml = '<bpmn:task id="node_2" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />';
-    const boundaryEventOnTaskXml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_2">';
+    const boundaryEventOnTaskXml = '<bpmn:boundaryEvent id="node_12" name="Boundary Timer Event" attachedToRef="node_2">';
 
     assertDownloadedXmlContainsExpected(taskXml, boundaryEventOnTaskXml);
 
@@ -196,8 +196,8 @@ describe('Boundary Timer Event', { scrollBehavior: false }, () => {
           .trigger('mouseup')
           .then(waitToRenderAllShapes)
           .then(() => {
-            const task2Xml = '<bpmn:task id="node_12" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />';
-            const boundaryEventOnTask2Xml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_12">';
+            const task2Xml = '<bpmn:task id="node_13" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />';
+            const boundaryEventOnTask2Xml = '<bpmn:boundaryEvent id="node_12" name="Boundary Timer Event" attachedToRef="node_13">';
 
             assertDownloadedXmlContainsExpected(task2Xml, boundaryEventOnTask2Xml);
             assertDownloadedXmlDoesNotContainExpected(boundaryEventOnTaskXml);

--- a/tests/e2e/specs/BoundaryTimerEvent.cy.js
+++ b/tests/e2e/specs/BoundaryTimerEvent.cy.js
@@ -172,7 +172,7 @@ describe('Boundary Timer Event', { scrollBehavior: false }, () => {
     setBoundaryEvent(nodeTypes.boundaryTimerEvent, taskPosition);
     waitToRenderAllShapes();
 
-    const taskXml = '<bpmn:task id="node_2" name="Form Task" pm:assignment="requester" />';
+    const taskXml = '<bpmn:task id="node_2" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />';
     const boundaryEventOnTaskXml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_2">';
 
     assertDownloadedXmlContainsExpected(taskXml, boundaryEventOnTaskXml);
@@ -196,7 +196,7 @@ describe('Boundary Timer Event', { scrollBehavior: false }, () => {
           .trigger('mouseup')
           .then(waitToRenderAllShapes)
           .then(() => {
-            const task2Xml = '<bpmn:task id="node_12" name="Form Task" pm:assignment="requester" />';
+            const task2Xml = '<bpmn:task id="node_12" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />';
             const boundaryEventOnTask2Xml = '<bpmn:boundaryEvent id="node_11" name="Boundary Timer Event" attachedToRef="node_12">';
 
             assertDownloadedXmlContainsExpected(task2Xml, boundaryEventOnTask2Xml);

--- a/tests/e2e/specs/CopyElements.cy.js
+++ b/tests/e2e/specs/CopyElements.cy.js
@@ -58,9 +58,9 @@ describe('Copy element', { scrollBehavior: false }, () => {
 
     const processWithTwoStartEventCopies = `
       <bpmn:startEvent id="node_1" name="Start Event" />
-      <bpmn:task id="node_2" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" />
-      <bpmn:task id="node_26" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" />
-      <bpmn:task id="node_28" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" />
+      <bpmn:task id="node_2" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
+      <bpmn:task id="node_27" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
+      <bpmn:task id="node_29" name="Test Name" pm:dueIn="45" pm:assignment="requester" pm:assignedUsers="John Smith" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
     `;
 
     assertDownloadedXmlContainsExpected(processWithTwoStartEventCopies);

--- a/tests/e2e/specs/DataObjectDataStore.cy.js
+++ b/tests/e2e/specs/DataObjectDataStore.cy.js
@@ -97,7 +97,7 @@ describe('Data Objects and Data Stores', () => {
       const name = nodeType === 'processmaker-modeler-data-object' ? 'Data Object' : 'Data Store';
       getNumberOfLinks().should('equal', 1);
       assertDownloadedXmlMatch(`
-        <bpmn:task id="node_*" name="Form Task" pm:assignment="requester">
+        <bpmn:task id="node_*" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
           <bpmn:ioSpecification id="*">
             <bpmn:dataInput id="data_input_node_*" name="${name}" isCollection="false" />
             <bpmn:inputSet id="*">

--- a/tests/e2e/specs/MessageFlows.cy.js
+++ b/tests/e2e/specs/MessageFlows.cy.js
@@ -256,10 +256,10 @@ describe('Message Flows', { scrollBehavior: false }, () => {
     connectNodesWithFlow('generic-flow-button', startEventPosition, boundaryEventPosition, 'center');
 
     const endEventId = 'node_3';
-    const boundaryEventId = 'node_18';
+    const boundaryEventId = 'node_19';
     const endEventXml = `<bpmn:endEvent id="${endEventId}" name="Message End Event">`;
-    const boundaryEventXml = `<bpmn:boundaryEvent id="${boundaryEventId}" name="Boundary Message Event" attachedToRef="node_12">`;
-    const messageFlowXml = `<bpmn:messageFlow id="node_19" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
+    const boundaryEventXml = `<bpmn:boundaryEvent id="${boundaryEventId}" name="Boundary Message Event" attachedToRef="node_13">`;
+    const messageFlowXml = `<bpmn:messageFlow id="node_20" name="" sourceRef="${endEventId}" targetRef="${boundaryEventId}" />`;
 
     assertDownloadedXmlContainsExpected(endEventXml, boundaryEventXml, messageFlowXml);
   });

--- a/tests/e2e/specs/Pools.cy.js
+++ b/tests/e2e/specs/Pools.cy.js
@@ -219,7 +219,7 @@ describe('Pools', { scrollBehavior: false }, () => {
     const pool1taskXml = `
       <bpmn:process id="Process_1" isExecutable="true">
         <bpmn:startEvent id="node_1" name="Start Event" />
-        <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" />
+        <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
         <bpmn:boundaryEvent id="node_13" name="Boundary Timer Event" attachedToRef="node_4">
     `;
     assertDownloadedXmlContainsExpected(pool1taskXml);
@@ -231,7 +231,7 @@ describe('Pools', { scrollBehavior: false }, () => {
 
     const pool2taskXml = `
       <bpmn:process id="Process_2">
-        <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" />
+        <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
         <bpmn:boundaryEvent id="node_13" name="Boundary Timer Event" attachedToRef="node_4">
     `;
     assertDownloadedXmlContainsExpected(pool2taskXml);

--- a/tests/e2e/specs/Pools.cy.js
+++ b/tests/e2e/specs/Pools.cy.js
@@ -220,7 +220,7 @@ describe('Pools', { scrollBehavior: false }, () => {
       <bpmn:process id="Process_1" isExecutable="true">
         <bpmn:startEvent id="node_1" name="Start Event" />
         <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
-        <bpmn:boundaryEvent id="node_13" name="Boundary Timer Event" attachedToRef="node_4">
+        <bpmn:boundaryEvent id="node_14" name="Boundary Timer Event" attachedToRef="node_4">
     `;
     assertDownloadedXmlContainsExpected(pool1taskXml);
 
@@ -232,7 +232,7 @@ describe('Pools', { scrollBehavior: false }, () => {
     const pool2taskXml = `
       <bpmn:process id="Process_2">
         <bpmn:task id="node_4" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />
-        <bpmn:boundaryEvent id="node_13" name="Boundary Timer Event" attachedToRef="node_4">
+        <bpmn:boundaryEvent id="node_14" name="Boundary Timer Event" attachedToRef="node_4">
     `;
     assertDownloadedXmlContainsExpected(pool2taskXml);
   });

--- a/tests/e2e/specs/SequenceFlows.cy.js
+++ b/tests/e2e/specs/SequenceFlows.cy.js
@@ -58,7 +58,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
     typeIntoTextInput('[name=conditionExpression]', testExpressionString);
     cy.get('[name=conditionExpression]').should('have.value', testExpressionString);
 
-    const sequenceFlowXml = `<bpmn:sequenceFlow id="node_9" name="${testNameString}" sourceRef="node_2" targetRef="node_3"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testExpressionString}</bpmn:conditionExpression></bpmn:sequenceFlow>`;
+    const sequenceFlowXml = `<bpmn:sequenceFlow id="node_10" name="${testNameString}" sourceRef="node_2" targetRef="node_3"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${testExpressionString}</bpmn:conditionExpression></bpmn:sequenceFlow>`;
 
     cy.get('[data-test=downloadXMLBtn]').click();
     cy.window()
@@ -290,7 +290,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
     const taskPosition = { x: 350, y: 250 };
     let numberOfSequenceFlowsAdded = 1;
 
-    const sequenceFlow = '<bpmn:sequenceFlow id="node_12" sourceRef="node_1" targetRef="node_8"';
+    const sequenceFlow = '<bpmn:sequenceFlow id="node_13" sourceRef="node_1" targetRef="node_9"';
 
     addNodeTypeToPaper(taskPosition, nodeTypes.task, 'switch-to-script-task');
     getElementAtPosition(taskPosition).getType().should('equal', nodeTypes.scriptTask);
@@ -315,7 +315,7 @@ describe('Sequence Flows', { scrollBehavior: false }, () => {
       expect($links.length).to.eq(numberOfSequenceFlowsAdded);
     });
 
-    const updatedSequenceFlow = '<bpmn:sequenceFlow id="node_12" sourceRef="node_1" targetRef="node_14"';
+    const updatedSequenceFlow = '<bpmn:sequenceFlow id="node_13" sourceRef="node_1" targetRef="node_15"';
     assertDownloadedXmlContainsExpected(updatedSequenceFlow);
   });
 });

--- a/tests/e2e/specs/SignalEndEvent.cy.js
+++ b/tests/e2e/specs/SignalEndEvent.cy.js
@@ -7,7 +7,7 @@ describe('Signal End Event', () => {
     addNodeTypeToPaper(signalEndEventPosition, nodeTypes.endEvent, 'switch-to-signal-end-event');
 
     assertDownloadedXmlContainsExpected(`
-      <bpmn:endEvent id="node_3" name="Signal End Event">
+      <bpmn:endEvent id="node_3" name="Signal End Event" pm:elementDestination="{&#34;type&#34;:&#34;summaryScreen&#34;,&#34;value&#34;:null}">
         <bpmn:signalEventDefinition />
       </bpmn:endEvent>
     `);

--- a/tests/e2e/specs/SubProcess.cy.js
+++ b/tests/e2e/specs/SubProcess.cy.js
@@ -61,7 +61,7 @@ describe('Sub Process (Call Activities)', { scrollBehavior: false }, () => {
     selectCalledProcess('Process with multiple start events');
     selectSubProcessStartEvent(startEventName);
 
-    assertDownloadedXmlContainsExpected(`<bpmn:callActivity id="node_8" name="${defaultSubProcessNodeName}" calledElement="Subprocess1-5" pm:config="${encodedConfig}" />`);
+    assertDownloadedXmlContainsExpected(`<bpmn:callActivity id="node_9" name="${defaultSubProcessNodeName}" calledElement="Subprocess1-5" pm:config="${encodedConfig}" />`);
   });
 
   it('Allows typing in name field on new sub process', () => {

--- a/tests/e2e/specs/TaskLoop.cy.js
+++ b/tests/e2e/specs/TaskLoop.cy.js
@@ -21,7 +21,7 @@ describe('Task Loop properties', () => {
 
     // loopMaximum should be removed from xml
     assertDownloadedXmlMatch(`
-      <bpmn:task id="node_1" name="Form Task" pm:assignment="requester">
+      <bpmn:task id="node_1" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
         <bpmn:standardLoopCharacteristics id="*" />
       </bpmn:task>
     `);

--- a/tests/e2e/specs/TaskLoop.cy.js
+++ b/tests/e2e/specs/TaskLoop.cy.js
@@ -31,7 +31,7 @@ describe('Task Loop properties', () => {
 
     // loopMaximum should be added to xml
     assertDownloadedXmlMatch(`
-      <bpmn:task id="node_1" name="Form Task" pm:assignment="requester">
+      <bpmn:task id="node_1" name="Form Task" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
         <bpmn:standardLoopCharacteristics id="*" loopMaximum="10" />
       </bpmn:task>
     `);

--- a/tests/e2e/specs/TaskMarkerFlags.cy.js
+++ b/tests/e2e/specs/TaskMarkerFlags.cy.js
@@ -23,7 +23,7 @@ describe('Task Marker Flags', () => {
 
   it('sets a task as "for compensation"', () => {
     cy.get('[data-test=for-compensation').check({ force: true });
-    assertDownloadedXmlContainsExpected('<bpmn:task id="node_2" name="Form Task" isForCompensation="true" pm:assignment="requester" />');
+    assertDownloadedXmlContainsExpected('<bpmn:task id="node_2" name="Form Task" isForCompensation="true" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}" />');
     assertBottomCenterTaskMarkerHasImage('compensation');
   });
 
@@ -46,7 +46,7 @@ describe('Task Marker Flags', () => {
     assertBottomCenterTaskMarkerHasImage('compensation');
     assertBottomCenterTaskMarkerHasImage('loop', 1);
     assertDownloadedXmlContainsExpected(`
-      <bpmn:task id="node_1" name="Form Task" isForCompensation="true" pm:assignment="requester">
+      <bpmn:task id="node_1" name="Form Task" isForCompensation="true" pm:assignment="requester" pm:elementDestination="{&#34;type&#34;:&#34;taskSource&#34;,&#34;value&#34;:null}">
         <bpmn:standardLoopCharacteristics id="node_1_inner_2" />
       </bpmn:task>
     `);

--- a/tests/e2e/specs/TerminateEndEvent.cy.js
+++ b/tests/e2e/specs/TerminateEndEvent.cy.js
@@ -7,7 +7,7 @@ describe('Terminate End Event', () => {
     addNodeTypeToPaper(terminateEndEventPosition, nodeTypes.endEvent, 'switch-to-terminate-end-event');
 
     assertDownloadedXmlContainsExpected(`
-      <bpmn:endEvent id="node_3" name="Terminate End Event">
+      <bpmn:endEvent id="node_3" name="Terminate End Event" pm:elementDestination="{&#34;type&#34;:&#34;summaryScreen&#34;,&#34;value&#34;:null}">
         <bpmn:terminateEventDefinition />
       </bpmn:endEvent>
     `);


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
A user not assigned to the next task should be redirected to the source from which the task was accessed

Actual behavior: 
A user not assigned to the next task is not redirected to the source from which the task was accessed

## Solution
- set `elementDestination` property on mounted 

## How to Test
1. Login with admin user
2. Import attached process
3. Assign other user 
4. First scenario:From Processes page
   1. Create a request of process 
   2. Go to task
   3. Fill form 
   4. Click on submit button
5. Second scenario:From Request page
   1. Create a request of process 
   2. Go to task
   3. Fill form 
   4. Click on submit button
6. Third scenario:From Designer page
   1. Create a request of process 
   2. Go to task
   3. Fill form 
   4. Click on submit button
7. Fourth scenario:From  Admin page
   1. Create a request of process 
   2. Go to task
   3. Fill form 
   4. Click on submit button

## Related Tickets & Packages
[FOUR-16813](https://processmaker.atlassian.net/browse/FOUR-16813)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16813]: https://processmaker.atlassian.net/browse/FOUR-16813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ