### PR TITLE
FOUR-17336: Modeler: some times, after the mouse leaves the documentation icon, the number does not disappear

### DIFF
--- a/src/components/documenting/NodeDocumentation.vue
+++ b/src/components/documenting/NodeDocumentation.vue
@@ -84,7 +84,7 @@ export default {
       window.ProcessMaker.EventBus.$emit('show-documentation', this.event);
     },
     mouseLeave() {
-      window.ProcessMaker.EventBus.$emit('hide-documentation');
+      window.ProcessMaker.EventBus.$emit('hide-documentation', this.event);
     },
     getImplementationIcon() {
       switch (this.elementImplementation) {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -605,15 +605,44 @@ export default {
 
             circle.addTo(this.graph);
           }
+
+          if (event.view?.path?.segments === undefined) {
+            event.view.model.attr({
+              doccircle: {
+                r: 20,
+                fill: '#1572C2',
+                strokeWidth: 0,
+              },
+              doclabel: {
+                display: 'block',
+              },
+            });
+          }
+
         }
       });
 
-      window.ProcessMaker.EventBus.$on('hide-documentation', () => {
+      window.ProcessMaker.EventBus.$on('hide-documentation', (event) => {
         if (this.$refs['nodeDocumentation']) {
           this.$refs['nodeDocumentation'].text = '';
           this.$refs['nodeDocumentation'].number = null;
           this.$refs['nodeDocumentation'].isVisible = false;
         }
+
+        if (event.view?.model?.attributes?.attrs?.doccircle) {
+          event.view.model.attr({
+            doccircle: {
+              r: 10,
+              stroke: '#2B9DFF',
+              strokeWidth: '3',
+              fill: '#8DC8FF',
+            },
+            doclabel: {
+              display:'none',
+            },
+          });
+        }
+
 
         const cell = this.graph.getCell('sequenceDocCircle');
         if (cell) {

--- a/src/components/nodes/baseStartEvent/baseStartEvent.vue
+++ b/src/components/nodes/baseStartEvent/baseStartEvent.vue
@@ -18,7 +18,7 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import EventShape from './eventShape';
+import { getEventShape } from './eventShape';
 import hasMarkers from '@/mixins/hasMarkers';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import { startColor, startColorStroke } from '@/components/nodeColors';
@@ -27,6 +27,7 @@ import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from './defaultNames';
 import updateIconColor from '@/mixins/updateIconColor';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 export default {
   components: {
@@ -48,7 +49,7 @@ export default {
   mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag, updateIconColor, documentingIcons],
   data() {
     return {
-      shape: new EventShape(),
+      shape: getEventShape(store.getters.isForDocumenting),
       definition: null,
       dropdownData: [
         {

--- a/src/components/nodes/baseStartEvent/eventShape.js
+++ b/src/components/nodes/baseStartEvent/eventShape.js
@@ -1,10 +1,9 @@
 import { shapes, util } from 'jointjs';
 import { markersMarkup, markersAttrs } from '@/mixins/hasMarkers';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
-export default shapes.standard.Circle.extend({
-
-  markup: [{
+export function getEventShape(forDocumenting = false) {
+  let markup = [{
     tagName: 'circle',
     selector: 'body',
   }, {
@@ -21,22 +20,27 @@ export default shapes.standard.Circle.extend({
   markersMarkup('topRight'),
   markersMarkup('bottomLeft'),
   markersMarkup('bottomCenter'),
-  markersMarkup('bottomRight')],
+  markersMarkup('bottomRight')];
 
-  defaults: util.deepSupplement({
+  markup = docIconAdaptMarkup(markup, forDocumenting);
 
-    size: { width: 36, height: 36 },
-    attrs: {
-      'image': { 'ref-x': 5, 'ref-y': 5, ref: 'circle', width: 26, height: 26 },
-      ...docIconAttrs('doclabel', { 'ref-x': 26, 'ref-y': -4 }),
-      ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
-      ...markersAttrs('topLeft', { ref: 'circle', 'ref-y': -20, 'ref-padding-x': 0 }),
-      ...markersAttrs('topCenter', { ref: 'circle', 'ref-y': -20 }),
-      ...markersAttrs('topRight', { ref: 'circle', 'ref-x': 26, 'ref-y': -20, 'ref-padding-x': 0 }, -1),
-      ...markersAttrs('bottomLeft', { ref: 'circle', 'ref-padding-x': 0, 'ref-padding-y': -40 }),
-      ...markersAttrs('bottomCenter', { ref: 'circle', 'ref-padding-y': -40 }),
-      ...markersAttrs('bottomRight', { ref: 'circle', 'ref-x': 26, 'ref-padding-x': 0, 'ref-padding-y': -40 }, -1),
-    },
+  const EventShape = shapes.standard.Circle.extend({
+    markup,
+    defaults: util.deepSupplement({
+      size: { width: 36, height: 36 },
+      attrs: {
+        'image': { 'ref-x': 5, 'ref-y': 5, ref: 'circle', width: 26, height: 26 },
+        ...docIconAttrs('doclabel', { 'ref-x': 26, 'ref-y': -4 }),
+        ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
+        ...markersAttrs('topLeft', { ref: 'circle', 'ref-y': -20, 'ref-padding-x': 0 }),
+        ...markersAttrs('topCenter', { ref: 'circle', 'ref-y': -20 }),
+        ...markersAttrs('topRight', { ref: 'circle', 'ref-x': 26, 'ref-y': -20, 'ref-padding-x': 0 }, -1),
+        ...markersAttrs('bottomLeft', { ref: 'circle', 'ref-padding-x': 0, 'ref-padding-y': -40 }),
+        ...markersAttrs('bottomCenter', { ref: 'circle', 'ref-padding-y': -40 }),
+        ...markersAttrs('bottomRight', { ref: 'circle', 'ref-x': 26, 'ref-padding-x': 0, 'ref-padding-y': -40 }, -1),
+      },
 
-  }, shapes.standard.Circle.prototype.defaults),
-});
+    }, shapes.standard.Circle.prototype.defaults),
+  });
+  return new EventShape();
+}

--- a/src/components/nodes/baseStartEvent/eventShape.js
+++ b/src/components/nodes/baseStartEvent/eventShape.js
@@ -1,5 +1,6 @@
 import { shapes, util } from 'jointjs';
 import { markersMarkup, markersAttrs } from '@/mixins/hasMarkers';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
 
 export default shapes.standard.Circle.extend({
 
@@ -12,13 +13,9 @@ export default shapes.standard.Circle.extend({
   }, {
     tagName: 'image',
     selector: 'image',
-  }, {
-    tagName: 'circle',
-    selector: 'doccircle',
-  }, {
-    tagName: 'text',
-    selector: 'doclabel',
   },
+  docIconMarkup('doccircle'),
+  docIconMarkup('doclabel'),
   markersMarkup('topLeft'),
   markersMarkup('topCenter'),
   markersMarkup('topRight'),
@@ -31,17 +28,8 @@ export default shapes.standard.Circle.extend({
     size: { width: 36, height: 36 },
     attrs: {
       'image': { 'ref-x': 5, 'ref-y': 5, ref: 'circle', width: 26, height: 26 },
-      'doclabel': {
-        'ref-x': 26,
-        'ref-y': -4, ref: 'circle', fontSize: 20, fontWeight: 'bold',
-        width: 16, height: 16, 'data-test': 'nodeDocLabel', 'text':'',
-        fill: 'white', display: 'none',
-      },
-      'doccircle': {
-        'cx': 30, 'cy': 5, 'r': 10,
-        'label': '7',
-        'fill': '#8DC8FF', 'stroke': '#2B9DFF', 'strokeWidth': '3', 'display': 'none',
-        ref: 'rect', width: 15, height: 15, 'data-test': 'nodeDocCircle' },
+      ...docIconAttrs('doclabel', { 'ref-x': 26, 'ref-y': -4 }),
+      ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
       ...markersAttrs('topLeft', { ref: 'circle', 'ref-y': -20, 'ref-padding-x': 0 }),
       ...markersAttrs('topCenter', { ref: 'circle', 'ref-y': -20 }),
       ...markersAttrs('topRight', { ref: 'circle', 'ref-x': 26, 'ref-y': -20, 'ref-padding-x': 0 }, -1),

--- a/src/components/nodes/dataObject/dataObject.vue
+++ b/src/components/nodes/dataObject/dataObject.vue
@@ -21,8 +21,9 @@ import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import portsConfig from '@/mixins/portsConfig';
-import DataObjectShape from './shape';
+import { getDataObjectShape } from './shape';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 
 export default {
@@ -57,7 +58,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new DataObjectShape();
+    this.shape = getDataObjectShape(store.getters.isForDocumenting);
     this.shape.attr('label/text', this.node.definition.get('name'));
 
     const bounds = this.node.diagram.bounds;

--- a/src/components/nodes/dataObject/dataObject.vue
+++ b/src/components/nodes/dataObject/dataObject.vue
@@ -20,8 +20,10 @@
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
-import { shapes } from 'jointjs';
 import portsConfig from '@/mixins/portsConfig';
+import DataObjectShape from './shape';
+import documentingIcons from '@/mixins/documentingIcons';
+
 
 export default {
   inheritAttrs: false,
@@ -41,7 +43,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, hideLabelOnDrag, portsConfig],
+  mixins: [highlightConfig, hideLabelOnDrag, portsConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -55,23 +57,16 @@ export default {
     },
   },
   mounted() {
-    this.shape = new shapes.standard.Path();
-    this.shape.attr('root/title', 'joint.shapes.standard.Path');
-    this.shape.attr('label', {
-      refY: 65,
-      text: this.node.definition.get('name'),
-      fill: 'black',
-    });
-    this.shape.attr('body', {
-      refD: 'M1,1 L25,1 L35,10 L35,49 L1,49 L1,1 M24,1 L24,10 L35,10',
-    });
+    this.shape = new DataObjectShape();
+    this.shape.attr('label/text', this.node.definition.get('name'));
 
     const bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);
-
     this.shape.addTo(this.graph);
     this.shape.component = this;
+
+    this.initDocumentingIcons({labelX: '39px', labelY: '-4px'});
   },
 };
 </script>

--- a/src/components/nodes/dataObject/shape.js
+++ b/src/components/nodes/dataObject/shape.js
@@ -1,0 +1,18 @@
+import { shapes, util } from 'jointjs';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+
+export default shapes.standard.Path.extend({
+  markup: [
+    ...shapes.standard.Path.prototype.markup,
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
+  ],
+  defaults: util.deepSupplement({
+    attrs: {
+      label: { refY: 65, text: '', fill: 'black' },
+      body: { refD: 'M1,1 L25,1 L35,10 L35,49 L1,49 L1,1 M24,1 L24,10 L35,10' },
+      ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
+      ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
+    },
+  }, shapes.standard.Path.prototype.defaults),
+});

--- a/src/components/nodes/dataObject/shape.js
+++ b/src/components/nodes/dataObject/shape.js
@@ -1,18 +1,26 @@
 import { shapes, util } from 'jointjs';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
-export default shapes.standard.Path.extend({
-  markup: [
+export function getDataObjectShape(forDocumenting = false) {
+  let markup = [
     ...shapes.standard.Path.prototype.markup,
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
-  ],
-  defaults: util.deepSupplement({
-    attrs: {
-      label: { refY: 65, text: '', fill: 'black' },
-      body: { refD: 'M1,1 L25,1 L35,10 L35,49 L1,49 L1,1 M24,1 L24,10 L35,10' },
-      ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
-      ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
-    },
-  }, shapes.standard.Path.prototype.defaults),
-});
+  ];
+
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const DataObjectShape = shapes.standard.Path.extend({
+    markup,
+    defaults: util.deepSupplement({
+      attrs: {
+        label: { refY: 65, text: '', fill: 'black' },
+        body: { refD: 'M1,1 L25,1 L35,10 L35,49 L1,49 L1,1 M24,1 L24,10 L35,10' },
+        ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
+        ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
+      },
+    }, shapes.standard.Path.prototype.defaults),
+  });
+
+  return new DataObjectShape();
+}

--- a/src/components/nodes/dataStore/dataStore.vue
+++ b/src/components/nodes/dataStore/dataStore.vue
@@ -20,9 +20,10 @@
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
-import DataStoreShape from './shape';
+import { getDataStoreShape } from './shape';
 import portsConfig from '@/mixins/portsConfig';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 export default {
   components: {
@@ -55,7 +56,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new DataStoreShape();
+    this.shape = getDataStoreShape(store.getters.isForDocumenting);
     this.shape.attr('label/text', this.node.definition.get('name'));
 
     const bounds = this.node.diagram.bounds;

--- a/src/components/nodes/dataStore/dataStore.vue
+++ b/src/components/nodes/dataStore/dataStore.vue
@@ -22,6 +22,7 @@ import highlightConfig from '@/mixins/highlightConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import DataStoreShape from './shape';
 import portsConfig from '@/mixins/portsConfig';
+import documentingIcons from '@/mixins/documentingIcons';
 
 export default {
   components: {
@@ -40,7 +41,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, hideLabelOnDrag, portsConfig],
+  mixins: [highlightConfig, hideLabelOnDrag, portsConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -62,6 +63,8 @@ export default {
     this.shape.resize(bounds.width, bounds.height);
     this.shape.addTo(this.graph);
     this.shape.component = this;
+
+    this.initDocumentingIcons({labelX: '39px', labelY: '-4px'});
   },
 };
 </script>

--- a/src/components/nodes/dataStore/shape.js
+++ b/src/components/nodes/dataStore/shape.js
@@ -1,4 +1,5 @@
 import { shapes, util } from 'jointjs';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
 
 export default shapes.standard.Cylinder.extend({
   markup: [
@@ -6,6 +7,8 @@ export default shapes.standard.Cylinder.extend({
     { tagName: 'ellipse', selector: 'thirdLine' },
     { tagName: 'ellipse', selector: 'secondLine' },
     { tagName: 'ellipse', selector: 'firstLine' },
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
   ],
   defaults: util.deepSupplement({
     attrs: {
@@ -13,6 +16,8 @@ export default shapes.standard.Cylinder.extend({
       secondLine: { refCx: '50%', refRx: '50%', cy: 15, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
       firstLine: { refCx: '50%', refRx: '50%', cy: 10, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
       label: { refY: 50, fill: '#000' },
+      ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
+      ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
     },
   }, shapes.standard.Cylinder.prototype.defaults),
 });

--- a/src/components/nodes/dataStore/shape.js
+++ b/src/components/nodes/dataStore/shape.js
@@ -1,23 +1,31 @@
 import { shapes, util } from 'jointjs';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
-export default shapes.standard.Cylinder.extend({
-  markup: [
+export function getDataStoreShape(forDocumenting = false) {
+  let markup = [
     ...shapes.standard.Cylinder.prototype.markup,
     { tagName: 'ellipse', selector: 'thirdLine' },
     { tagName: 'ellipse', selector: 'secondLine' },
     { tagName: 'ellipse', selector: 'firstLine' },
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
-  ],
-  defaults: util.deepSupplement({
-    attrs: {
-      thirdLine: { refCx: '50%', refRx: '50%', cy: 20, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
-      secondLine: { refCx: '50%', refRx: '50%', cy: 15, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
-      firstLine: { refCx: '50%', refRx: '50%', cy: 10, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
-      label: { refY: 50, fill: '#000' },
-      ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
-      ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
-    },
-  }, shapes.standard.Cylinder.prototype.defaults),
-});
+  ];
+
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const DataStoreShape =  shapes.standard.Cylinder.extend({
+    markup,
+    defaults: util.deepSupplement({
+      attrs: {
+        thirdLine: { refCx: '50%', refRx: '50%', cy: 20, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
+        secondLine: { refCx: '50%', refRx: '50%', cy: 15, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
+        firstLine: { refCx: '50%', refRx: '50%', cy: 10, refRy: '20%', 'stroke-width': 2, fill: '#fff', stroke: '#000' },
+        label: { refY: 50, fill: '#000' },
+        ...docIconAttrs('doclabel', { 'ref-x': 39, 'ref-y': -4 }),
+        ...docIconAttrs('doccircle', { 'cx': 40, 'cy': 5 }),
+      },
+    }, shapes.standard.Cylinder.prototype.defaults),
+  });
+
+  return new DataStoreShape();
+}

--- a/src/components/nodes/endEvent/endEvent.vue
+++ b/src/components/nodes/endEvent/endEvent.vue
@@ -19,12 +19,13 @@
 <script>
 import portsConfig from '@/mixins/portsConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
-import EventShape from '../baseStartEvent/eventShape';
+import { getEventShape } from '../baseStartEvent/eventShape';
 import { endColor, endColorStroke } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from '@/components/nodes/endEvent/defaultNames';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 
 export default {
@@ -83,7 +84,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new EventShape();
+    this.shape = getEventShape(store.getters.isForDocumenting);
     this.shape.set('type', 'processmaker.components.nodes.endEvent.Shape');
     const bounds = this.node.diagram.bounds;
     this.shape.position(bounds.get('x'), bounds.get('y'));

--- a/src/components/nodes/gateway/gateway.vue
+++ b/src/components/nodes/gateway/gateway.vue
@@ -18,12 +18,13 @@
 
 <script>
 import portsConfig from '@/mixins/portsConfig';
-import GatewayShape from '@/components/nodes/gateway/shape';
+import { getGatewayShape } from '@/components/nodes/gateway/shape';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import defaultNames from '@/components/nodes/gateway/defaultNames';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 
 const hasDefaultFlow = [
@@ -98,7 +99,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new GatewayShape();
+    this.shape = getGatewayShape(store.getters.isForDocumenting);
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);

--- a/src/components/nodes/gateway/shape.js
+++ b/src/components/nodes/gateway/shape.js
@@ -1,4 +1,5 @@
 import { dia, shapes } from 'jointjs';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
 
 const iconSize = 18;
 
@@ -6,8 +7,8 @@ export default dia.Element.define('processmaker.components.nodes.gateway.Shape',
   markup: [
     ...shapes.standard.Polygon.prototype.markup,
     { tagName: 'image', selector: 'image' },
-    { tagName: 'circle', selector: 'doccircle'},
-    { tagName: 'text', selector: 'doclabel' },
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
   ],
   attrs: {
     body: {
@@ -34,16 +35,7 @@ export default dia.Element.define('processmaker.components.nodes.gateway.Shape',
       refY: '50%',
       refY2: -(iconSize / 2),
     },
-    'doclabel': {
-      'ref-x': 8,
-      'ref-y': 10, ref: 'circle', fontSize: 20, fontWeight: 'bold',
-      width: 16, height: 16, 'data-test': 'nodeDocLabel', 'text':'',
-      fill: 'white', display: 'none',
-    },
-    'doccircle': {
-      'cx': 30, 'cy': 5, 'r': 10,
-      'label': '7',
-      'fill': '#8DC8FF', 'stroke': '#2B9DFF', 'strokeWidth': '3', 'display': 'none',
-      ref: 'rect', width: 15, height: 15, 'data-test': 'nodeDocCircle' },
+    ...docIconAttrs('doclabel', { 'ref-x': 8, 'ref-y': 10 }),
+    ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
   },
 });

--- a/src/components/nodes/gateway/shape.js
+++ b/src/components/nodes/gateway/shape.js
@@ -1,41 +1,49 @@
 import { dia, shapes } from 'jointjs';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
 const iconSize = 18;
 
-export default dia.Element.define('processmaker.components.nodes.gateway.Shape', {
-  markup: [
+export function getGatewayShape(forDocumenting = false) {
+  let markup = [
     ...shapes.standard.Polygon.prototype.markup,
     { tagName: 'image', selector: 'image' },
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
-  ],
-  attrs: {
-    body: {
-      strokeWidth: 2,
-      stroke: '#000000',
-      refPointsKeepOffset: '40,0, 80,40, 40,80, 0,40',
-      fill: '#FFFFFF',
+  ];
+
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const GatewayShape = dia.Element.define('processmaker.components.nodes.gateway.Shape', {
+    markup,
+    attrs: {
+      body: {
+        strokeWidth: 2,
+        stroke: '#000000',
+        refPointsKeepOffset: '40,0, 80,40, 40,80, 0,40',
+        fill: '#FFFFFF',
+      },
+      label: {
+        textVerticalAnchor: 'top',
+        textAnchor: 'middle',
+        refX: '50%',
+        refY: '50',
+        fontSize: 14,
+        fill: '#333333',
+      },
+      image: {
+        width: iconSize,
+        height: iconSize,
+        fill: 'transparent',
+        xlinkHref: '',
+        refX: '50%',
+        refX2: -(iconSize / 2),
+        refY: '50%',
+        refY2: -(iconSize / 2),
+      },
+      ...docIconAttrs('doclabel', { 'ref-x': 8, 'ref-y': 10 }),
+      ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
     },
-    label: {
-      textVerticalAnchor: 'top',
-      textAnchor: 'middle',
-      refX: '50%',
-      refY: '50',
-      fontSize: 14,
-      fill: '#333333',
-    },
-    image: {
-      width: iconSize,
-      height: iconSize,
-      fill: 'transparent',
-      xlinkHref: '',
-      refX: '50%',
-      refX2: -(iconSize / 2),
-      refY: '50%',
-      refY2: -(iconSize / 2),
-    },
-    ...docIconAttrs('doclabel', { 'ref-x': 8, 'ref-y': 10 }),
-    ...docIconAttrs('doccircle', { 'cx': 30, 'cy': 5 }),
-  },
-});
+  });
+
+  return new GatewayShape();
+}

--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -44,6 +44,8 @@ import AddLaneBelowButton from '@/components/crown/crownButtons/addLaneBelowButt
 import { configurePool, elementShouldHaveFlowNodeRef } from '@/components/nodes/pool/poolUtils';
 import Node from '@/components/nodes/node';
 import { aPortEveryXPixels } from '@/portsUtils';
+import documentingIcons from '@/mixins/documentingIcons';
+
 
 export default {
   components: {
@@ -69,7 +71,7 @@ export default {
     'paperManager',
     'nodeIdGenerator',
   ],
-  mixins: [highlightConfig, resizeConfig, portsConfig],
+  mixins: [highlightConfig, resizeConfig, portsConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -528,6 +530,10 @@ export default {
 
     this.shape = configurePool(this.collaboration, this.node, this.graph);
     this.shape.component = this;
+    this.initDocumentingIcons({labelX: '-10px', labelY: '-4px'});
+
+
+
     /* If there are no other pools, the first pool should capture all current flow elements.
      * Don't do this when parsing an uploaded diagram. */
     if (!this.collaboration) {

--- a/src/components/nodes/pool/poolShape.js
+++ b/src/components/nodes/pool/poolShape.js
@@ -1,8 +1,12 @@
 import { shapes } from 'jointjs';
 import { labelWidth } from '@/components/nodes/pool/poolSizes';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+
 
 const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
   markup: [
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
     ...shapes.standard.Rectangle.prototype.markup,
     { tagName: 'polyline', selector: 'polyline' },
   ],
@@ -18,6 +22,8 @@ const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', 
       fill: '#fff',
       strokeWidth: 2,
     },
+    ...docIconAttrs('doclabel', { 'x': -10, 'ref-y': -4 }),
+    ...docIconAttrs('doccircle', { 'cx': -18, 'cy': 5 }),
   },
 });
 

--- a/src/components/nodes/pool/poolShape.js
+++ b/src/components/nodes/pool/poolShape.js
@@ -1,30 +1,36 @@
 import { shapes } from 'jointjs';
 import { labelWidth } from '@/components/nodes/pool/poolSizes';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
 
-const Pool = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
-  markup: [
+export function getPoolShape(forDocumenting = false) {
+  let markup = [
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
     ...shapes.standard.Rectangle.prototype.markup,
     { tagName: 'polyline', selector: 'polyline' },
-  ],
-  attrs: {
-    label: {
-      fill: 'black',
-      transform: 'rotate(-90)',
-      refX: labelWidth / 2,
-    },
-    polyline: {
-      refPointsKeepOffset: `${labelWidth},0 ${labelWidth},200`,
-      stroke: '#000',
-      fill: '#fff',
-      strokeWidth: 2,
-    },
-    ...docIconAttrs('doclabel', { 'x': -10, 'ref-y': -4 }),
-    ...docIconAttrs('doccircle', { 'cx': -18, 'cy': 5 }),
-  },
-});
+  ];
 
-export default Pool;
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const PoolShape = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.pool', {
+    markup,
+    attrs: {
+      label: {
+        fill: 'black',
+        transform: 'rotate(-90)',
+        refX: labelWidth / 2,
+      },
+      polyline: {
+        refPointsKeepOffset: `${labelWidth},0 ${labelWidth},200`,
+        stroke: '#000',
+        fill: '#fff',
+        strokeWidth: 2,
+      },
+      ...docIconAttrs('doclabel', { 'x': -10, 'ref-y': -4 }),
+      ...docIconAttrs('doccircle', { 'cx': -18, 'cy': 5 }),
+    },
+  });
+
+  return new PoolShape();
+}

--- a/src/components/nodes/pool/poolUtils.js
+++ b/src/components/nodes/pool/poolUtils.js
@@ -1,14 +1,15 @@
 import { util } from 'jointjs';
 import { poolColor } from '@/components/nodeColors';
 import { labelWidth, poolPadding } from '@/components/nodes/pool/poolSizes';
-import PoolShape from '@/components/nodes/pool/poolShape';
+import { getPoolShape } from '@/components/nodes/pool/poolShape';
 import { id as laneId } from '@/components/nodes/poolLane/config';
 import { id as textAnnotationId } from '@/components/nodes/textAnnotation';
 import { id as dataObjectId } from '@/components/nodes/dataObject';
 import { id as dataStoreId } from '@/components/nodes/dataStore';
+import store from '@/store';
 
 function createPool(node, graph) {
-  const pool = new PoolShape();
+  const pool = getPoolShape(store.getters.isForDocumenting);
   const bounds = node.diagram.bounds;
   pool.position(bounds.x, bounds.y);
   pool.resize(bounds.width, bounds.height);

--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -16,13 +16,16 @@
 </template>
 
 <script>
-import { shapes, util } from 'jointjs';
+import { util } from 'jointjs';
 import resizeConfig from '@/mixins/resizeConfig';
 import { labelWidth } from '../pool/poolSizes';
 import pull from 'lodash/pull';
 import { poolColor } from '@/components/nodeColors';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import { getPoolLine } from './poolLaneShape';
+import documentingIcons from '@/mixins/documentingIcons';
+
 
 export default {
   components: {
@@ -42,7 +45,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, resizeConfig],
+  mixins: [highlightConfig, resizeConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -55,9 +58,9 @@ export default {
     },
   },
   mounted() {
-    this.shape = new shapes.standard.Rectangle();
-    this.shape.set('type', 'PoolLane');
     const bounds = this.node.diagram.bounds;
+
+    this.shape = getPoolLine(bounds);
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);
 
@@ -75,6 +78,9 @@ export default {
 
     this.shape.component = this;
     this.shape.addTo(this.graph);
+
+    this.initDocumentingIcons({labelX: '995px', labelY: '-4px'});
+
 
     if (!this.planeElements.includes(this.node.diagram)) {
       this.planeElements.push(this.node.diagram);

--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -25,6 +25,7 @@ import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
 import { getPoolLine } from './poolLaneShape';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 
 export default {
@@ -60,7 +61,7 @@ export default {
   mounted() {
     const bounds = this.node.diagram.bounds;
 
-    this.shape = getPoolLine(bounds);
+    this.shape = getPoolLine(bounds, store.getters.isForDocumenting);
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);
 

--- a/src/components/nodes/poolLane/poolLaneShape.js
+++ b/src/components/nodes/poolLane/poolLaneShape.js
@@ -1,0 +1,20 @@
+import { shapes } from 'jointjs';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+
+
+//export default PoolLane;
+export function getPoolLine(bounds) {
+  const PoolLaneClass = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.poolLane', {
+    markup: [
+      docIconMarkup('doccircle'),
+      docIconMarkup('doclabel'),
+      ...shapes.standard.Rectangle.prototype.markup,
+    ],
+    attrs: {
+      ...docIconAttrs('doclabel', { 'x': -108, 'ref-y': 5 }),
+      ...docIconAttrs('doccircle', { 'cx': bounds.width  + 22, 'cy': 5 }),
+    },
+  });
+
+  return new PoolLaneClass();
+}

--- a/src/components/nodes/poolLane/poolLaneShape.js
+++ b/src/components/nodes/poolLane/poolLaneShape.js
@@ -1,8 +1,6 @@
 import { shapes } from 'jointjs';
 import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
-
-//export default PoolLane;
 export function getPoolLine(bounds, forDocumenting = false) {
   let markup = [
     docIconMarkup('doccircle'),

--- a/src/components/nodes/poolLane/poolLaneShape.js
+++ b/src/components/nodes/poolLane/poolLaneShape.js
@@ -1,15 +1,19 @@
 import { shapes } from 'jointjs';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
 
 
 //export default PoolLane;
-export function getPoolLine(bounds) {
+export function getPoolLine(bounds, forDocumenting = false) {
+  let markup = [
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
+    ...shapes.standard.Rectangle.prototype.markup,
+  ];
+
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
   const PoolLaneClass = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.poolLane', {
-    markup: [
-      docIconMarkup('doccircle'),
-      docIconMarkup('doclabel'),
-      ...shapes.standard.Rectangle.prototype.markup,
-    ],
+    markup,
     attrs: {
       ...docIconAttrs('doclabel', { 'x': -108, 'ref-y': 5 }),
       ...docIconAttrs('doccircle', { 'cx': bounds.width  + 22, 'cy': 5 }),

--- a/src/components/nodes/poolLane/poolLaneShape.js
+++ b/src/components/nodes/poolLane/poolLaneShape.js
@@ -20,5 +20,10 @@ export function getPoolLine(bounds, forDocumenting = false) {
     },
   });
 
-  return new PoolLaneClass();
+  const result = new PoolLaneClass();
+
+  // The original type name used in the app is 'PoolLane'
+  result.set('type', 'PoolLane');
+
+  return result;
 }

--- a/src/components/nodes/subProcess/subProcess.vue
+++ b/src/components/nodes/subProcess/subProcess.vue
@@ -58,6 +58,7 @@ import updateIconColor from '@/mixins/updateIconColor';
 import customIcon from '@/mixins/customIcon';
 import { getRectangleAnchorPoint } from '@/portsUtils';
 import setupLoopCharacteristicsMarkers from '@/components/nodes/task/setupMultiInstanceMarkers';
+import documentingIcons from '@/mixins/documentingIcons';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -84,7 +85,7 @@ export default {
     'isRendering',
     'paperManager',
   ],
-  mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag, updateIconColor, customIcon],
+  mixins: [highlightConfig, portsConfig, hasMarkers, hideLabelOnDrag, updateIconColor, customIcon, documentingIcons],
   data() {
     return {
       subProcessSvg: null,
@@ -219,6 +220,8 @@ export default {
     if (this.node.definition.get('customIcon')) {
       this.setCustomIcon(this.node.definition.get('customIcon'));
     }
+
+    this.initDocumentingIcons({labelX: '100px', labelY: '-4px'});
   },
 };
 </script>

--- a/src/components/nodes/task/shape.js
+++ b/src/components/nodes/task/shape.js
@@ -1,9 +1,44 @@
 import { shapes, util } from 'jointjs';
 import { markersMarkup, markersAttrs } from '@/mixins/hasMarkers';
-import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup} from '@/mixins/documentingIcons';
+
 
 export default shapes.standard.Rectangle.extend({
   markup: [{
+    tagName: 'rect',
+    selector: 'body',
+  }, {
+    tagName: 'text',
+    selector: 'label',
+  }, {
+    tagName: 'image',
+    selector: 'image',
+  },
+  markersMarkup('topLeft'),
+  markersMarkup('topCenter'),
+  markersMarkup('topRight'),
+  markersMarkup('bottomLeft'),
+  markersMarkup('bottomCenter'),
+  markersMarkup('bottomRight'),
+  ],
+
+  defaults: util.deepSupplement({
+    type: 'processmaker.components.nodes.task.Shape',
+    size: { width: 100, height: 60 },
+    attrs: {
+      'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16, 'data-test': 'nodeIcon' },
+      ...markersAttrs('topLeft', { 'ref-y': 4, ref: 'rect' }),
+      ...markersAttrs('topCenter', { 'ref-y': 4, ref: 'rect' }),
+      ...markersAttrs('topRight', { 'ref-y': 4, 'ref-x': 96, ref: 'rect' }, -1),
+      ...markersAttrs('bottomLeft', { ref: 'rect' }),
+      ...markersAttrs('bottomCenter', { ref: 'rect' }),
+      ...markersAttrs('bottomRight', { 'ref-x': 96, ref: 'rect' }, -1),
+    },
+  }, shapes.standard.Rectangle.prototype.defaults),
+});
+
+export function getTaskShape(forDocumenting = false) {
+  let markup = [{
     tagName: 'rect',
     selector: 'body',
   }, {
@@ -21,21 +56,28 @@ export default shapes.standard.Rectangle.extend({
   markersMarkup('bottomLeft'),
   markersMarkup('bottomCenter'),
   markersMarkup('bottomRight'),
-  ],
+  ];
 
-  defaults: util.deepSupplement({
-    type: 'processmaker.components.nodes.task.Shape',
-    size: { width: 100, height: 60 },
-    attrs: {
-      'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16, 'data-test': 'nodeIcon' },
-      ...docIconAttrs('doclabel', { 'ref-x': 95, 'ref-y': -4 }),
-      ...docIconAttrs('doccircle', { 'cx': 100, 'cy': 5 }),
-      ...markersAttrs('topLeft', { 'ref-y': 4, ref: 'rect' }),
-      ...markersAttrs('topCenter', { 'ref-y': 4, ref: 'rect' }),
-      ...markersAttrs('topRight', { 'ref-y': 4, 'ref-x': 96, ref: 'rect' }, -1),
-      ...markersAttrs('bottomLeft', { ref: 'rect' }),
-      ...markersAttrs('bottomCenter', { ref: 'rect' }),
-      ...markersAttrs('bottomRight', { 'ref-x': 96, ref: 'rect' }, -1),
-    },
-  }, shapes.standard.Rectangle.prototype.defaults),
-});
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const TaskShapeClass = shapes.standard.Rectangle.extend({
+    markup,
+    defaults: util.deepSupplement({
+      type: 'processmaker.components.nodes.task.Shape',
+      size: { width: 100, height: 60 },
+      attrs: {
+        'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16, 'data-test': 'nodeIcon' },
+        ...docIconAttrs('doclabel', { 'ref-x': 95, 'ref-y': -4 }),
+        ...docIconAttrs('doccircle', { 'cx': 100, 'cy': 5 }),
+        ...markersAttrs('topLeft', { 'ref-y': 4, ref: 'rect' }),
+        ...markersAttrs('topCenter', { 'ref-y': 4, ref: 'rect' }),
+        ...markersAttrs('topRight', { 'ref-y': 4, 'ref-x': 96, ref: 'rect' }, -1),
+        ...markersAttrs('bottomLeft', { ref: 'rect' }),
+        ...markersAttrs('bottomCenter', { ref: 'rect' }),
+        ...markersAttrs('bottomRight', { 'ref-x': 96, ref: 'rect' }, -1),
+      },
+    }, shapes.standard.Rectangle.prototype.defaults),
+  });
+
+  return new TaskShapeClass();
+}

--- a/src/components/nodes/task/shape.js
+++ b/src/components/nodes/task/shape.js
@@ -1,5 +1,6 @@
 import { shapes, util } from 'jointjs';
 import { markersMarkup, markersAttrs } from '@/mixins/hasMarkers';
+import { docIconMarkup, docIconAttrs } from '@/mixins/documentingIcons';
 
 export default shapes.standard.Rectangle.extend({
   markup: [{
@@ -11,13 +12,9 @@ export default shapes.standard.Rectangle.extend({
   }, {
     tagName: 'image',
     selector: 'image',
-  }, {
-    tagName: 'circle',
-    selector: 'doccircle',
-  }, {
-    tagName: 'text',
-    selector: 'doclabel',
   },
+  docIconMarkup('doccircle'),
+  docIconMarkup('doclabel'),
   markersMarkup('topLeft'),
   markersMarkup('topCenter'),
   markersMarkup('topRight'),
@@ -31,17 +28,8 @@ export default shapes.standard.Rectangle.extend({
     size: { width: 100, height: 60 },
     attrs: {
       'image': { 'ref-x': 4, 'ref-y': 4, ref: 'rect', width: 16, height: 16, 'data-test': 'nodeIcon' },
-      'doclabel': {
-        'ref-x': 95,
-        'ref-y': -4, ref: 'rect', fontSize: 20, fontWeight: 'bold',
-        width: 16, height: 16, 'data-test': 'nodeDocLabel', 'text':'',
-        fill: 'white', display: 'none',
-      },
-      'doccircle': {
-        'cx': 100, 'cy': 5, 'r': 10,
-        'label': '7',
-        'fill': '#8DC8FF', 'stroke': '#2B9DFF', 'strokeWidth': '3', 'display': 'none',
-        ref: 'rect', width: 15, height: 15, 'data-test': 'nodeDocCircle' },
+      ...docIconAttrs('doclabel', { 'ref-x': 95, 'ref-y': -4 }),
+      ...docIconAttrs('doccircle', { 'cx': 100, 'cy': 5 }),
       ...markersAttrs('topLeft', { 'ref-y': 4, ref: 'rect' }),
       ...markersAttrs('topCenter', { 'ref-y': 4, ref: 'rect' }),
       ...markersAttrs('topRight', { 'ref-y': 4, 'ref-x': 96, ref: 'rect' }, -1),
@@ -49,6 +37,5 @@ export default shapes.standard.Rectangle.extend({
       ...markersAttrs('bottomCenter', { ref: 'rect' }),
       ...markersAttrs('bottomRight', { 'ref-x': 96, ref: 'rect' }, -1),
     },
-
   }, shapes.standard.Rectangle.prototype.defaults),
 });

--- a/src/components/nodes/task/task.vue
+++ b/src/components/nodes/task/task.vue
@@ -28,7 +28,7 @@ import { util } from 'jointjs';
 import highlightConfig from '@/mixins/highlightConfig';
 import portsConfig from '@/mixins/portsConfig';
 import hasMarkers, { markerSize } from '@/mixins/hasMarkers';
-import TaskShape from '@/components/nodes/task/shape';
+import { getTaskShape } from '@/components/nodes/task/shape';
 import { taskHeight } from './taskConfig';
 import hideLabelOnDrag from '@/mixins/hideLabelOnDrag';
 import customIcon from '@/mixins/customIcon';
@@ -40,6 +40,7 @@ import setupLoopCharacteristicsMarkers from '@/components/nodes/task/setupMultiI
 import setupCompensationMarker from '@/components/nodes/task/setupCompensationMarker';
 import { getRectangleAnchorPoint } from '@/portsUtils';
 import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 const labelPadding = 15;
 const topAndBottomMarkersSpace = 2 * markerSize;
@@ -148,7 +149,7 @@ export default {
     },
   },
   mounted() {
-    this.shape = new TaskShape();
+    this.shape = getTaskShape(store.getters.isForDocumenting);
     let bounds = this.node.diagram.bounds;
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(bounds.width, bounds.height);

--- a/src/mixins/documentingIcons.js
+++ b/src/mixins/documentingIcons.js
@@ -64,16 +64,6 @@ export default {
         : (docElement ?? '').trim();
 
       const view = this.paper.findViewByModel(this.shape);
-      view.model.attr({
-        doccircle: {
-          display:'none',
-        },
-        doclabel: {
-          display: 'none',
-          style: `text-anchor: middle; transform: translate(${params.labelX}, ${params.labelY});`,
-          text: null,
-        },
-      });
 
       const interval = window.setInterval(() => {
         if (view.$('circle').length > 0 && store.getters.isForDocumenting) {
@@ -83,6 +73,8 @@ export default {
             },
             doclabel: {
               display: 'none',
+              style: `text-anchor: middle; transform: translate(${params.labelX}, ${params.labelY});`,
+              text: null,
             },
           });
           clearInterval(interval);

--- a/src/mixins/documentingIcons.js
+++ b/src/mixins/documentingIcons.js
@@ -1,5 +1,47 @@
 import store from '@/store';
 
+export function docIconMarkup(selector) {
+  const markups = [
+    {
+      tagName: 'circle',
+      selector: 'doccircle',
+    }, {
+      tagName: 'text',
+      selector: 'doclabel',
+    },
+  ];
+
+  return markups.find(item => item.selector === selector);
+}
+
+export function docIconAttrs(selector, customValues) {
+  const attrs = [
+    {
+      selector: 'doclabel',
+      attributes: {
+        'ref-x': 26, 'ref-y': -4, ref: 'circle', fontSize: 20, fontWeight: 'bold',
+        width: 16, height: 16, 'data-test': 'nodeDocLabel', 'text':'',
+        fill: 'white', display: 'none',
+      },
+    },
+    {
+      selector: 'doccircle',
+      attributes: {
+        'cx': 30, 'cy': 5, 'r': 10,
+        'label': '7',
+        'fill': '#8DC8FF', 'stroke': '#2B9DFF', 'strokeWidth': '3', 'display': 'none',
+        ref: 'rect', width: 15, height: 15, 'data-test': 'nodeDocCircle',
+      },
+    },
+  ];
+
+  const selectorAttributes = attrs.find(item => item.selector === selector).attributes;
+
+  let result = {};
+  result[selector]  = {...selectorAttributes, ...customValues};
+  return result;
+}
+
 export default {
   methods: {
     initDocumentingIcons(iconParams) {
@@ -8,7 +50,6 @@ export default {
       if (elementType === 'flow') {
         this.initDocumentingIconsForFlow();
       }
-
 
       const defaultParams = {
         labelX: '100px', // x position of the number inside the circle icon

--- a/src/mixins/documentingIcons.js
+++ b/src/mixins/documentingIcons.js
@@ -1,5 +1,14 @@
 import store from '@/store';
 
+export function docIconAdaptMarkup(markup, forDocumenting) {
+  // Remove the icon tags from markup if modeler is in designer mode
+  if (!forDocumenting) {
+    return markup.filter(item => !['doccircle', 'doclabel'].includes(item.selector));
+  }
+
+  return markup;
+}
+
 export function docIconMarkup(selector) {
   const markups = [
     {
@@ -45,6 +54,9 @@ export function docIconAttrs(selector, customValues) {
 export default {
   methods: {
     initDocumentingIcons(iconParams) {
+      if (!(store.getters.isForDocumenting ?? false)) {
+        return;
+      }
       const elementType = iconParams.elementType ?? '';
 
       if (elementType === 'flow') {
@@ -83,6 +95,10 @@ export default {
     },
 
     initDocumentingIconsForFlow() {
+
+      if (!(store.getters.isForDocumenting ?? false)) {
+        return;
+      }
       const docElement = this.node?.definition?.documentation;
       const doc = Array.isArray(docElement)
         ? (docElement[0].text ?? '').trim()

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -459,20 +459,6 @@ export default {
               view,
             });
         }
-
-        // if it is not a link
-        // if (view?.path?.segments === undefined) {
-        //   view.model.attr({
-        //     doccircle: {
-        //       r: 20,
-        //       fill: '#1572C2',
-        //       strokeWidth: 0,
-        //     },
-        //     doclabel: {
-        //       display: 'block',
-        //     },
-        //   });
-        // }
       }
     },
   },

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -63,23 +63,7 @@ export default {
     linkEditingInit() {
       this.paperManager.addEventHandler('cell:mouseleave', (view) => {
         if (store.getters.isForDocumenting) {
-          window.ProcessMaker.EventBus.$emit('hide-documentation');
-
-          if (view?.model?.attributes?.attrs?.doccircle) {
-            view.model.attr({
-              doccircle: {
-                r: 10,
-                stroke: '#2B9DFF',
-                strokeWidth: '3',
-                fill: '#8DC8FF',
-              },
-              doclabel: {
-                display:'none',
-              },
-            });
-          }
-
-          this.currentHover = null;
+          this.hideDocumentingIcons(view);
         }
       });
 
@@ -95,6 +79,7 @@ export default {
           }, 1000);
         }
       });
+
       this.paperManager.addEventHandler('cell:mouseout', () => {
         clearTimeout(this.timeout);
         this.timeout = null;
@@ -430,22 +415,29 @@ export default {
       }
     },
 
+    hideDocumentingIcons(view) {
+      if (view?.model?.isLink()) {
+        return;
+      }
+      window.ProcessMaker.EventBus.$emit('hide-documentation', { view });
+      this.currentHover = null;
+    },
+
     showDocumentingIcons(view, evt) {
+      const docElement = view?.model?.component?.node?.definition?.documentation;
+      if (docElement === undefined) {
+        return;
+
+      }
+      const doc = Array.isArray(docElement)
+        ? (docElement[0].text ?? '').trim()
+        : (docElement ?? '').trim();
+
       const offset = this.getOffset(this.$refs.paper);
       const pos = {
         x: evt.clientX - offset.x + window.scrollX,
         y: evt.clientY - offset.y + window.scrollY,
       };
-
-
-      const docElement = view?.model?.component?.node?.definition?.documentation;
-      const doc = Array.isArray(docElement)
-        ? (docElement[0].text ?? '').trim()
-        : (docElement ?? '').trim();
-
-      if (view.cid !== this.currentHover) {
-        this.currentHover = view.cid;
-      }
 
       if (doc) {
         const nodeId = view.model.component.node.id;
@@ -469,18 +461,18 @@ export default {
         }
 
         // if it is not a link
-        if (view?.path?.segments === undefined) {
-          view.model.attr({
-            doccircle: {
-              r: 20,
-              fill: '#1572C2',
-              strokeWidth: 0,
-            },
-            doclabel: {
-              display: 'block',
-            },
-          });
-        }
+        // if (view?.path?.segments === undefined) {
+        //   view.model.attr({
+        //     doccircle: {
+        //       r: 20,
+        //       fill: '#1572C2',
+        //       strokeWidth: 0,
+        //     },
+        //     doclabel: {
+        //       display: 'block',
+        //     },
+        //   });
+        // }
       }
     },
   },

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -447,8 +447,8 @@ export default {
         const circlePosX = view.model.attributes.attrs.doccircle.cx + view.model.component.shape.attributes.position.x;
         const circlePosY = view.model.attributes.attrs.doccircle.cy + view.model.component.shape.attributes.position.y;
         const distance = Math.sqrt((
-          cursorClientCoords.x - circlePosX) ^2 + (cursorClientCoords.y - circlePosY)^2);
-        if (distance > 7) {
+          cursorClientCoords.x - circlePosX) ** 2 + (cursorClientCoords.y - circlePosY) ** 2);
+        if (distance > 20) {
           return;
         }
       }


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a process with at least a task
- Add documentation to the task
- Go to the documentation.
- Move the cursor over the task, and try to overlap the documentation card with the cursor pointer. 
- Move the cursor over the documentation card (it works better if the movement is fast)
- Move the cursor to any other element.

Actual behavior: 
The number associated with the documentation is left visible
![image](https://github.com/user-attachments/assets/84308a13-a1af-4978-8a5f-3c159f6f66e7)


Expected behavior: 
Once the mouse cursor moves away of the element the number should not be visible in the little circle


## Solution
- Added code to hide the number when the cursor leaves the element
- Refactor to improve code readability

## How to Test
Test the steps above

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-17336

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next