### PR TITLE
bugfix/FOUR-17036: Added generic icons for service tasks and other gateways + interm events icon added

### DIFF
--- a/src/assets/documenting/intermediate_event.svg
+++ b/src/assets/documenting/intermediate_event.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #ffb01f;
+      }
+
+      .cls-1, .cls-2 {
+        stroke-width: 0px;
+      }
+
+      .cls-2 {
+        fill: #ffeaca;
+      }
+    </style>
+  </defs>
+  <g id="Layer_1-2" data-name="Layer 1">
+    <g>
+      <g>
+        <circle class="cls-2" cx="8" cy="8" r="7.5"/>
+        <path class="cls-1" d="M8,1c3.86,0,7,3.14,7,7s-3.14,7-7,7S1,11.86,1,8,4.14,1,8,1M8,0C3.58,0,0,3.58,0,8s3.58,8,8,8,8-3.58,8-8S12.42,0,8,0h0Z"/>
+      </g>
+      <path class="cls-1" d="M8,3.82c2.3,0,4.18,1.87,4.18,4.18s-1.87,4.18-4.18,4.18-4.18-1.87-4.18-4.18,1.87-4.18,4.18-4.18M8,2.82c-2.86,0-5.18,2.32-5.18,5.18s2.32,5.18,5.18,5.18,5.18-2.32,5.18-5.18-2.32-5.18-5.18-5.18h0Z"/>
+    </g>
+  </g>
+</svg>

--- a/src/components/documenting/NodeDocumentation.vue
+++ b/src/components/documenting/NodeDocumentation.vue
@@ -44,6 +44,7 @@ export default {
       },
       startEventIcon: require('./../../assets/documenting/start_event.svg'),
       endEventIcon: require('./../../assets/documenting/end_event.svg'),
+      intermediateEventIcon: require('./../../assets/documenting/intermediate_event.svg'),
       taskIcon: require('./../../assets/documenting/task.svg'),
       gatewayIcon: require('./../../assets/documenting/gateway.svg'),
     };
@@ -60,9 +61,17 @@ export default {
           return this.startEventIcon;
         case 'EndEvent':
           return this.endEventIcon;
+        case 'IntermediateEvent':
+          return this.intermediateEventIcon;
         case 'Task':
           return this.taskIcon;
+        case 'ServiceTask':
+          return this.taskIcon;
         case 'ExclusiveGateway':
+          return this.gatewayIcon;
+        case 'ParallelGateway':
+          return this.gatewayIcon;
+        case 'InclusiveGateway':
           return this.gatewayIcon;
         default:
           return '';


### PR DESCRIPTION
## Issue 
- [FOUR-17036](https://processmaker.atlassian.net/browse/FOUR-17036)

## Solution
- Added a generic icon for all gateways
- Added a generic icon for all tasks
- Added a new icon for intermediate events

## How to Test
Test the steps above

## Related PRs:
- https://github.com/ProcessMaker/package-ai/pull/237

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-17036]: https://processmaker.atlassian.net/browse/FOUR-17036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ