### PR TITLE
FOUR-25228: Create default email notification config when task is created in Modeler

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1611,6 +1611,8 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
+      this.$emit('before-node-added', newNode);
+
       this.highlightNode(newNode);
 
       await this.addNode(newNode);


### PR DESCRIPTION
## Issue & Reproduction Steps
New Task — Default Notification Present

Scenario: Default email configuration is applied for a new task
Given I am logged in as a Designer with Edit Process permission
And I have navigated to a Process in the Modeler
When I create a new Task
Then I should see a default email notification configuration populated with:

To: Assigned user

Email Server: Default Email Server

Subject: {userFirstName} assigned you in ‘{TaskName}’

Body: Display Screen

Screen: DEFAULT_EMAIL_TASK_NOTIFICATION

## Related Tickets & Packages
- Link to any related FOUR tickets, PRDs, or packages

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
