### PR TITLE
FOUR-24334: Error with PM Block element in modeler, "Call Activity must have child process selected" error - [45092]

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -842,6 +842,8 @@ export default {
       if (this.isOpenPreview) {
         this.handlePreview();
       }
+      // Ensure validations are up to date when a node definition changes.
+      this.safeRevalidate();
     },
     onStartPreviewResize(event) {
       this.isResizingPreview = true;
@@ -2554,6 +2556,16 @@ export default {
           this.centered = true;
         }
       });
+    },
+    async safeRevalidate() {
+      // Run bpmnlint only when auto-validate is enabled and the model is ready.
+      if (!this.autoValidate) return;
+      // Wait for Vue and JointJS to settle before validating, so we don't lose errors
+      await this.$nextTick();
+      if (this.paperManager?.awaitScheduledUpdates) {
+        await this.paperManager.awaitScheduledUpdates();
+      }
+      await this.validateBpmnDiagram();
     },
   },
   created() {


### PR DESCRIPTION
## Issue & Reproduction Steps
When adding a new PM Block element on the canvas, validation errors show up and then disappear when moving the element. "Call Activity must have child process selected" is incorrectly displayed as if the PM Block were corrupted.  

## Solution
- Introduced a `safeRevalidate` method to centralize and properly time BPMN validation.
- Trigger `safeRevalidate` to ensure validation runs correctly right after placement.
- With this change:
  - PM Blocks can now be added to the flow without being flagged as corrupted.
  - The validation error no longer appears incorrectly on new PM Blocks.

## How to Test
1. Log into ProcessMaker.
2. Open modeler.
3. Enable **Auto validate**.
4. Add a PM Block.
   - No validation error should be shown for the PM Block.

## Related Tickets & Packages
- [FOUR-24334](https://processmaker.atlassian.net/browse/FOUR-24334)


[FOUR-24334]: https://processmaker.atlassian.net/browse/FOUR-24334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ