### PR TITLE
FOUR-22600: [SUMMER 25] Stages configuration (Progress Bar)

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -782,6 +782,11 @@ export default {
           this.generateAssets();
         }
       });
+      
+      this.paperManager.paper.on('link:pointerclick', function(linkView, evt, x, y) {
+        const model = linkView.model;
+        model.component.addCustomMarker();
+      });
 
     },
     registerCustomNodes()

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -451,6 +451,7 @@ export default {
       ],
       validPreviewElements,
       centered: false,
+      currentStageModel: null
     };
   },
   watch: {
@@ -783,11 +784,12 @@ export default {
         }
       });
       
-      this.paperManager.paper.on('link:pointerclick', function(linkView, evt, x, y) {
-        const model = linkView.model;
-        model.component.addCustomMarker();
+      this.paperManager.paper.on('link:pointerclick', (linkView, evt, x, y) => {
+        this.currentStageModel = linkView.model;
       });
-
+    },
+    getCurrentStageModelComponent() {
+      return this.currentStageModel.component;
     },
     registerCustomNodes()
     {

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -451,7 +451,7 @@ export default {
       ],
       validPreviewElements,
       centered: false,
-      currentStageModel: null
+      currentStageModel: null,
     };
   },
   watch: {
@@ -784,7 +784,7 @@ export default {
         }
       });
       
-      this.paperManager.paper.on('link:pointerclick', (linkView, evt, x, y) => {
+      this.paperManager.paper.on('link:pointerclick', (linkView) => {
         this.currentStageModel = linkView.model;
       });
     },

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -437,6 +437,21 @@ export default {
         this.listeningToMouseup = false;
       }
     },
+    addCustomMarker() {
+      //change line color
+      this.shape.attr({
+        line: { stroke: 'red' },
+      });
+
+      //add a square marker to the link
+      this.shape.attr({
+        '.joint-marker-target': {
+          'fill': 'red',
+          'stroke': 'red',
+          'stroke-width': 2,
+        },
+      });
+    },
   },
   created() {
     this.updateWaypoints = debounce(this.updateWaypoints, 100);

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -485,7 +485,7 @@ export default {
       if (!(config?.stage?.id)) {
         return;
       }
-      const label = this.stageLabel(config.stage.order, config.stage.label);
+      const label = this.stageLabel(config.stage.order, config.stage.name);
       this.$nextTick(()=> {
         this.removeStageLabels();
         const linkView = this.shape.findView(this.paper);

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -437,25 +437,79 @@ export default {
         this.listeningToMouseup = false;
       }
     },
-    addCustomMarker() {
-      //change line color
-      this.shape.attr({
-        line: { stroke: 'red' },
-      });
-
-      //add a square marker to the link
-      this.shape.attr({
-        '.joint-marker-target': {
-          'fill': 'red',
-          'stroke': 'red',
-          'stroke-width': 2,
+    /** 
+     * This function creates a label for a stage.
+     * @param {string} string - The text to display in the label.
+     * @returns {Object} The label object.
+     */
+    stageLabel(string) {
+      const label = {
+        customType: 'stage',
+        position: {
+          distance: 0.5,
+          offset: { x: 0, y: 0 }
         },
+        attrs: {
+          text: {
+            text: string,
+            fill: '#ffffff',
+            fontWeight: 'bold',
+            fontSize: 12
+          },
+          rect: {
+            fill: '#788793',
+            stroke: '#555555',
+            strokeWidth: 1,
+            rx: 3,
+            ry: 3,
+            ref: 'text',         // Relate rect to text
+            refWidth: '250%',    // Expand width in relation to text
+            refHeight: '100%',   // Expand height in relation to text
+            refX: '-70%',        // Move rect slightly to the left (horizontal padding)
+            refY: '0%'           // Move rect slightly upward (vertical padding)
+          }
+        }
+      };
+      return label;
+    },
+    /**
+     * This function sets the stage label for a link.
+     * @returns {void}
+     */
+    setStageLabel() {
+      if(!(this.node.definition?.config)) {
+        return;
+      }
+      const config = JSON.parse(this.node.definition.config);
+      if(!(config?.stage?.id)) {
+        return;
+      }
+      const label = this.stageLabel(config.stage.order);
+      this.$nextTick(()=> {
+        this.removeStageLabels();
+        const linkView = this.shape.findView(this.paper);
+        const labels = linkView.model.get('labels') || [];
+        linkView.model.set('labels', [...labels, label]);
       });
     },
+    /**
+     * This function removes the stage labels for a link.
+     * @returns {void}
+     */
+    removeStageLabels() {
+      const linkView = this.shape.findView(this.paper);
+      const labels = linkView.model.get('labels') || [];
+      for (let i = labels.length - 1; i >= 0; i--) {
+        if (labels[i].customType === 'stage') {
+          linkView.model.removeLabel(i);
+        }
+      } 
+    }
   },
   created() {
     this.updateWaypoints = debounce(this.updateWaypoints, 100);
     this.emitSave.bind(this);
+    this.setStageLabel();
   },
   async mounted() {
     await this.$nextTick();

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -442,7 +442,7 @@ export default {
      * @param {string} string - The text to display in the label.
      * @returns {Object} The label object.
      */
-    stageLabel(string) {
+    stageLabel(string, title) {
       const label = {
         customType: 'stage',
         position: {
@@ -467,6 +467,7 @@ export default {
             refHeight: '100%',   // Expand height in relation to text
             refX: '-70%',        // Move rect slightly to the left (horizontal padding)
             refY: '0%',          // Move rect slightly upward (vertical padding)
+            title: `${this.$t('Stage:')} ${title}`,
           },
         },
       };
@@ -484,7 +485,7 @@ export default {
       if (!(config?.stage?.id)) {
         return;
       }
-      const label = this.stageLabel(config.stage.order);
+      const label = this.stageLabel(config.stage.order, config.stage.label);
       this.$nextTick(()=> {
         this.removeStageLabels();
         const linkView = this.shape.findView(this.paper);

--- a/src/mixins/linkConfig.js
+++ b/src/mixins/linkConfig.js
@@ -447,14 +447,14 @@ export default {
         customType: 'stage',
         position: {
           distance: 0.5,
-          offset: { x: 0, y: 0 }
+          offset: { x: 0, y: 0 },
         },
         attrs: {
           text: {
             text: string,
             fill: '#ffffff',
             fontWeight: 'bold',
-            fontSize: 12
+            fontSize: 12,
           },
           rect: {
             fill: '#788793',
@@ -466,9 +466,9 @@ export default {
             refWidth: '250%',    // Expand width in relation to text
             refHeight: '100%',   // Expand height in relation to text
             refX: '-70%',        // Move rect slightly to the left (horizontal padding)
-            refY: '0%'           // Move rect slightly upward (vertical padding)
-          }
-        }
+            refY: '0%',          // Move rect slightly upward (vertical padding)
+          },
+        },
       };
       return label;
     },
@@ -477,11 +477,11 @@ export default {
      * @returns {void}
      */
     setStageLabel() {
-      if(!(this.node.definition?.config)) {
+      if (!(this.node.definition?.config)) {
         return;
       }
       const config = JSON.parse(this.node.definition.config);
-      if(!(config?.stage?.id)) {
+      if (!(config?.stage?.id)) {
         return;
       }
       const label = this.stageLabel(config.stage.order);
@@ -504,7 +504,7 @@ export default {
           linkView.model.removeLabel(i);
         }
       } 
-    }
+    },
   },
   created() {
     this.updateWaypoints = debounce(this.updateWaypoints, 100);


### PR DESCRIPTION
## Issue & Reproduction Steps

Implementing custom-defined waypoints that prefill a progress bar will significantly improve user experience by providing clarity, reducing uncertainty, and enhancing time management. Clients will appreciate the transparency in tracking project or task stages, making it easier to oversee complex workflows. This feature can boost both productivity and satisfaction, ensuring that Tasks are managed smoothly and efficiently.

[PRD - Stages configuration (Progress Bar)](https://processmaker.atlassian.net/wiki/spaces/PM4/pages/3986063361)
[FIGMA - Stages configuration (Progress Bar)](https://www.figma.com/design/yMpUWMQv7jD8AYWxFsuZHl/Summer-2025?node-id=1122-16953&p=f&t=QyX230LETGsF1QfC-0)

## Solution
- We created a new Stage section in the modeler
- We add a new Stage status in Open Case
- We Updated the process Info
- A new Stage and progress columns was added

## How to Test

1. Open a Process
2. Select a flow configue a stage
3. Save the process
4. Execute cases and review the columns Stages and Progress
5. Open the case related

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-22600

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
