### PR TITLE
FOUR-17060: The slideshown image of a published form task defaults to…

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -2389,7 +2389,7 @@ export default {
         this.isOpenPreview = this.isOpenPreview && this.validPreviewElements.includes(nodeType);
       }
     },
-    reset(payload){
+    reset(payload) {
       this.$refs.selector.clearSelection();
 
       store.commit('reset', payload);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -782,6 +782,8 @@ export default {
 
       clonedNode.diagram.bounds.y += yOffset;
       this.addNode(clonedNode);
+
+      this.$emit('cloneElement', clonedNode);
     },
     copyElement() {
       // Checking if User selected a single flow and tries to copy it, to deny it.
@@ -1630,6 +1632,8 @@ export default {
         window.ProcessMaker.EventBus.$emit('multiplayer-removeNode', node);
       }
       this.removeNodeProcedure(node, options);
+
+      this.$emit('removeNode', node, options);
     },
     async removeNodeProcedure(node, { removeRelationships = true } = {}) {
       if (!node) {
@@ -2340,6 +2344,8 @@ export default {
       }
     },
     reset(payload){
+      this.$refs.selector.clearSelection();
+
       store.commit('reset', payload);
     },
   },

--- a/src/store.js
+++ b/src/store.js
@@ -46,7 +46,7 @@ export default new Vuex.Store({
     paper: state => state.paper,
     highlightedNodes: state => state.highlightedNodes,
     nodeShape: state => node => {
-      return state.graph.getCells().find(cell => cell.component && cell.component.node === node);
+      return state.graph?.getCells().find(cell => cell.component && cell.component.node === node);
     },
     highlightedShapes: (state, getters) => {
       return getters.highlightedNodes


### PR DESCRIPTION
## Solution
- Add emit event in modeler for catch this from slideshow package

## How to Test
1. Create a process
2. Add a task form 
3. Upload an image to slide show in the form task
4. Publish the changes 
5. Delete the elements 
6. Publish the changes 
7. Refresh the changes
8. Add a new control

Check the slide show configuration 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17060

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next
ci:deploy