### PR TITLE
FOUR-23656: Element destination redirect to Home page should update the URL

### DIFF
--- a/src/components/inspectors/endEventElementDestination.js
+++ b/src/components/inspectors/endEventElementDestination.js
@@ -10,7 +10,7 @@ export default {
       { value: 'summaryScreen', content: 'Summary Screen (Default)' },
       { value: 'taskList', content: 'Task List' },
       { value: 'processLaunchpad', content: 'Process Launchpad' },
-      { value: 'homepageDashboard', content: 'Welcome Screen' },
+      { value: 'homepageDashboard', content: 'Home Page' },
       { value: 'customDashboard', content: 'Custom Dashboard' },
       { value: 'externalURL', content: 'External URL' },
       { value: 'anotherProcess', content: 'Another Process' },

--- a/src/components/inspectors/taskElementDestination.js
+++ b/src/components/inspectors/taskElementDestination.js
@@ -10,7 +10,7 @@ export default {
       { value: 'taskSource', content: 'Task Source (Default)' },
       { value: 'taskList', content: 'Task List' },
       { value: 'processLaunchpad', content: 'Process Launchpad' },
-      { value: 'homepageDashboard', content: 'Welcome Screen' },
+      { value: 'homepageDashboard', content: 'Home Page' },
       { value: 'customDashboard', content: 'Custom Dashboard' },
       { value: 'externalURL', content: 'External URL' },
       { value: 'displayNextAssignedTask', content: 'Display Next Assigned Task' },

--- a/tests/e2e/specs/Tasks.cy.js
+++ b/tests/e2e/specs/Tasks.cy.js
@@ -52,7 +52,7 @@ describe('Tasks', () => {
     cy.get('[data-test=dashboard]').should('not.exist');
     cy.get('[data-test=external-url]').should('not.exist');
 
-    // Process Launchpad
+    // Home Page
     cy.get('[data-test=element-destination-type]').should('exist');
     cy.get('[data-test=element-destination-type]').click();
     cy.get('[id=option-1-3]').click();

--- a/tests/e2e/specs/Tasks.cy.js
+++ b/tests/e2e/specs/Tasks.cy.js
@@ -57,7 +57,7 @@ describe('Tasks', () => {
     cy.get('[data-test=element-destination-type]').click();
     cy.get('[id=option-1-3]').click();
     cy.get('[class=multiselect__single]').should('exist');
-    cy.get('[class=multiselect__single]').contains('Welcome Screen');
+    cy.get('[class=multiselect__single]').contains('Home Page');
     cy.get('[data-test=dashboard]').should('not.exist');
     cy.get('[data-test=external-url]').should('not.exist');
 

--- a/tests/e2e/specs/Tasks.cy.js
+++ b/tests/e2e/specs/Tasks.cy.js
@@ -55,7 +55,7 @@ describe('Tasks', () => {
     // Home Page
     cy.get('[data-test=element-destination-type]').should('exist');
     cy.get('[data-test=element-destination-type]').click();
-    cy.get('[id=option-1-3]').click();
+    cy.contains('Home Page').click();
     cy.get('[class=multiselect__single]').should('exist');
     cy.get('[class=multiselect__single]').contains('Home Page');
     cy.get('[data-test=dashboard]').should('not.exist');


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Create/ update a process
2. Select a Task
3. Select the **Welcome Screen** as  Destination
![image](https://github.com/user-attachments/assets/e5e83377-52b2-415d-a4fa-89fe8a563657)

5. Start the Case

## Solution

1. If the user does not have a Home will redirect to inbox
2. If the user define the Home = Default will redirect to inbox
3. If the user define the Home = My Dashboard will redirect to the custom dashboard
4. If the user define the Home = My URL will redirect to the custom URL

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-23656

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:package-dynamic-ui:bugfix/FOUR-23656

ci:deploy