### PR TITLE
FOUR-21508:When I publish the process the launchpad button is showing the modal

### DIFF
--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -117,7 +117,7 @@ export default {
         this.showLaunchpadModal = true;
       } else {
         this.openLaunchpad = false;
-        window.location.href = '/process-browser/' + window.ProcessMaker.modeler.launchpad.process_id;
+        window.location.href = '/process-browser/' + window.ProcessMaker.modeler.process.id;
       }
     },
     closeModal() {


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create process
2. Go to Launchpad button
3. See the modal
4. Publish the process
5. Click again in the Launchpad button

**Current Behavior**
After publish the process the Launchpad button needs to redirect to launchpad

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21508

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
