### PR TITLE
FOUR-19781 Improve load in cypress tests

### DIFF
--- a/src/setup/globals.js
+++ b/src/setup/globals.js
@@ -5,7 +5,6 @@ import mockProcesses from './mockProcesses.json';
 import mockDashboards from './mockDashboards.json';
 import mockSignals from './mockSignals.json';
 import mockProcessSvg from './mockProcessSvg';
-import { faker } from '@faker-js/faker';
 
 axios.defaults.baseURL = 'https://bpm4.local.processmaker.com/api/1.0/';
 axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
@@ -62,7 +61,7 @@ window.ProcessMaker = {
   },
   user: {
     id: 'standalone',
-    fullName:  faker.person.fullName(),
+    fullName:  'Joe Doe',
     avatar: null,
   },
 };

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -4,6 +4,22 @@ import { boundaryEventSelector, nodeTypes, taskSelector } from './constants';
 
 const renderTime = 300;
 
+function waitForCanvasOrReload(retries = 10) {
+  cy.document().then((doc) => {
+    if (doc.querySelector('[joint-selector="svg"]')) {
+      // Element exists, proceed with your test
+    } else if (retries > 0) {
+      // Wait 500ms and check again
+      cy.wait(500).then(() => {
+        waitForCanvasOrReload(retries - 1);
+      });
+    } else {
+      // Element did not appear after retries, reload the page
+      cy.reload();
+    }
+  });
+}
+
 export function getTinyMceEditor() {
   return cy
     .get('#collapse-documentation-accordion iframe.tox-edit-area__iframe')
@@ -163,7 +179,7 @@ export function selectOptionByName(selector, name) {
 export function waitToRenderAllShapes() {
   cy.wait(renderTime);
   // wait at least 5 seconds for the canvas be ready [joint-selector="svg"]
-  cy.get('[joint-selector="svg"]', { timeout: 5000 }).should('be.visible');
+  waitForCanvasOrReload();
 }
 
 export function waitForAnimations() {

--- a/tests/e2e/support/utils.js
+++ b/tests/e2e/support/utils.js
@@ -2,7 +2,7 @@ import { saveDebounce } from '../../../src/components/inspectors/inspectorConsta
 import path from 'path';
 import { boundaryEventSelector, nodeTypes, taskSelector } from './constants';
 
-const renderTime = 5000;
+const renderTime = 300;
 
 export function getTinyMceEditor() {
   return cy
@@ -162,6 +162,8 @@ export function selectOptionByName(selector, name) {
 
 export function waitToRenderAllShapes() {
   cy.wait(renderTime);
+  // wait at least 5 seconds for the canvas be ready [joint-selector="svg"]
+  cy.get('[joint-selector="svg"]', { timeout: 5000 }).should('be.visible');
 }
 
 export function waitForAnimations() {

--- a/vue.config.js
+++ b/vue.config.js
@@ -57,6 +57,11 @@ module.exports = {
           'bpmn-moddle',
         );
       }
+      // when running in development mode (npm run dev and cypress)
+      if (process.env.NODE_ENV === 'development') {
+        // reduce the chunk-vendors size
+        externals.push("@processmaker/screen-builder/dist/vue-form-builder");
+      }
       return externals;
     })(),
     plugins: (() => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -60,7 +60,7 @@ module.exports = {
       // when running in development mode (npm run dev and cypress)
       if (process.env.NODE_ENV === 'development') {
         // reduce the chunk-vendors size
-        externals.push("@processmaker/screen-builder/dist/vue-form-builder");
+        externals.push('@processmaker/screen-builder/dist/vue-form-builder');
       }
       return externals;
     })(),


### PR DESCRIPTION
## Issue & Reproduction Steps
- Javascript sizes are very large
- Browser sometimes do not wait for modeler to be loaded before run the tests

## Solution
- Reduce the javascript sizes
- Add a better wait for modeler to be loaded

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-19781

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
