### PR TITLE
FOUR-22466

### DIFF
--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -113,7 +113,7 @@ export default {
     },
     handleVerifyLaunchpad(value) {
       this.openLaunchpad = value;
-      if (this.openLaunchpad) {
+      if (this.openLaunchpad || window.ProcessMaker.modeler.isPublished === false) {
         this.showLaunchpadModal = true;
       } else {
         this.openLaunchpad = false;


### PR DESCRIPTION
## Issue & Reproduction Steps
"Open launch pad" in modeler is not synchronized when it is configured from PROCESS LAUNCH PAD

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22463

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
