### PR TITLE
observation/FOUR-16694: Modeler preview on documenting is now non-editable

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1945,7 +1945,7 @@ export default {
       }, 3000000, { leading: true, trailing: true });
       updateMousePosition();
 
-      if (this.panMode) {
+      if (this.panMode || this.isForDocumenting) {
         return;
       }
 


### PR DESCRIPTION
## Tickets solved by this PR:
- [FOUR-16694](https://processmaker.atlassian.net/browse/FOUR-16694)

## Solution
- Added the variable that indicates that modeler is being used on Documenting (`isForDocumenting`) in checks when panning

## How to Test
Test the steps above

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next


[FOUR-16694]: https://processmaker.atlassian.net/browse/FOUR-16694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ