### PR TITLE
FOUR-23496: button displays a wrong message when the process is not published

### DIFF
--- a/src/components/topRail/launchpadControl/LaunchpadModal.vue
+++ b/src/components/topRail/launchpadControl/LaunchpadModal.vue
@@ -5,7 +5,7 @@
     @hide="closeModal"
   >
     <p>
-      {{ $t('You have not published your process. Please publish your process to use the Launchpad.') }}
+      {{ $t('To proceed, please make sure to publish the process. Once the process is published, you will be redirected to the launchpad, where you can manage and track it further.') }}
     </p>
     <template #modal-footer>
       <b-button

--- a/src/setup/translations.json
+++ b/src/setup/translations.json
@@ -10,5 +10,5 @@
   "Upload file": "Upload file",
   "Upload XML": "Upload XML",
   "You have not publish your process": "You have not publish your process",
-  "You have not published your process. Please publish your process to use the Launchpad.": "You have not published your process. Please publish your process to use the Launchpad."
+  "To proceed, please make sure to publish the process. Once the process is published, you will be redirected to the launchpad, where you can manage and track it further.": "To proceed, please make sure to publish the process. Once the process is published, you will be redirected to the launchpad, where you can manage and track it further."
 }


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Go to server https://release-2025-spring-qa.processmaker.net/ 
2. ProcessMaker Platform Spring 2025 Version 4.14.0+beta-3 (Build #4bdd20e5)
3. Go to the Designer > processes
4. Create a process
5. Press open lauchpad button

## Solution
- Update the message

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23496

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:deploy