### PR TITLE
FOUR-18161: Pool and lane do not show documentation in doc-circle

### DIFF
--- a/src/components/nodes/pool/pool.vue
+++ b/src/components/nodes/pool/pool.vue
@@ -530,7 +530,7 @@ export default {
 
     this.shape = configurePool(this.collaboration, this.node, this.graph);
     this.shape.component = this;
-    this.initDocumentingIcons({ labelX: '-10px', labelY: '-4px' });
+    this.initDocumentingIcons({ labelX: '-15px', labelY: '2px' });
 
 
 

--- a/src/components/nodes/pool/poolShape.js
+++ b/src/components/nodes/pool/poolShape.js
@@ -5,9 +5,9 @@ import { docIconMarkup, docIconAttrs, docIconAdaptMarkup } from '@/mixins/docume
 
 export function getPoolShape(forDocumenting = false) {
   let markup = [
+    ...shapes.standard.Rectangle.prototype.markup,
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
-    ...shapes.standard.Rectangle.prototype.markup,
     { tagName: 'polyline', selector: 'polyline' },
   ];
 
@@ -27,8 +27,8 @@ export function getPoolShape(forDocumenting = false) {
         fill: '#fff',
         strokeWidth: 2,
       },
-      ...docIconAttrs('doclabel', { 'x': -10, 'ref-y': -4 }),
-      ...docIconAttrs('doccircle', { 'cx': -18, 'cy': 5 }),
+      ...docIconAttrs('doclabel', { 'x': 28, 'ref-y': 0 }),
+      ...docIconAttrs('doccircle', { 'cx': 12, 'cy': 12 }),
     },
   });
 

--- a/src/components/nodes/poolLane/poolLane.vue
+++ b/src/components/nodes/poolLane/poolLane.vue
@@ -80,7 +80,7 @@ export default {
     this.shape.component = this;
     this.shape.addTo(this.graph);
 
-    this.initDocumentingIcons({ labelX: '995px', labelY: '-4px' });
+    this.initDocumentingIcons({ labelX: `${bounds.width + 7}px`, labelY: '-4px' });
 
 
     if (!this.planeElements.includes(this.node.diagram)) {

--- a/src/components/nodes/poolLane/poolLaneShape.js
+++ b/src/components/nodes/poolLane/poolLaneShape.js
@@ -3,9 +3,9 @@ import { docIconMarkup, docIconAttrs, docIconAdaptMarkup } from '@/mixins/docume
 
 export function getPoolLine(bounds, forDocumenting = false) {
   let markup = [
+    ...shapes.standard.Rectangle.prototype.markup,
     docIconMarkup('doccircle'),
     docIconMarkup('doclabel'),
-    ...shapes.standard.Rectangle.prototype.markup,
   ];
 
   markup = docIconAdaptMarkup(markup, forDocumenting);
@@ -13,8 +13,8 @@ export function getPoolLine(bounds, forDocumenting = false) {
   const PoolLaneClass = shapes.standard.Rectangle.define('processmaker.modeler.bpmn.poolLane', {
     markup,
     attrs: {
-      ...docIconAttrs('doclabel', { 'x': -108, 'ref-y': 5 }),
-      ...docIconAttrs('doccircle', { 'cx': bounds.width  + 22, 'cy': 5 }),
+      ...docIconAttrs('doclabel', { 'x': -20, 'y':22 }),
+      ...docIconAttrs('doccircle', { 'cx': bounds.width  - 12, 'cy': 12 }),
     },
   });
 

--- a/src/mixins/linkEditing.js
+++ b/src/mixins/linkEditing.js
@@ -443,7 +443,7 @@ export default {
       if (['processmaker-modeler-pool', 'processmaker-modeler-lane']
         .some(item => item === view.model.component.$options.propsData.node.type)
       ) {
-        const cursorClientCoords = this.paper.clientToLocalPoint(pos.x, pos.y);
+        const cursorClientCoords = this.paper.clientToLocalPoint(evt.clientX, evt.clientY);
         const circlePosX = view.model.attributes.attrs.doccircle.cx + view.model.component.shape.attributes.position.x;
         const circlePosY = view.model.attributes.attrs.doccircle.cy + view.model.component.shape.attributes.position.y;
         const distance = Math.sqrt((


### PR DESCRIPTION
## Issue & Reproduction Steps
1.Create a process with lanes and pools
2. Document the lanes and pools
3.Go to documentation
4.Generate documentation
5.Move mouse to Pool or line doc-circle

Current Behavior:
Pool and line documentation is not shown in the process.
Actual behavior: 

Expected Behavior:
Doc-circle should show documentation for all objects in the modeler.
![Peek 2024-08-26 17-49](https://github.com/user-attachments/assets/56c5c6d8-6b87-4eec-b2c7-ac1150cc4e48)


## Solution
- Fixed position of doc. circles and coordinates calculation of them .

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-18161

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next