### PR TITLE
FOUR-16762 options in element destination are not translated

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -8,7 +8,7 @@
       :placeholder="$t('Select element destination')"
       :showLabels="false"
       :allow-empty="false"
-      :options="options"
+      :options="optionsCopy"
       :loading="loading"
       optionContent="content"
       optionValue="value"
@@ -80,6 +80,7 @@ export default {
 
   data() {
     return {
+      optionsCopy: [],
       loading: false,
       validation: '',
       destinationType: null,
@@ -165,7 +166,12 @@ export default {
       }
     },
     loadData() {
-      this.elementDestination = this.options?.[0] ?? null;
+      this.optionsCopy = this.options.map(option => ({
+        value: option.value,
+        content: this.$t(option.content),
+      }));
+
+      this.elementDestination = this.optionsCopy?.[0] ?? null;
 
       if (this.value) {
         this.local = JSON.parse(this.value);
@@ -184,7 +190,7 @@ export default {
     },
     getElementDestination() {
       if (!this.local?.type) return null;
-      return this.options.find(element => element.value === this.local.type);
+      return this.optionsCopy.find(element => element.value === this.local.type);
     },
     getDestinationType() {
       if (!this.local?.type) return null;


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Options in the element destination should be translated

Actual behavior: 
Options in element destination are not translated

## Solution
- Add missing translations

![image](https://github.com/ProcessMaker/modeler/assets/3604190/c2f756ab-c20b-468b-bc06-edd52500b7e0)

## How to Test
1. Import attached process
2. Create a new user and edit
   1. Make admin user
   2. Change language(Spanish, French or Deutsch)
   3. Save changes
3. Login with new user
4. Open process
5. Click on task
   1. Go to element destination
   2. View items in the list
6. Click on End Event
   1. Go to element destination
   2. View items in the list 

## Related Tickets & Packages
[FOUR-16762](https://processmaker.atlassian.net/browse/FOUR-16762)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-16762]: https://processmaker.atlassian.net/browse/FOUR-16762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ