### PR TITLE
FOUR-17212: Documentation of Intermediate Events and Flows is not displayed

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -578,6 +578,7 @@ export default {
             },
           });
 
+          // if it is a link
           if (event?.view?.path?.segments) {
             const firstSegment = event.view.path.segments[0];
             const diffX = Math.floor(firstSegment.nextSegment.end.x) - Math.floor(firstSegment.end.x);

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -207,6 +207,7 @@
 </template>
 
 <script>
+import { shapes } from 'jointjs';
 import Vue from 'vue';
 import NodeDocumentation from '../documenting/NodeDocumentation.vue';
 import _ from 'lodash';
@@ -568,6 +569,7 @@ export default {
           this.$refs['nodeDocumentation'].elementTitle = event.node.definition.name;
           this.$refs['nodeDocumentation'].isVisible = true;
           this.$refs['nodeDocumentation'].event = event;
+
           event.view.model.attr({
             doclabel: {
               text: event.number,
@@ -575,6 +577,30 @@ export default {
               display: 'block',
             },
           });
+
+          if (event?.view?.path?.segments) {
+            const firstSegment = event.view.path.segments[0];
+            const diffX = Math.floor(firstSegment.nextSegment.end.x) - Math.floor(firstSegment.end.x);
+            const diffY = Math.floor(firstSegment.nextSegment.end.y) - Math.floor(firstSegment.end.y);
+            const deltaX = diffX == 0 ? -17 : -Math.sign(diffX) * 5;
+            const deltaY = diffY == 0 ? -17 : -Math.sign(diffY) * 5;
+
+            const circle = new shapes.basic.Circle({
+              id: 'sequenceDocCircle',
+              position: { x: event.view.sourcePoint.x + deltaX, y: event.view.sourcePoint.y + deltaY },
+              size: { width: 40, height: 40 },
+
+              attrs: {
+                circle: {
+                  fill:  '#1572C2',
+                  strokeWidth: 0,
+                },
+                text: { text: event.number , fill: 'white', fontSize: 20, fontWeight: 'bold'},
+              },
+            });
+
+            circle.addTo(this.graph);
+          }
         }
       });
 
@@ -583,6 +609,11 @@ export default {
           this.$refs['nodeDocumentation'].text = '';
           this.$refs['nodeDocumentation'].number = null;
           this.$refs['nodeDocumentation'].isVisible = false;
+        }
+
+        const cell = this.graph.getCell('sequenceDocCircle');
+        if (cell) {
+          cell.remove();
         }
       });
 

--- a/src/components/nodes/intermediateEvent/intermediateEvent.vue
+++ b/src/components/nodes/intermediateEvent/intermediateEvent.vue
@@ -24,6 +24,7 @@ import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from '@/components/nodes/intermediateEvent/defaultNames';
+import documentingIcons from '@/mixins/documentingIcons';
 
 export default {
   components: {
@@ -42,7 +43,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag],
+  mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag, documentingIcons],
   data() {
     return {
       shape: null,
@@ -100,6 +101,8 @@ export default {
     });
     this.shape.addTo(this.graph);
     this.shape.component = this;
+
+    this.initDocumentingIcons({labelX: '30px', labelY: '-4px'});
   },
 };
 </script>

--- a/src/components/nodes/intermediateEvent/shape.js
+++ b/src/components/nodes/intermediateEvent/shape.js
@@ -17,6 +17,13 @@ export default shapes.standard.Circle.extend({
     tagName: 'image',
     selector: 'image',
   },
+  {
+    tagName: 'circle',
+    selector: 'doccircle',
+  }, {
+    tagName: 'text',
+    selector: 'doclabel',
+  },
   markersMarkup('topLeft'),
   markersMarkup('topCenter'),
   markersMarkup('topRight'),
@@ -29,6 +36,17 @@ export default shapes.standard.Circle.extend({
     type: 'processmaker.components.nodes.intermediateEvent.Shape',
     size: { width: 36, height: 36 },
     attrs: {
+      'doclabel': {
+        'ref-x': 26,
+        'ref-y': -4, ref: 'circle', fontSize: 20, fontWeight: 'bold',
+        width: 16, height: 16, 'data-test': 'nodeDocLabel', 'text':'',
+        fill: 'white', display: 'none',
+      },
+      'doccircle': {
+        'cx': 30, 'cy': 5, 'r': 10,
+        'label': '7',
+        'fill': '#8DC8FF', 'stroke': '#2B9DFF', 'strokeWidth': '3', 'display': 'none',
+        ref: 'rect', width: 15, height: 15, 'data-test': 'nodeDocCircle' },
       'body': { fill: intermediateColor, stroke: intermediateColorStroke },
       'body2': { cx: 18, cy: 18, r: 15, 'stroke-width': 2, fill: intermediateColor, stroke: intermediateColorStroke },
       'image': { 'ref-x': 5, 'ref-y': 5, ref: 'circle', width: 26, height: 26 },

--- a/src/components/nodes/sequenceFlow/sequenceFlow.vue
+++ b/src/components/nodes/sequenceFlow/sequenceFlow.vue
@@ -23,6 +23,7 @@ import { namePosition } from './sequenceFlowConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import SequenceFlow from '@/components/nodes/genericFlow/SequenceFlow';
+import documentingIcons from '@/mixins/documentingIcons';
 
 export default {
   components: {
@@ -41,7 +42,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, linkConfig],
+  mixins: [highlightConfig, linkConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -147,6 +148,8 @@ export default {
 
     this.shape.addTo(this.graph);
     this.shape.component = this;
+
+    this.initDocumentingIcons({ elementType: 'flow' });
   },
 };
 </script>

--- a/src/mixins/documentingIcons.js
+++ b/src/mixins/documentingIcons.js
@@ -3,6 +3,13 @@ import store from '@/store';
 export default {
   methods: {
     initDocumentingIcons(iconParams) {
+      const elementType = iconParams.elementType ?? '';
+
+      if (elementType === 'flow') {
+        this.initDocumentingIconsForFlow();
+      }
+
+
       const defaultParams = {
         labelX: '100px', // x position of the number inside the circle icon
         labelY: '-4px', // y position of the number inside the circle icon
@@ -40,6 +47,26 @@ export default {
           clearInterval(interval);
         }
       }, 200);
+    },
+
+    initDocumentingIconsForFlow() {
+      const docElement = this.node?.definition?.documentation;
+      const doc = Array.isArray(docElement)
+        ? (docElement[0].text ?? '').trim()
+        : (docElement ?? '').trim();
+
+      if (doc && store.getters.isForDocumenting) {
+        this.shape.attr('line', {
+          sourceMarker: {
+            'type': 'circle',
+            'fill': '#8DC8FF',
+            'r': 10,
+            'cx': 20,
+            'stroke': '#2B9DFF',
+            'stroke-width': 3,
+          },
+        });
+      }
     },
   },
 };

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -64,18 +64,22 @@ export default {
       this.paperManager.addEventHandler('cell:mouseleave', (view) => {
         if (store.getters.isForDocumenting) {
           window.ProcessMaker.EventBus.$emit('hide-documentation');
+
+          if (view?.model?.attributes?.attrs?.doccircle) {
+            view.model.attr({
+              doccircle: {
+                r: 10,
+                stroke: '#2B9DFF',
+                strokeWidth: '3',
+                fill: '#8DC8FF',
+              },
+              doclabel: {
+                display:'none',
+              },
+            });
+          }
+
           this.currentHover = null;
-          view.model.attr({
-            doccircle: {
-              r: 10,
-              stroke: '#2B9DFF',
-              strokeWidth: '3',
-              fill: '#8DC8FF',
-            },
-            doclabel: {
-              display:'none',
-            },
-          });
         }
       });
 
@@ -86,6 +90,7 @@ export default {
           x: evt.clientX - offset.x + window.scrollX,
           y: evt.clientY - offset.y + window.scrollY,
         };
+
 
         const docElement = view?.model?.component?.node?.definition?.documentation;
         const doc = Array.isArray(docElement)
@@ -117,16 +122,18 @@ export default {
               });
           }
 
-          view.model.attr({
-            doccircle: {
-              r: 20,
-              fill: '#1572C2',
-              strokeWidth: 0,
-            },
-            doclabel: {
-              display: 'block',
-            },
-          });
+          if (view?.model?.attributes?.attrs?.doccircle) {
+            view.model.attr({
+              doccircle: {
+                r: 20,
+                fill: '#1572C2',
+                strokeWidth: 0,
+              },
+              doclabel: {
+                display: 'block',
+              },
+            });
+          }
         }
 
         if (view?.model?.isLink() && this.addingEligibleItem()) {

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -85,55 +85,8 @@ export default {
 
       // Handle hovering a new element on the page
       this.paperManager.addEventHandler('cell:mouseover', (view, evt) => {
-        const offset = this.getOffset(this.$refs.paper);
-        const pos = {
-          x: evt.clientX - offset.x + window.scrollX,
-          y: evt.clientY - offset.y + window.scrollY,
-        };
-
-
-        const docElement = view?.model?.component?.node?.definition?.documentation;
-        const doc = Array.isArray(docElement)
-          ? (docElement[0].text ?? '').trim()
-          : (docElement ?? '').trim();
-
-        if (view.cid !== this.currentHover) {
-          this.currentHover = view.cid;
-        }
-
-        if (doc && store.getters.isForDocumenting) {
-          const nodeId = view.model.component.node.id;
-          let nodeNumber = -1;
-          for (let process of view.model.component.$attrs.processes) {
-            nodeNumber = process.flowElements.findIndex(item => item.id === nodeId);
-            if (nodeNumber >=0) {
-              break;
-            }
-          }
-
-          if (nodeNumber >= 0) {
-            window.ProcessMaker.EventBus.$emit(
-              'show-documentation', {
-                number: nodeNumber + 1,
-                text: doc,
-                position: pos,
-                node: view.model.component.node,
-                view,
-              });
-          }
-
-          if (view?.model?.attributes?.attrs?.doccircle) {
-            view.model.attr({
-              doccircle: {
-                r: 20,
-                fill: '#1572C2',
-                strokeWidth: 0,
-              },
-              doclabel: {
-                display: 'block',
-              },
-            });
-          }
+        if (store.getters.isForDocumenting) {
+          this.showDocumentingIcons(view, evt);
         }
 
         if (view?.model?.isLink() && this.addingEligibleItem()) {
@@ -474,6 +427,60 @@ export default {
         document.removeEventListener('mousemove', this.setTooltipPosition);
         document.body.removeChild(this.tooltipEl);
         this.tooltipEl = null;
+      }
+    },
+
+    showDocumentingIcons(view, evt) {
+      const offset = this.getOffset(this.$refs.paper);
+      const pos = {
+        x: evt.clientX - offset.x + window.scrollX,
+        y: evt.clientY - offset.y + window.scrollY,
+      };
+
+
+      const docElement = view?.model?.component?.node?.definition?.documentation;
+      const doc = Array.isArray(docElement)
+        ? (docElement[0].text ?? '').trim()
+        : (docElement ?? '').trim();
+
+      if (view.cid !== this.currentHover) {
+        this.currentHover = view.cid;
+      }
+
+      if (doc) {
+        const nodeId = view.model.component.node.id;
+        let nodeNumber = -1;
+        for (let process of view.model.component.$attrs.processes) {
+          nodeNumber = process.flowElements.findIndex(item => item.id === nodeId);
+          if (nodeNumber >=0) {
+            break;
+          }
+        }
+
+        if (nodeNumber >= 0) {
+          window.ProcessMaker.EventBus.$emit(
+            'show-documentation', {
+              number: nodeNumber + 1,
+              text: doc,
+              position: pos,
+              node: view.model.component.node,
+              view,
+            });
+        }
+
+        // if it is not a link
+        if (view?.path?.segments === undefined) {
+          view.model.attr({
+            doccircle: {
+              r: 20,
+              fill: '#1572C2',
+              strokeWidth: 0,
+            },
+            doclabel: {
+              display: 'block',
+            },
+          });
+        }
       }
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a process
- Add documentation to a flow of the process
-  Go to the "documentation" option

Expected behavior: 
Flows must be able to display its documetation

Actual behavior: 
The flow with the documentation does not have the circle icon to display its documetation


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-17212

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
