### PR TITLE
FOUR-26374: The name in the properties of a "Start event" does not work correctly.

### DIFF
--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -1,4 +1,4 @@
-import { getAssociationFlowsForNode, keepOriginalName } from '@/components/modeler/modelerUtils';
+import { getAssociationFlowsForNode } from '@/components/modeler/modelerUtils';
 
 export class NodeMigrator {
   constructor(nodeThatWillBeReplaced, definition, graph, newNode, processes, collaboration) {
@@ -11,9 +11,6 @@ export class NodeMigrator {
   }
 
   migrate() {
-    if (keepOriginalName(this._nodeThatWillBeReplaced)) {
-      this._definition.name = this._nodeThatWillBeReplaced.definition.name;
-    }
     const flowNodes = [];
     const forceNodeToRemount = definition => {
       const shape = this._graph.getLinks().find(element => {

--- a/src/components/modeler/NodeMigrator.js
+++ b/src/components/modeler/NodeMigrator.js
@@ -1,4 +1,4 @@
-import { getAssociationFlowsForNode } from '@/components/modeler/modelerUtils';
+import { getAssociationFlowsForNode, keepOriginalName } from '@/components/modeler/modelerUtils';
 
 export class NodeMigrator {
   constructor(nodeThatWillBeReplaced, definition, graph, newNode, processes, collaboration) {
@@ -11,6 +11,9 @@ export class NodeMigrator {
   }
 
   migrate() {
+    if (keepOriginalName(this._nodeThatWillBeReplaced)) {
+      this._definition.name = this._nodeThatWillBeReplaced.definition.name;
+    }
     const flowNodes = [];
     const forceNodeToRemount = definition => {
       const shape = this._graph.getLinks().find(element => {

--- a/src/components/nodes/baseStartEvent/defaultNames.js
+++ b/src/components/nodes/baseStartEvent/defaultNames.js
@@ -4,6 +4,7 @@ const defaultNames = {
   'processmaker-modeler-signal-start-event': 'Signal Start Event',
   'processmaker-modeler-message-start-event': 'Message Start Event',
   'processmaker-modeler-conditional-start-event': 'Conditional Start Event',
+  'processmaker-modeler-email-start-event': 'Email Start Event',
 };
 
 export default defaultNames;


### PR DESCRIPTION


## Issue & Reproduction Steps

Expected behavior: 
As in previous versions, it should display the name of the selected start event.
Actual behavior: 
The object name doesn't change; it remains Email start event
## Solution
- remove keepOriginalName migrate validations


https://github.com/user-attachments/assets/3efa6b9d-c2fb-4b29-a10e-84e5e81546cb



## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-26374

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
