### PR TITLE
Wait for the chunk and app js required to run the tests

### DIFF
--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -32,7 +32,11 @@ Cypress.Commands.add('loadModeler', () => {
     : '/';
 
   cy.viewport(defaultViewportDimensions.width, defaultViewportDimensions.height);
+  cy.intercept('/js/chunk-vendors.js').as('chunkVendorsJs');
+  cy.intercept('/js/app.js').as('appJs');
   cy.visit(url);
+  cy.wait('@chunkVendorsJs', { timeout: 30000 });
+  cy.wait('@appJs', { timeout: 30000 });
   waitToRenderAllShapes();
 });
 


### PR DESCRIPTION
## Issue & Reproduction Steps
Sometimes the app.js did not load, causing the test to fail because the modeler was not rendered before to run the test steps.

## Solution
- Add a wait to load the app.js

