### PR TITLE
FOUR-24334-B | Error with PM Block Element in Modeler, "Call Activity Must Have Child Process Selected"

### DIFF
--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1147,14 +1147,13 @@ export default {
             const hasProcessId = config.processId && config.processId !== null;
             const hasStartEvent = config.startEvent && config.startEvent !== null;
             
-            if (!hasProcessId || !hasStartEvent) {
-              return true; // Keep the error if required fields are missing
+            // If PM Block is properly configured, remove the error; otherwise keep it
+            return !(hasProcessId && hasStartEvent);
+          } catch (error) {
+            if (error instanceof SyntaxError) {
+              return true; // Keep the error if config is invalid JSON or parsing fails
             }
-            
-            // If PM Block is properly configured, remove the error
-            return false;
-          } catch (e) {
-            return true; // Keep the error if config parsing fails
+            throw error;
           }
         });
         

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1071,7 +1071,7 @@ export default {
     },
     validateIfAutoValidateIsOn() {
       if (this.autoValidate) {
-        this.validateBpmnDiagram();
+        this.safeRevalidate();
       }
     },
     translateConfig(inspectorConfig) {
@@ -1114,8 +1114,52 @@ export default {
       if (!store.getters.globalProcesses || store.getters.globalProcesses.length === 0) {
         await store.dispatch('fetchGlobalProcesses');
       }
+
       this.validationErrors = await this.linter.lint(this.definitions);
+      
+      // Filter out false positive validation errors for properly configured PM Blocks
+      this.filterFalsePositivePMBlockErrors();
+      
       this.$emit('validate', this.validationErrors);
+    },
+    filterFalsePositivePMBlockErrors() {
+      // Filter out false positive validation errors for properly configured PM Blocks
+      if (this.validationErrors['processmaker/call-activity-child-process']) {
+        const originalErrors = this.validationErrors['processmaker/call-activity-child-process'];
+        const filteredErrors = originalErrors.filter(error => {
+          // Find the corresponding node
+          const node = this.nodes.find(n => n.definition.id === error.id);
+          if (!node || !node.isBpmnType('bpmn:CallActivity')) {
+            return true; // Keep the error if we can't find the node
+          }
+          
+          // Check if the PM Block is properly configured
+          const hasCalledElement = node.definition.calledElement && node.definition.calledElement !== '';
+          const hasConfig = node.definition.config && node.definition.config !== '{}';
+          
+          if (!hasCalledElement || !hasConfig) {
+            return true; // Keep the error if the PM Block is genuinely unconfigured
+          }
+          
+          // Parse the config and check for required fields
+          try {
+            const config = JSON.parse(node.definition.config);
+            const hasProcessId = config.processId && config.processId !== null;
+            const hasStartEvent = config.startEvent && config.startEvent !== null;
+            
+            if (!hasProcessId || !hasStartEvent) {
+              return true; // Keep the error if required fields are missing
+            }
+            
+            // If PM Block is properly configured, remove the error
+            return false;
+          } catch (e) {
+            return true; // Keep the error if config parsing fails
+          }
+        });
+        
+        this.validationErrors['processmaker/call-activity-child-process'] = filteredErrors;
+      }
     },
     setPools(poolDefinition) {
       if (!this.collaboration) {
@@ -1610,7 +1654,7 @@ export default {
       await this.$nextTick();
       await this.paperManager.awaitScheduledUpdates();
       if (this.autoValidate) {
-        this.validateBpmnDiagram();
+        this.safeRevalidate();
       }
     },
 
@@ -2560,6 +2604,7 @@ export default {
     async safeRevalidate() {
       // Run bpmnlint only when auto-validate is enabled and the model is ready.
       if (!this.autoValidate) return;
+      
       // Wait for Vue and JointJS to settle before validating, so we don't lose errors
       await this.$nextTick();
       if (this.paperManager?.awaitScheduledUpdates) {
@@ -2615,6 +2660,7 @@ export default {
     this.initTransparentDragging();
     this.test = true;
     this.adjustPaperPosition();
+    this.safeRevalidate();
   },
 };
 </script>


### PR DESCRIPTION
# Issue
Ticket: [FOUR-24334](https://processmaker.atlassian.net/browse/FOUR-24334)

PM Blocks were incorrectly showing validation errors with the message "Call Activity must have a child process and a start event selected" even when they were properly configured with valid processId, startEvent, and calledElement values. The bpmnlint plugin's processmaker/call-activity-child-process validation rule was incorrectly flagging properly configured PM Blocks as invalid. The modeler was correctly loading and configuring PM Blocks, but the validation rule had a bug in how it parsed or validated the PM Block configuration.

# Solution
Implemented a false positive filter in the modeler that runs after validation to remove incorrect validation errors for properly configured PM Blocks while preserving validation errors for genuinely unconfigured PM Blocks.

# How to Test
1. Login to ProcessMaker
2. Go to Designer → Processes.
3. Create a Process.
4. Have a PM Block created.
5. Add the PM Block to the Process Modeler.
6. Select the Auto-Validate option.
  - The "Call Activity must have a child process and a start event selected" error should not appear.
  
# Code Review Checklist
- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-24334]: https://processmaker.atlassian.net/browse/FOUR-24334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ