### PR TITLE
FOUR-21507: After use the X option the button Launchpad is not working

### DIFF
--- a/src/components/topRail/launchpadControl/LaunchpadModal.vue
+++ b/src/components/topRail/launchpadControl/LaunchpadModal.vue
@@ -2,6 +2,7 @@
   <b-modal
     ref="launchpad-modal"
     :title="$t('You have not publish your process')"
+    @hide="closeModal"
   >
     <p>
       {{ $t('You have not published your process. Please publish your process to use the Launchpad.') }}


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create process
2. Go to Launchpad button
3. See the modal and click in X 

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21507

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy
ci:processmaker:epic/FOUR-20318