### PR TITLE
FOUR-25689 Modeler > Start event icon is displayed cut when it was pinned in the rail-botton

### DIFF
--- a/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
+++ b/src/components/railBottom/controls/SubmenuPopper/SubmenuPopper.vue
@@ -92,6 +92,10 @@ export default ({
   border-radius: 4px;
   list-style: none;
   &-item {
+    display: block;
+    min-width: 26px;
+    min-height: 26px;
+    box-sizing: content-box;
     & > svg {
       width: 24px;
       height: 24px;


### PR DESCRIPTION
## Issue & Reproduction Steps
Modeler > Start event icon is displayed cut when it was pinned in the rail-bottom

Expected behavior: 
In the rail-bottom the start event icon should not be cut.

Actual behavior: 
In the rail-bottom the start event icon is cutting.

## Solution
Improve layout to submenu items

## Related Tickets & Packages
[FOUR-25689](https://processmaker.atlassian.net/browse/FOUR-25689)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-25689]: https://processmaker.atlassian.net/browse/FOUR-25689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ