### PR TITLE
FOUR-18157: Text Annotations do not have the documentation circle icon

### DIFF
--- a/src/components/nodes/textAnnotation/textAnnotation.vue
+++ b/src/components/nodes/textAnnotation/textAnnotation.vue
@@ -16,10 +16,13 @@
 </template>
 
 <script>
-import { shapes, util } from 'jointjs';
+import { util } from 'jointjs';
 import portsConfig from '@/mixins/portsConfig';
 import CrownConfig from '@/components/crown/crownConfig/crownConfig';
 import highlightConfig from '@/mixins/highlightConfig';
+import { getTextAnnotationShape } from './textAnnotationShape';
+import documentingIcons from '@/mixins/documentingIcons';
+import store from '@/store';
 
 export const maxTextAnnotationWidth = 160;
 export default {
@@ -40,7 +43,7 @@ export default {
     'planeElements',
     'isRendering',
   ],
-  mixins: [highlightConfig, portsConfig],
+  mixins: [highlightConfig, portsConfig, documentingIcons],
   data() {
     return {
       shape: null,
@@ -100,8 +103,7 @@ export default {
   mounted() {
     const bounds = this.node.diagram.bounds;
 
-    this.shape = new shapes.standard.Polyline();
-    this.shape.set('type', 'textAnnotation');
+    this.shape = getTextAnnotationShape(store.getters.isForDocumenting);
     this.shape.position(bounds.x, bounds.y);
     this.shape.resize(this.nodeWidth, bounds.height);
     this.shape.attr({
@@ -121,6 +123,7 @@ export default {
     this.shape.addTo(this.graph);
     this.shape.component = this;
     this.updateNodeText(this.node.definition.get('text'));
+    this.initDocumentingIcons({ labelX: '-6px', labelY: '-17px' });
   },
 };
 </script>

--- a/src/components/nodes/textAnnotation/textAnnotationShape.js
+++ b/src/components/nodes/textAnnotation/textAnnotationShape.js
@@ -1,0 +1,29 @@
+import { shapes, util } from 'jointjs';
+import { docIconMarkup, docIconAttrs, docIconAdaptMarkup } from '@/mixins/documentingIcons';
+
+export function getTextAnnotationShape(forDocumenting = false) {
+  let markup = [
+    docIconMarkup('doccircle'),
+    docIconMarkup('doclabel'),
+    ...shapes.standard.Polyline.prototype.markup,
+  ];
+
+  markup = docIconAdaptMarkup(markup, forDocumenting);
+
+  const textAnnotationShape =  shapes.standard.Polyline.extend({
+    markup,
+    defaults: util.deepSupplement({
+      attrs: {
+        markup,
+        ...docIconAttrs('doclabel', { 'ref-x': 0, 'ref-y': -4 }),
+        ...docIconAttrs('doccircle', { 'cx': -8, 'cy': -8 }),
+      },
+    }, shapes.standard.Polyline.prototype.defaults),
+  });
+
+  const result = new textAnnotationShape();
+
+  result.set('type', 'textAnnotation');
+
+  return result;
+}


### PR DESCRIPTION
## Issue & Reproduction Steps
Steps to reproduced:

1.Create a process
2.Add one or more Text Annotation elements
3.Document the Text Annotations
Current Behavior:

The circle icon that is used to mark elements with documentation is not displayed

Expected Behavior:

Text Annotations elements with documentation should display the documentation circle icon

## Solution
- Added documentation circle to the text annotation shapes
![image](https://github.com/user-attachments/assets/e37c2a05-1c5f-423b-aea6-c7b00c582fd7)


## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18157

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
