### PR TITLE
FOUR-25224: [STORY] Notifications should be driven by standard email notification configuration 

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1611,6 +1611,8 @@ export default {
         this.setShapeCenterUnderCursor(diagram);
       }
 
+      this.$emit('before-node-added', newNode);
+
       this.highlightNode(newNode);
 
       await this.addNode(newNode);


### PR DESCRIPTION
## Issue & Reproduction Steps
Notifications should be driven by standard email notification configuration

As a user or administrator,
I want notifications to be driven by the standard Email Notification configuration in the Modeler, so that I can ensure consistent delivery settings.

## Solution
- **What needs to be built?** The system needs to ensure that email notifications for processes and tasks within the Modeler are configured and driven by a standard, default email notification setting. Users should also have the ability to override or update this default configuration.

## How to Test
- Create new FORM TASK
- Set to FORM TASK

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-25224

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.