### PR TITLE
FOUR-22061: "Cannot read properties of undefined (reading 'id')" with connection arrows that were added an element with the "Drop to add this flow" option

### DIFF
--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -223,7 +223,7 @@ export default {
         return;
       }
       // Check if the target shape has changed.
-      const targetChanged = this.target.id !== this.currentTarget.id;
+      const targetChanged = this.target?.id !== this.currentTarget?.id;
       if (targetChanged) {
         // Disable the 'onChange' event to prevent redundant processing.
         this.onChangeWasFired = false;


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create process
2. Add Start Event 
3. Add End Event
4. Connect the Start Event with End Event 
5. Add task form in the canvas
6. Drag the task to connect between (Start and End) event Until "Drop to add this flow" option appears
7. Drop the element so that this is positioned in the middle of the connector
8. Click on the right connector
9. Click on the left connector
![image](https://github.com/user-attachments/assets/80879bab-cfde-4dce-8d11-0d6a786c081d)

## Solution
- Validate the to ensure that both this.target and this.currentTarget are defined before accessing their id properties.

## How to Test
Test the steps above

## Related Tickets & Packages
-  https://processmaker.atlassian.net/browse/FOUR-22061

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy