### PR TITLE
FOUR-16635: The added documentation is displayed in modeler

### DIFF
--- a/src/components/nodes/baseStartEvent/baseStartEvent.vue
+++ b/src/components/nodes/baseStartEvent/baseStartEvent.vue
@@ -121,7 +121,7 @@ export default {
       doclabel: {
         display: 'none',
         style: 'text-anchor: middle; transform: translate(30px, -4px);',
-        text:this._uid,
+        text: null,
       },
     });
 

--- a/src/components/nodes/baseStartEvent/baseStartEvent.vue
+++ b/src/components/nodes/baseStartEvent/baseStartEvent.vue
@@ -26,6 +26,7 @@ import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from './defaultNames';
 import updateIconColor from '@/mixins/updateIconColor';
+import store from '@/store';
 
 export default {
   components: {
@@ -125,7 +126,7 @@ export default {
     });
 
     const interval = window.setInterval(() => {
-      if (view.$('circle').length > 0) {
+      if (view.$('circle').length > 0 && store.getters.isForDocumenting) {
         view.model.attr({
           doccircle: {
             display:(doc ? 'block' : 'none'),

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -24,6 +24,8 @@ import { endColor, endColorStroke } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from '@/components/nodes/endEvent/defaultNames';
+import store from '@/store';
+
 
 export default {
   components: {
@@ -117,7 +119,7 @@ export default {
     });
 
     const interval = window.setInterval(() => {
-      if (view.$('circle').length > 0) {
+      if (view.$('circle').length > 0 && store.getters.isForDocumenting) {
         view.model.attr({
           doccircle: {
             display:(doc ? 'block' : 'none'),

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -114,7 +114,7 @@ export default {
       doclabel: {
         display: 'none',
         style: 'text-anchor: middle; transform: translate(30px, -4px);',
-        text: this._uid,
+        text: null,
       },
     });
 

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -23,6 +23,8 @@ import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from '@/components/nodes/gateway/defaultNames';
+import store from '@/store';
+
 
 const hasDefaultFlow = [
   'bpmn:ExclusiveGateway',
@@ -128,7 +130,7 @@ export default {
     });
 
     const interval = window.setInterval(() => {
-      if (view.$('circle').length > 0) {
+      if (view.$('circle').length > 0 && store.getters.isForDocumenting) {
         view.model.attr({
           doccircle: {
             display:(doc ? 'block' : 'none'),

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -125,7 +125,7 @@ export default {
       doclabel: {
         display: 'none',
         style: 'text-anchor: middle; transform: translate(30px, -4px);',
-        text: this._uid,
+        text: null,
       },
     });
 

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -181,7 +181,7 @@ export default {
       doclabel: {
         display: 'none',
         style: 'text-anchor: middle; transform: translate(100px, -4px);',
-        text: this._uid,
+        text: null,
       },
     });
 

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -39,6 +39,7 @@ import boundaryEventDropdownData from '@/components/nodes/boundaryEvent/boundary
 import setupLoopCharacteristicsMarkers from '@/components/nodes/task/setupMultiInstanceMarkers';
 import setupCompensationMarker from '@/components/nodes/task/setupCompensationMarker';
 import { getRectangleAnchorPoint } from '@/portsUtils';
+import store from '@/store';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -185,7 +186,7 @@ export default {
     });
 
     const interval = window.setInterval(() => {
-      if (view.$('circle').length > 0) {
+      if (view.$('circle').length > 0 && store.getters.isForDocumenting) {
         view.model.attr({
           doccircle: {
             display:(doc ? 'block' : 'none'),

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -1,6 +1,7 @@
 import nodeTypesStore from '@/nodeTypesStore';
 import { COLOR_DEFAULT } from '@/components/highlightColors.js';
 import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
+import store from '@/store';
 
 const ALLOWED_BPMN_TYPES = [
   'bpmn:Task',
@@ -61,19 +62,21 @@ export default {
   methods: {
     linkEditingInit() {
       this.paperManager.addEventHandler('cell:mouseleave', (view) => {
-        window.ProcessMaker.EventBus.$emit('hide-documentation');
-        this.currentHover = null;
-        view.model.attr({
-          doccircle: {
-            r: 10,
-            stroke: '#2B9DFF',
-            strokeWidth: '3',
-            fill: '#8DC8FF',
-          },
-          doclabel: {
-            display:'none',
-          },
-        });
+        if (store.getters.isForDocumenting) {
+          window.ProcessMaker.EventBus.$emit('hide-documentation');
+          this.currentHover = null;
+          view.model.attr({
+            doccircle: {
+              r: 10,
+              stroke: '#2B9DFF',
+              strokeWidth: '3',
+              fill: '#8DC8FF',
+            },
+            doclabel: {
+              display:'none',
+            },
+          });
+        }
       });
 
       // Handle hovering a new element on the page
@@ -87,7 +90,7 @@ export default {
           this.currentHover = view.cid;
         }
 
-        if (doc) {
+        if (doc && store.getters.isForDocumenting) {
           const nodeId = view.model.component.node.id;
           let nodeNumber = -1;
           for (let process of view.model.component.$attrs.processes) {


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to reproduced:

1.Create a process
2.Add different objects
3.Add documentation
4.Move the mouse over any of the objects

Current Behavior:
Time tracking
Description

Steps to reproduced:

1.Create a process
2.Add different objects
3.Add documentation
4.Move the mouse over any of the objects

Current Behavior:
The added documentation is displayed

Expected Behavior:
The added documentation is displayed

Documentation added to objects should not be displayed in the modeler.
## Solution
https://processmaker.atlassian.net/browse/FOUR-16635

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-16635

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
