### PR TITLE
FOUR-16894 dashboard field is not required

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -35,7 +35,7 @@
       optionContent="title"
       optionValue="url"
       class="p-0 mb-2"
-      :validation="validation"
+      validation="required"
       :searchable="true"
       :internal-search="false"
       :preserve-search="false"


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The Dashboard field must be required for the user to be redirected to their custom dashboard

Actual behavior: 
The Dashboard field is not required

## Solution
- Add validation to custom dashboard select field

![image](https://github.com/ProcessMaker/modeler/assets/3604190/a3722a4f-43e9-40aa-9710-77eb195d6a82)

## How to Test
Test the steps above

## Related Tickets & Packages
[FOUR-16894](https://processmaker.atlassian.net/browse/FOUR-16894)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.




[FOUR-16894]: https://processmaker.atlassian.net/browse/FOUR-16894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ