### PR TITLE
FOUR-16995 when a user decides to use the redirect the interstitial functionality is not disabled

### DIFF
--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -137,6 +137,9 @@ export default {
       const list = this.filterValidDashboards(this.dashboards) || [];
       return list;
     },
+    node() {
+      return this.$root.$children[0].$refs.modeler.highlightedNode.definition;
+    },
   },
   created() {
     this.loadDashboardsDebounced = debounce((filter) => {
@@ -208,6 +211,10 @@ export default {
         value: this.urlModel[this.destinationType],
       });
       this.$emit('input', data);
+
+      this.$nextTick(() => {
+        this.handleInterstitial(newType);
+      });
     },
 
     resetProperties() {
@@ -256,6 +263,29 @@ export default {
     onProcessInput(event) {
       this.anotherProcess = event;
       this.setBpmnValues(event);
+    },
+    /**
+     * Handle interstitial for task source
+     *
+     * @param {String} newValue
+     */
+    handleInterstitial(newValue) {
+      const taskTypes = ['bpmn:Task', 'bpmn:ManualTask'];
+
+      if (!taskTypes.includes(this.node.$type)) {
+        return;
+      }
+
+      let isDisabled = false;
+
+      if (newValue === 'taskSource') {
+        isDisabled = true;
+      }
+
+      this.$root.$emit('handle-interstitial', {
+        nodeId: this.node.id,
+        isDisabled,
+      });
     },
   },
 };

--- a/src/components/inspectors/ElementDestination.vue
+++ b/src/components/inspectors/ElementDestination.vue
@@ -3,7 +3,7 @@
     <form-multi-select
       :label="$t('Element Destination')"
       name="ElementDestination"
-      :helper="$t('Enter the destination...')"
+      :helper="helper"
       v-model="elementDestination"
       :placeholder="$t('Select element destination')"
       :showLabels="false"
@@ -139,6 +139,13 @@ export default {
     },
     node() {
       return this.$root.$children[0].$refs.modeler.highlightedNode.definition;
+    },
+    helper() {
+      if (this.node.$type === 'bpmn:EndEvent') {
+        return this.$t('The user will go here after completing the task.');
+      }
+
+      return this.$t('Select where to send users after this task. Any Non-default destination will disable the “Display Next Assigned Task” function.');
     },
   },
   created() {

--- a/tests/e2e/specs/Documentation.cy.js
+++ b/tests/e2e/specs/Documentation.cy.js
@@ -46,7 +46,7 @@ describe('Documentation accordion', { scrollBehavior: false }, () => {
         clickAndDropElement(type, position);
         waitToRenderAllShapes();
         cy.get('iframe.tox-edit-area__iframe').should('not.be.visible');
-        cy.contains('Advanced').click();
+        cy.contains('Advanced').click({ force: true });
         cy.tick(accordionOpenAnimationTime);
         cy.get('iframe.tox-edit-area__iframe').should('not.be.visible');
         cy.contains('Documentation').click();


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
- The user should be redirected according to the configuration in the element destination (In this case: to task list)

Actual behavior: 
- The user is redirected to the next task

## Solution
- Disable the interstitial checkbox when the Task Source is selected
- Update the Element Destination helper

## How to Test
1. Log in
2. Create a new process
3. Search process and edit
4. First scenario: Form Task
    1. Add Form Task to modeler
    2. Select any option in element destination field
5. Second scenario: End Event
    1. Add End event to modeler
    2. Select any option in element destination field

## Related Tickets & Packages
[FOUR-16995](https://processmaker.atlassian.net/browse/FOUR-16995)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.



[FOUR-16995]: https://processmaker.atlassian.net/browse/FOUR-16995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ