### PR TITLE
Bugfix/FOUR-17713: 39852 Immatics Corrupted Process

### DIFF
--- a/src/components/inspectors/process.js
+++ b/src/components/inspectors/process.js
@@ -1,5 +1,10 @@
 import idConfigSettings from './idConfigSettings';
 
+const extendedIdConfigSettings = {
+  ...idConfigSettings,
+  validateKeyStrokes: '^[_A-Za-z][-._A-Za-z0-9]*$ ',
+};
+
 const process = {
   id: 'processmaker-modeler-process',
   bpmnType: 'bpmn:Process',
@@ -21,7 +26,7 @@ const process = {
           items: [
             {
               component: 'FormInput',
-              config: idConfigSettings,
+              config: extendedIdConfigSettings,
             },
             {
               component: 'FormInput',


### PR DESCRIPTION
## Issue & Reproduction Steps
Please refer to https://processmaker.atlassian.net/browse/FOUR-17713

## Solution
- For every key stoke, if passed validateKeyStrokes regexp, it will validate the pressed keys are allowed.

## Related Tickets & Packages
- [FOUR-17713](https://processmaker.atlassian.net/browse/FOUR-17713)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:vue-form-elements:bugfix/FOUR-17713

[FOUR-17713]: https://processmaker.atlassian.net/browse/FOUR-17713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ