### PR TITLE
FOUR-26707 Implement Conditional Destination Redirect 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "socket.io-client": "^4.7.2",
         "svg-inline-loader": "^0.8.2",
         "tinycolor2": "^1.4.2",
+        "uuid": "^13.0.0",
         "vue": "^2.6.12",
         "vue-deepset": "^0.6.3",
         "vue-inline-svg": "^2.1.3",
@@ -2584,6 +2585,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/@cypress/request/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cypress/webpack-preprocessor": {
@@ -16442,6 +16453,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/istanbul-lib-processinfo/node_modules/which": {
       "version": "2.0.2",
       "dev": true,
@@ -18291,6 +18312,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jest-junit/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -22585,6 +22615,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/node-notifier/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/node-notifier/node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -25526,6 +25568,16 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
@@ -27619,10 +27671,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
+      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@cypress/code-coverage": "^3.12.10",
         "@faker-js/faker": "^8.1.0",
         "@panter/vue-i18next": "^0.15.2",
-        "@processmaker/processmaker-bpmn-moddle": "0.16.0",
+        "@processmaker/processmaker-bpmn-moddle": "0.16.1",
         "@types/jest": "^24.9.1",
         "@vue/babel-preset-app": "^5.0.4",
         "@vue/cli-plugin-babel": "~5.0.0",
@@ -4671,10 +4671,11 @@
       "license": "MIT"
     },
     "node_modules/@processmaker/processmaker-bpmn-moddle": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.16.0.tgz",
-      "integrity": "sha512-udek14EJS5n2qOqbgItfAnUDoCoETczbO12Tknrknv4n0ohOhrx+eLJT+yEtGLwIZYVUU41t4q3qoHDZTUolgQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@processmaker/processmaker-bpmn-moddle/-/processmaker-bpmn-moddle-0.16.1.tgz",
+      "integrity": "sha512-ESyrux2/TSMghUqVaurJuH61dIliYhTbhJsD3Sp97hvzs4XbpKKTCwDFyZq3VRpzXcNnNmlDbQcF5+Ym/a9bCg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "min-dash": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@cypress/code-coverage": "^3.12.10",
     "@faker-js/faker": "^8.1.0",
     "@panter/vue-i18next": "^0.15.2",
-    "@processmaker/processmaker-bpmn-moddle": "0.16.0",
+    "@processmaker/processmaker-bpmn-moddle": "0.16.1",
     "@types/jest": "^24.9.1",
     "@vue/babel-preset-app": "^5.0.4",
     "@vue/cli-plugin-babel": "~5.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "socket.io-client": "^4.7.2",
     "svg-inline-loader": "^0.8.2",
     "tinycolor2": "^1.4.2",
+    "uuid": "^13.0.0",
     "vue": "^2.6.12",
     "vue-deepset": "^0.6.3",
     "vue-inline-svg": "^2.1.3",

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -28,6 +28,14 @@
           @remove="onRemoveCondition"
         />
       </div>
+
+      <hr class="my-2">
+
+      <div class="d-flex justify-content-end">
+        <small class="text-muted text-right">
+          {{ $t('Rules are evaluated top to bottom.') }}
+        </small>
+      </div>
     </div>
   </div>
 </template>

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -11,6 +11,7 @@
         name="conditionalRedirectEnabled"
         :aria-checked="isEnabled"
         switch
+        data-test="conditional-toggle"
       />
     </div>
     <div v-if="isEnabled">
@@ -19,11 +20,16 @@
         class="btn btn-light"
         @click="addCondition"
         :disabled="conditions.length >= MAX_CONDITIONS"
+        data-test="conditional-add-button"
       >
         <i class="fas fa-plus-circle" />
       </button>
 
-      <div v-for="condition in conditions" :key="condition.id">
+      <div
+        v-for="condition in conditions"
+        :key="condition.id"
+        data-test="conditional-box"
+      >
         <TaskDestination
           :value="condition"
           :taskDestinationOptions="taskDestinationOptions"

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -2,9 +2,10 @@
   <div>
     <label>{{ $t(label) }}</label>
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <label for="conditionalRedirectEnabled" class="text-muted small">
-        {{ $t("Enable to add rules that route users to different tasks. If none match, the default destination is used.") }}
-      </label>
+      <span
+        class="text-muted small"
+        v-html="conditionalRedirectDescription"
+      />
       <b-form-checkbox
         id="conditionalRedirectEnabled"
         v-model="isEnabled"
@@ -84,6 +85,9 @@ export default {
     };
   },
   computed: {
+    conditionalRedirectDescription() {
+      return this.$t('Enable to add rules that route users to different tasks. If none match, the <b>Task Destination</b> is used.');
+    },
     maxConditionsReached() {
       return this.conditions.length >= MAX_CONDITIONS;
     },

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -1,0 +1,131 @@
+<template>
+  <div>
+    <label>{{ $t(label) }}</label>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+      <label for="conditionalRedirectEnabled">{{ $t("Enable to add rules that route users to different tasks. If none match, the default destination is used.") }}</label>
+      <b-form-checkbox
+        id="conditionalRedirectEnabled"
+        v-model="isEnabled"
+        name="conditionalRedirectEnabled"
+        :aria-checked="isEnabled"
+        switch
+      />
+    </div>
+    <div v-if="isEnabled">
+      <button type="button" class="btn btn-light" @click="addCondition">
+        <i class="fas fa-plus-circle" />
+      </button>
+
+      <div v-for="condition in conditions" :key="condition.id">
+        <TaskDestination
+          :value="condition"
+          :taskDestinationOptions="taskDestinationOptions"
+          :conditionId="condition.id"
+          @input="onConditionInput"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import TaskDestination from './TaskDestination.vue';
+import { v4 as uuidv4 } from 'uuid';
+import isEqual from 'lodash/isEqual';
+
+const MAX_CONDITIONS = 10;
+
+export default {
+  components: {
+    TaskDestination,
+  },
+  props: {
+    value: {
+      type: String,
+      required: true,
+    },
+    label: {
+      type: String,
+      required: true,
+    },
+    options: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      isEnabled: false,
+      conditions: [],
+      taskDestinationOptions: [],
+    };
+  },
+  watch: {
+    /* conditionalRedirect: {
+      handler(newValue, oldValue) {
+        if (newValue && !isEqual(newValue, oldValue)) {
+          this.updateConditionalRedirect(newValue);
+        }
+      },
+      deep: true,
+    }, */
+    isEnabled: {
+      handler() {
+        this.updateConditionalRedirect();
+      },
+    },
+  },
+  mounted() {
+    this.updateConditionalRedirect();
+    this.initTaskDestinationOptions();
+
+    if (this.value) {
+      const local = JSON.parse(this.value);
+
+      this.isEnabled = local.isEnabled ?? false;
+      this.conditions = local.conditions ?? [];
+    }
+  },
+  methods: {
+    initTaskDestinationOptions() {
+      this.taskDestinationOptions = this.options.map(({ value, content }) => ({
+        value,
+        content: this.$t(content),
+      }));
+
+      this.taskDestination = this.taskDestinationOptions?.[0] ?? null;
+    },
+    updateConditionalRedirect(newValue) {
+      const data =  JSON.stringify({
+        isEnabled: this.isEnabled,
+        conditions: this.conditions,
+      });
+
+      this.$emit('input', data);
+    },
+    addCondition() {
+      if (this.conditions.length >= MAX_CONDITIONS) {
+        return;
+      }
+
+      this.conditions.push({
+        id: uuidv4(),
+        condition: '',
+        taskDestination: null,
+      });
+    },
+    onConditionInput(value) {
+      const index = this.conditions.findIndex((condition) => condition.id === value.conditionId);
+
+      if (index !== -1) {
+        this.conditions[index] = {
+          ...this.conditions[index],
+          ...value.condition,
+        };
+      }
+
+      this.updateConditionalRedirect();
+    },
+  },
+};
+</script>

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -78,6 +78,7 @@ export default {
   },
   data() {
     return {
+      taskDestination: null,
       isEnabled: false,
       conditions: [],
       taskDestinationOptions: [],

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -63,14 +63,6 @@ export default {
     };
   },
   watch: {
-    /* conditionalRedirect: {
-      handler(newValue, oldValue) {
-        if (newValue && !isEqual(newValue, oldValue)) {
-          this.updateConditionalRedirect(newValue);
-        }
-      },
-      deep: true,
-    }, */
     isEnabled: {
       handler() {
         this.updateConditionalRedirect();
@@ -96,7 +88,7 @@ export default {
 
       this.taskDestination = this.taskDestinationOptions?.[0] ?? null;
     },
-    updateConditionalRedirect(newValue) {
+    updateConditionalRedirect() {
       const data =  JSON.stringify({
         isEnabled: this.isEnabled,
         conditions: this.conditions,

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -35,7 +35,6 @@
 <script>
 import TaskDestination from './TaskDestination.vue';
 import { v4 as uuidv4 } from 'uuid';
-import isEqual from 'lodash/isEqual';
 
 const MAX_CONDITIONS = 10;
 
@@ -46,7 +45,6 @@ export default {
   props: {
     value: {
       type: String,
-      required: true,
     },
     label: {
       type: String,

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -2,7 +2,9 @@
   <div>
     <label>{{ $t(label) }}</label>
     <div class="d-flex justify-content-between align-items-center mb-2">
-      <label for="conditionalRedirectEnabled">{{ $t("Enable to add rules that route users to different tasks. If none match, the default destination is used.") }}</label>
+      <label for="conditionalRedirectEnabled" class="text-muted small">
+        {{ $t("Enable to add rules that route users to different tasks. If none match, the default destination is used.") }}
+      </label>
       <b-form-checkbox
         id="conditionalRedirectEnabled"
         v-model="isEnabled"

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -14,7 +14,12 @@
       />
     </div>
     <div v-if="isEnabled">
-      <button type="button" class="btn btn-light" @click="addCondition">
+      <button
+        type="button"
+        class="btn btn-light"
+        @click="addCondition"
+        :disabled="conditions.length >= MAX_CONDITIONS"
+      >
         <i class="fas fa-plus-circle" />
       </button>
 
@@ -68,6 +73,7 @@ export default {
       isEnabled: false,
       conditions: [],
       taskDestinationOptions: [],
+      MAX_CONDITIONS,
     };
   },
   watch: {
@@ -81,10 +87,14 @@ export default {
     this.initTaskDestinationOptions();
 
     if (this.value) {
-      const local = JSON.parse(this.value);
+      try {
+        const local = JSON.parse(this.value);
 
-      this.isEnabled = local.isEnabled ?? false;
-      this.conditions = local.conditions ?? [];
+        this.isEnabled = local.isEnabled ?? false;
+        this.conditions = local.conditions ?? [];
+      } catch (error) {
+        console.warn(error, 'Error parsing conditional redirect', this.value);
+      }
     }
   },
   methods: {
@@ -114,6 +124,8 @@ export default {
         condition: '',
         taskDestination: null,
       });
+
+      this.updateConditionalRedirect();
     },
     onSaveCondition(value) {
       const index = this.conditions.findIndex((condition) => condition.id === value.conditionId);

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -19,7 +19,7 @@
         type="button"
         class="btn btn-light"
         @click="addCondition"
-        :disabled="conditions.length >= MAX_CONDITIONS"
+        :disabled="maxConditionsReached"
         data-test="conditional-add-button"
       >
         <i class="fas fa-plus-circle" />
@@ -34,6 +34,7 @@
           :value="condition"
           :taskDestinationOptions="taskDestinationOptions"
           :conditionId="condition.id"
+          :maxConditionsReached="maxConditionsReached"
           @input="onSaveCondition"
           @duplicate="onDuplicateCondition"
           @remove="onRemoveCondition"
@@ -82,6 +83,11 @@ export default {
       MAX_CONDITIONS,
     };
   },
+  computed: {
+    maxConditionsReached() {
+      return this.conditions.length >= MAX_CONDITIONS;
+    },
+  },
   watch: {
     isEnabled: {
       handler() {
@@ -121,7 +127,7 @@ export default {
       this.$emit('input', data);
     },
     addCondition() {
-      if (this.conditions.length >= MAX_CONDITIONS) {
+      if (this.maxConditionsReached) {
         return;
       }
 
@@ -146,6 +152,10 @@ export default {
       this.updateConditionalRedirect();
     },
     onDuplicateCondition(conditionId) {
+      if (this.maxConditionsReached) {
+        return;
+      }
+
       const condition = this.conditions.find((condition) => condition.id === conditionId);
 
       this.conditions.push({

--- a/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
+++ b/src/components/inspectors/ConditionalRedirect/ConditionalRedirect.vue
@@ -23,7 +23,9 @@
           :value="condition"
           :taskDestinationOptions="taskDestinationOptions"
           :conditionId="condition.id"
-          @input="onConditionInput"
+          @input="onSaveCondition"
+          @duplicate="onDuplicateCondition"
+          @remove="onRemoveCondition"
         />
       </div>
     </div>
@@ -78,7 +80,6 @@ export default {
     },
   },
   mounted() {
-    this.updateConditionalRedirect();
     this.initTaskDestinationOptions();
 
     if (this.value) {
@@ -116,7 +117,7 @@ export default {
         taskDestination: null,
       });
     },
-    onConditionInput(value) {
+    onSaveCondition(value) {
       const index = this.conditions.findIndex((condition) => condition.id === value.conditionId);
 
       if (index !== -1) {
@@ -125,6 +126,21 @@ export default {
           ...value.condition,
         };
       }
+
+      this.updateConditionalRedirect();
+    },
+    onDuplicateCondition(conditionId) {
+      const condition = this.conditions.find((condition) => condition.id === conditionId);
+
+      this.conditions.push({
+        ...condition,
+        id: uuidv4(),
+      });
+
+      this.updateConditionalRedirect();
+    },
+    onRemoveCondition(conditionId) {
+      this.conditions = this.conditions.filter((condition) => condition.id !== conditionId);
 
       this.updateConditionalRedirect();
     },

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -23,6 +23,16 @@
       data-test="element-destination-type"
     />
 
+    <form-input
+      v-if="taskDestination?.value === 'externalURL'"
+      :label="$t('URL')"
+      v-model="externalURL"
+      :error="getValidationErrorForCustomURL(externalURL)"
+      :placeholder="urlPlaceholder"
+      :helper="$t('Determine the URL where the request will end')"
+      data-test="external-url"
+    />
+
     <b-card-footer class="d-flex justify-content-end p-1 bg-white">
       <button
         type="button"
@@ -70,21 +80,20 @@ export default {
       loading: false,
       condition: '',
       taskDestination: null,
+      externalURL: '',
+      urlPlaceholder: `${window.location.origin}/processes`,
     };
   },
   watch: {
-    value: {
-      handler(newValue) {
-        this.condition = newValue.condition;
-        this.taskDestination = newValue.taskDestination;
-      },
-      deep: true,
+    externalURL() {
+      this.onSaveCondition();
     },
   },
   mounted() {
     if (this.value) {
       this.condition = this.value.condition;
       this.taskDestination = this.value.taskDestination;
+      this.externalURL = this.value.externalUrl;
     }
   },
   methods: {
@@ -94,6 +103,7 @@ export default {
         condition: {
           condition: this.condition,
           taskDestination: this.taskDestination,
+          externalUrl: this.externalURL,
         },
       });
     },
@@ -102,6 +112,19 @@ export default {
     },
     onRemoveCondition() {
       this.$emit('remove', this.conditionId);
+    },
+    getValidationErrorForCustomURL(url) {
+      if (!url) return this.$t('URL is required');
+      if (!this.isValidCustomURL(url)) return this.$t('Must be a valid URL');
+      return '';
+    },
+    isValidCustomURL(url) {
+      try {
+        const parsed = new URL(url);
+        return ['http:', 'https:'].includes(parsed.protocol);
+      } catch {
+        return false;
+      }
     },
   },
 };

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -31,8 +31,20 @@
       >
         Save
       </button>
-      <button type="button" class="btn btn-light btn-sm text-capitalize">Duplicate</button>
-      <button type="button" class="btn btn-light btn-sm text-danger text-capitalize">Remove</button>
+      <button
+        type="button"
+        class="btn btn-light btn-sm text-capitalize"
+        @click="onDuplicateCondition"
+      >
+        Duplicate
+      </button>
+      <button
+        type="button"
+        class="btn btn-light btn-sm text-danger text-capitalize"
+        @click="onRemoveCondition"
+      >
+        Remove
+      </button>
     </b-card-footer>
   </b-card>
 </template>
@@ -84,6 +96,12 @@ export default {
           taskDestination: this.taskDestination,
         },
       });
+    },
+    onDuplicateCondition() {
+      this.$emit('duplicate', this.conditionId);
+    },
+    onRemoveCondition() {
+      this.$emit('remove', this.conditionId);
     },
   },
 };

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -259,6 +259,7 @@ export default {
       this.$root.$emit('handle-task-interstitial', {
         nodeId,
         show: newValue === 'displayNextAssignedTask',
+        isConditionalRedirect: true,
       });
     },
   },

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -59,13 +59,6 @@
     <b-card-footer class="d-flex justify-content-end p-1 bg-white">
       <button
         type="button"
-        class="btn btn-primary btn-sm text-capitalize"
-        @click="onSaveCondition"
-      >
-        Save
-      </button>
-      <button
-        type="button"
         class="btn btn-light btn-sm text-capitalize"
         @click="onDuplicateCondition"
       >
@@ -106,14 +99,30 @@ export default {
       loading: false,
       condition: '',
       taskDestination: null,
-      customDashboard: null,
       dashboards: [],
-      getCustomDashboardsDebounced: null,
+      customDashboard: null,
       externalURL: '',
       urlPlaceholder: `${window.location.origin}/processes`,
+      getCustomDashboardsDebounced: null,
+      saveConditionDebounced: null,
     };
   },
   watch: {
+    condition: {
+      handler(newValue, oldValue) {
+        if (!isEqual(newValue, oldValue)) {
+          this.saveConditionDebounced();
+        }
+      },
+    },
+    taskDestination: {
+      handler(newValue, oldValue) {
+        if (!isEqual(newValue, oldValue)) {
+          this.onSaveCondition();
+        }
+      },
+      deep: true,
+    },
     customDashboard: {
       handler(newValue, oldValue) {
         if (!isEqual(newValue, oldValue)) {
@@ -130,6 +139,10 @@ export default {
     this.getCustomDashboardsDebounced = debounce((filter) => {
       this.getCustomDashboards(filter);
     }, 500);
+
+    this.saveConditionDebounced = debounce(() => {
+      this.onSaveCondition();
+    }, 300);
   },
   mounted() {
     if (this.value) {

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -183,7 +183,8 @@ export default {
         order_direction: 'asc',
         per_page: 20,
         page: 1,
-        fields: 'title,url',
+        simplified_data_for_selector: true,
+        fields: 'id,title,token',
       };
 
       if (filter) {

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -4,7 +4,7 @@
       :label="$t('Condition')"
       v-model="condition"
       placeholder="e.g., score > 80 and segment == 'A'"
-      data-test="condition"
+      data-test="conditional-task-condition"
     />
 
     <form-multi-select
@@ -20,7 +20,7 @@
       :internal-search="false"
       :preserve-search="false"
       :clear-on-select="true"
-      data-test="element-destination-type"
+      data-test="conditional-task-redirect"
     />
 
     <form-multi-select
@@ -43,7 +43,7 @@
       :preserve-search="false"
       :clear-on-select="true"
       @search-change="onDashboardSearchChange"
-      data-test="dashboard"
+      data-test="conditional-task-dashboard"
     />
 
     <form-input
@@ -53,7 +53,7 @@
       :error="getValidationErrorForCustomURL(externalURL)"
       :placeholder="urlPlaceholder"
       :helper="$t('Determine the URL where the request will end')"
-      data-test="external-url"
+      data-test="conditional-task-external-url"
     />
 
     <b-card-footer class="d-flex justify-content-end p-1 bg-white">
@@ -61,6 +61,7 @@
         type="button"
         class="btn btn-light btn-sm text-capitalize"
         @click="onDuplicateCondition"
+        data-test="conditional-duplicate-button"
       >
         Duplicate
       </button>
@@ -68,6 +69,7 @@
         type="button"
         class="btn btn-light btn-sm text-danger text-capitalize"
         @click="onRemoveCondition"
+        data-test="conditional-remove-button"
       >
         Remove
       </button>

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -1,5 +1,5 @@
 <template>
-  <b-card class="mt-2 p-2 pb-0" no-body>
+  <b-card class="mt-2 p-2 pb-0 task-destination" no-body>
     <form-input
       :label="$t('Condition')"
       v-model="condition"
@@ -10,7 +10,6 @@
     <form-multi-select
       :label="$t('Task Destination')"
       v-model="taskDestination"
-      :showLabels="false"
       :allow-empty="false"
       :options="taskDestinationOptions"
       :loading="loading"
@@ -25,9 +24,15 @@
     />
 
     <b-card-footer class="d-flex justify-content-end p-1 bg-white">
-      <button type="button" class="btn btn-primary btn-sm" @click="onSaveCondition">Save</button>
-      <button type="button" class="btn btn-light btn-sm">Duplicate</button>
-      <button type="button" class="btn btn-light text-danger btn-sm">Remove</button>
+      <button
+        type="button"
+        class="btn btn-primary btn-sm text-capitalize"
+        @click="onSaveCondition"
+      >
+        Save
+      </button>
+      <button type="button" class="btn btn-light btn-sm text-capitalize">Duplicate</button>
+      <button type="button" class="btn btn-light btn-sm text-danger text-capitalize">Remove</button>
     </b-card-footer>
   </b-card>
 </template>
@@ -83,3 +88,18 @@ export default {
   },
 };
 </script>
+
+<style lang="scss" scoped>
+.task-destination {
+  --label-font-weight: 500;
+  --input-font-size: 14px;
+
+  ::v-deep .form-group label {
+    font-weight: var(--label-font-weight);
+  }
+
+  ::v-deep .form-control {
+    font-size: var(--input-font-size);
+  }
+}
+</style>

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -110,6 +110,11 @@ export default {
       saveConditionDebounced: null,
     };
   },
+  computed: {
+    node() {
+      return this.$root.$children[0].$refs.modeler.highlightedNode.definition;
+    },
+  },
   watch: {
     condition: {
       handler(newValue, oldValue) {
@@ -123,6 +128,10 @@ export default {
         if (!isEqual(newValue, oldValue)) {
           this.onSaveCondition();
         }
+
+        this.$nextTick(() => {
+          this.handleInterstitial(newValue.value);
+        });
       },
       deep: true,
     },
@@ -222,6 +231,30 @@ export default {
     },
     onDashboardSearchChange(filter) {
       this.getCustomDashboardsDebounced(filter);
+    },
+    /**
+     * Handles interstitial logic for supported task node types.
+     * @param {string} newValue - The new destination type value selected.
+     */
+    handleInterstitial(newValue) {
+      const { $type: nodeType, id: nodeId } = this.node;
+      const supportedTypes = ['bpmn:Task', 'bpmn:ManualTask'];
+
+      if (supportedTypes.includes(nodeType)) {
+        this.handleTaskInterstitial(newValue, nodeId);
+      }
+    },
+    /**
+     * Handle interstitial for task elements
+     *
+     * @param {String} newValue - The new destination type value selected
+     * @param {String} nodeId - The ID of the task node being modified
+     */
+    handleTaskInterstitial(newValue, nodeId) {
+      this.$root.$emit('handle-task-interstitial', {
+        nodeId,
+        show: newValue === 'displayNextAssignedTask',
+      });
     },
   },
 };

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -23,6 +23,29 @@
       data-test="element-destination-type"
     />
 
+    <form-multi-select
+      v-if="taskDestination?.value === 'customDashboard'"
+      :label="$t('Dashboard')"
+      name="Dashboard"
+      :helper="$t('Select the dashboard to show the summary of this request when it completes')"
+      v-model="customDashboard"
+      :placeholder="$t('Type here to search')"
+      :showLabels="false"
+      :allow-empty="false"
+      :options="dashboards"
+      :loading="loading"
+      optionContent="title"
+      optionValue="url"
+      class="p-0 mb-2"
+      validation="required"
+      :searchable="true"
+      :internal-search="false"
+      :preserve-search="false"
+      :clear-on-select="true"
+      @search-change="onDashboardSearchChange"
+      data-test="dashboard"
+    />
+
     <form-input
       v-if="taskDestination?.value === 'externalURL'"
       :label="$t('URL')"
@@ -60,6 +83,9 @@
 </template>
 
 <script>
+import debounce from 'lodash/debounce';
+import isEqual from 'lodash/isEqual';
+
 export default {
   props: {
     value: {
@@ -80,32 +106,56 @@ export default {
       loading: false,
       condition: '',
       taskDestination: null,
+      customDashboard: null,
+      dashboards: [],
+      getCustomDashboardsDebounced: null,
       externalURL: '',
       urlPlaceholder: `${window.location.origin}/processes`,
     };
   },
   watch: {
+    customDashboard: {
+      handler(newValue, oldValue) {
+        if (!isEqual(newValue, oldValue)) {
+          this.onSaveCondition();
+        }
+      },
+      deep: true,
+    },
     externalURL() {
       this.onSaveCondition();
     },
+  },
+  created() {
+    this.getCustomDashboardsDebounced = debounce((filter) => {
+      this.getCustomDashboards(filter);
+    }, 500);
   },
   mounted() {
     if (this.value) {
       this.condition = this.value.condition;
       this.taskDestination = this.value.taskDestination;
-      this.externalURL = this.value.externalUrl;
+      this.customDashboard = this.value.customDashboard ?? null;
+      this.externalURL = this.value.externalUrl ?? null;
+    }
+
+    if (this.dashboards.length === 0) {
+      this.getCustomDashboards();
     }
   },
   methods: {
     onSaveCondition() {
-      this.$emit('input', {
+      const conditionData = {
         conditionId: this.conditionId,
         condition: {
           condition: this.condition,
           taskDestination: this.taskDestination,
+          customDashboard: this.customDashboard,
           externalUrl: this.externalURL,
         },
-      });
+      };
+
+      this.$emit('input', conditionData);
     },
     onDuplicateCondition() {
       this.$emit('duplicate', this.conditionId);
@@ -125,6 +175,36 @@ export default {
       } catch {
         return false;
       }
+    },
+    getCustomDashboards(filter) {
+      this.loading = true;
+
+      const params = {
+        order_direction: 'asc',
+        per_page: 20,
+        page: 1,
+        fields: 'title,url',
+      };
+
+      if (filter) {
+        params.filter = filter;
+      }
+
+      window.ProcessMaker.apiClient.get('dynamic-ui/dashboards', {
+        params,
+      })
+        .then(response => {
+          this.dashboards = response.data.data;
+        })
+        .catch(() => {
+          this.dashboards = [];
+        })
+        .finally(() => {
+          this.loading = false;
+        });
+    },
+    onDashboardSearchChange(filter) {
+      this.getCustomDashboardsDebounced(filter);
     },
   },
 };

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -61,6 +61,7 @@
         type="button"
         class="btn btn-light btn-sm text-capitalize"
         @click="onDuplicateCondition"
+        :disabled="maxConditionsReached"
         data-test="conditional-duplicate-button"
       >
         Duplicate
@@ -94,6 +95,10 @@ export default {
     },
     taskDestinationOptions: {
       type: Array,
+      required: true,
+    },
+    maxConditionsReached: {
+      type: Boolean,
       required: true,
     },
   },

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -1,0 +1,85 @@
+<template>
+  <b-card class="mt-2 p-2 pb-0" no-body>
+    <form-input
+      :label="$t('Condition')"
+      v-model="condition"
+      placeholder="e.g., score > 80 and segment == 'A'"
+      data-test="condition"
+    />
+
+    <form-multi-select
+      :label="$t('Task Destination')"
+      v-model="taskDestination"
+      :showLabels="false"
+      :allow-empty="false"
+      :options="taskDestinationOptions"
+      :loading="loading"
+      optionContent="content"
+      optionValue="value"
+      class="p-0 mb-2"
+      :searchable="false"
+      :internal-search="false"
+      :preserve-search="false"
+      :clear-on-select="true"
+      data-test="element-destination-type"
+    />
+
+    <b-card-footer class="d-flex justify-content-end p-1 bg-white">
+      <button type="button" class="btn btn-primary btn-sm" @click="onSaveCondition">Save</button>
+      <button type="button" class="btn btn-light btn-sm">Duplicate</button>
+      <button type="button" class="btn btn-light text-danger btn-sm">Remove</button>
+    </b-card-footer>
+  </b-card>
+</template>
+
+<script>
+export default {
+  props: {
+    value: {
+      type: Object,
+      required: true,
+    },
+    conditionId: {
+      type: String,
+      required: true,
+    },
+    taskDestinationOptions: {
+      type: Array,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+      condition: '',
+      taskDestination: null,
+    };
+  },
+  watch: {
+    value: {
+      handler(newValue) {
+        this.condition = newValue.condition;
+        this.taskDestination = newValue.taskDestination;
+      },
+      deep: true,
+    },
+  },
+  mounted() {
+    if (this.value) {
+      this.condition = this.value.condition;
+      this.taskDestination = this.value.taskDestination;
+    }
+  },
+  methods: {
+    onSaveCondition() {
+      this.$emit('input', {
+        conditionId: this.conditionId,
+        condition: {
+          condition: this.condition,
+          taskDestination: this.taskDestination,
+        },
+      });
+    },
+  },
+};
+</script>

--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -78,6 +78,7 @@
 <script>
 import debounce from 'lodash/debounce';
 import isEqual from 'lodash/isEqual';
+import cloneDeep from 'lodash/cloneDeep';
 
 export default {
   props: {
@@ -146,10 +147,10 @@ export default {
   },
   mounted() {
     if (this.value) {
-      this.condition = this.value.condition;
-      this.taskDestination = this.value.taskDestination;
-      this.customDashboard = this.value.customDashboard ?? null;
-      this.externalURL = this.value.externalUrl ?? null;
+      this.condition = cloneDeep(this.value.condition);
+      this.taskDestination = cloneDeep(this.value.taskDestination);
+      this.customDashboard = cloneDeep(this.value.customDashboard) ?? null;
+      this.externalURL = cloneDeep(this.value.externalUrl) ?? null;
     }
 
     if (this.dashboards.length === 0) {

--- a/src/components/inspectors/ConditionalRedirect/conditionalRedirect.js
+++ b/src/components/inspectors/ConditionalRedirect/conditionalRedirect.js
@@ -6,7 +6,7 @@ export default {
     label: 'Conditional Redirects',
     name: 'conditionalRedirect',
     options: [
-      { value: 'taskSource', content: 'Task Source (Default)' },
+      { value: 'taskSource', content: 'Task Source' },
       { value: 'taskList', content: 'Task List' },
       { value: 'processLaunchpad', content: 'Process Launchpad' },
       { value: 'homepageDashboard', content: 'Home Page' },

--- a/src/components/inspectors/ConditionalRedirect/conditionalRedirect.js
+++ b/src/components/inspectors/ConditionalRedirect/conditionalRedirect.js
@@ -1,0 +1,18 @@
+import ConditionalRedirect from './ConditionalRedirect.vue';
+
+export default {
+  component: ConditionalRedirect,
+  config: {
+    label: 'Conditional Redirects',
+    name: 'conditionalRedirect',
+    options: [
+      { value: 'taskSource', content: 'Task Source (Default)' },
+      { value: 'taskList', content: 'Task List' },
+      { value: 'processLaunchpad', content: 'Process Launchpad' },
+      { value: 'homepageDashboard', content: 'Home Page' },
+      { value: 'customDashboard', content: 'Custom Dashboard' },
+      { value: 'externalURL', content: 'External URL' },
+      { value: 'displayNextAssignedTask', content: 'Display Next Assigned Task' },
+    ],
+  },
+};

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -1556,11 +1556,18 @@ export default {
                 // console.error('Error parsing conditional redirect', error);
               }
 
-              const elementDestination = element.get('pm:elementDestination') ;
+              if (element.get('pm:allowInterstitial') === true && !hasConditionalRedirect) {
+                let elementDestination = element.get('pm:elementDestination');
+                try {
+                  elementDestination = JSON.parse(elementDestination);
+                } catch (error) {
+                  // console.error('Error parsing element destination', error);
+                }
 
-              if (element.get('pm:allowInterstitial') === true && elementDestination === undefined && !hasConditionalRedirect) {
-                // Always update the element destination to display the next assigned task
-                element.set('pm:elementDestination', JSON.stringify({ type: 'displayNextAssignedTask' }));
+                if (elementDestination === undefined || elementDestination?.type !== 'displayNextAssignedTask') {
+                  // Always update the element destination to display the next assigned task
+                  element.set('pm:elementDestination', JSON.stringify({ type: 'displayNextAssignedTask' }));
+                }
               }
             }
           });

--- a/src/components/modeler/Modeler.vue
+++ b/src/components/modeler/Modeler.vue
@@ -70,7 +70,7 @@
         v-if="loadingAI"
         @stopAssetGeneration="onStopAssetGeneration()"
       />
-      
+
       <AssetsCreatedCard
         ref="assetsCreatedCard"
         v-if="assetsCreated"
@@ -202,7 +202,7 @@
         v-for="player in filteredPlayers"
         :key="player.id"
         :data="prepareCursorData(player)"
-      /> 
+      />
     </b-row>
   </span>
 </template>
@@ -523,10 +523,10 @@ export default {
       });
     },
     showWelcomeMessage() {
-      return !this.selectedNode && 
-        !this.nodes.length && 
-        !this.isReadOnly && 
-        this.isLoaded && 
+      return !this.selectedNode &&
+        !this.nodes.length &&
+        !this.isReadOnly &&
+        this.isLoaded &&
         !undoRedoStore.getters.isRunning &&
         this.isPackageAiInstalled;
     },
@@ -591,7 +591,7 @@ export default {
       window.ProcessMaker.EventBus.$on('show-documentation', (event) => {
         if (this.$refs['nodeDocumentation'] && this.$refs['nodeDocumentation'].isVisible === false) {
           this.$refs['nodeDocumentation'].text = event.text;
-          this.$refs['nodeDocumentation'].number = event.number;  
+          this.$refs['nodeDocumentation'].number = event.number;
           this.$refs['nodeDocumentation'].position = this.setCardPosition(event);
           this.$refs['nodeDocumentation'].elementType = event.node.definition.$type.replace('bpmn:', '');
           this.$refs['nodeDocumentation'].elementTitle = event.node.definition.name;
@@ -785,7 +785,7 @@ export default {
           this.generateAssets();
         }
       });
-      
+
       this.paperManager.paper.on('link:pointerclick', (linkView) => {
         this.currentStageModel = linkView.model;
       });
@@ -1538,11 +1538,27 @@ export default {
         if (rootElement.$type === 'bpmn:Process') {
           // Get all flow elements in the process
           const flowElements = rootElement.get('flowElements') || [];
-          
+
           // Find all tasks with interstitial enabled
           flowElements.forEach(element => {
             if (element.$type === 'bpmn:Task' || element.$type === 'bpmn:UserTask' || element.$type === 'bpmn:ManualTask') {
-              if (element.get('pm:allowInterstitial') === true) {
+              let hasConditionalRedirect = false;
+
+              try {
+                const conditionalRedirect = JSON.parse(element.get('pm:conditionalRedirect'));
+
+                if (conditionalRedirect?.isEnabled === true && Array.isArray(conditionalRedirect.conditions)) {
+                  hasConditionalRedirect = conditionalRedirect.conditions.some(
+                    condition => condition?.taskDestination?.value === 'displayNextAssignedTask',
+                  );
+                }
+              } catch (error) {
+                // console.error('Error parsing conditional redirect', error);
+              }
+
+              const elementDestination = element.get('pm:elementDestination') ;
+
+              if (element.get('pm:allowInterstitial') === true && elementDestination === undefined && !hasConditionalRedirect) {
                 // Always update the element destination to display the next assigned task
                 element.set('pm:elementDestination', JSON.stringify({ type: 'displayNextAssignedTask' }));
               }
@@ -2142,7 +2158,7 @@ export default {
     },
     redirect(redirectTo) {
       if (window.ProcessMaker.AbTesting) {
-        window.parent.location = redirectTo;  
+        window.parent.location = redirectTo;
       } else {
         window.location = redirectTo;
       }
@@ -2161,7 +2177,7 @@ export default {
     },
     /**
      * Update Client Cursor
-     * @param {Object} data 
+     * @param {Object} data
      */
     updateClientCursor(data) {
       if (data) {
@@ -2190,7 +2206,7 @@ export default {
     },
     /**
      * Unhightligt selected Nodes
-     * @param {String} clientId 
+     * @param {String} clientId
      */
     unhightligtNodes(clientId) {
       const player = this.players.find(player => player.id === clientId);
@@ -2204,7 +2220,7 @@ export default {
     },
     /**
      * Update the hightligted nodes
-     * @param {Object} data 
+     * @param {Object} data
      */
     updateHightligtedNodes(data) {
       if (data) {
@@ -2229,7 +2245,7 @@ export default {
           intersectionExists = player?.selectedNodes?.some(item => data.includes(item));
           return false;
         });
-       
+
       }
       return intersectionExists;
     },
@@ -2323,7 +2339,7 @@ export default {
         })
         .catch((error) => {
           const errorMsg = error.response?.data?.message || error.message;
-          
+
           this.loading = false;
           if (error.response.status === 404) {
             this.removePromptSessionForUser();
@@ -2391,7 +2407,7 @@ export default {
       taskArray.forEach(task => {
         const taskNode = self.getElementByNodeId(task.id);
         if (taskNode) {
-          taskNode.component.setAiStatusHighlight(task.status);  
+          taskNode.component.setAiStatusHighlight(task.status);
         }
       });
     },
@@ -2431,11 +2447,11 @@ export default {
             } else {
               this.highlightTaskArrays(response.data);
               setTimeout(() => {
-                this.unhighlightTaskArrays(response.data);  
+                this.unhighlightTaskArrays(response.data);
               }, 1000);
               this.setPromptSessions(response.data.promptSessionId);
-              // Successful generation 
-              this.assetsCreated = true; 
+              // Successful generation
+              this.assetsCreated = true;
               this.fetchHistory();
               setTimeout(() => {
                 this.loadingAI = false;

--- a/src/components/nodes/manualTask/index.js
+++ b/src/components/nodes/manualTask/index.js
@@ -4,6 +4,7 @@ import advancedAccordionConfig from '@/components/inspectors/advancedAccordionCo
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
 import defaultNames from '@/components/nodes/task/defaultNames';
 import elementDestination from '@/components/inspectors/taskElementDestination';
+import conditionalRedirect from '@/components/inspectors/ConditionalRedirect/conditionalRedirect';
 
 export const taskHeight = 76;
 export const id = 'processmaker-modeler-manual-task';
@@ -52,6 +53,7 @@ export default {
               config: nameConfigSettings,
             },
             elementDestination,
+            conditionalRedirect,
           ],
         },
         documentationAccordionConfig,

--- a/src/components/nodes/task/index.js
+++ b/src/components/nodes/task/index.js
@@ -5,6 +5,7 @@ import defaultNames from '@/components/nodes/task/defaultNames';
 import advancedAccordionConfigWithMarkerFlags from '@/components/inspectors/advancedAccordionConfigWithMarkerFlags';
 
 import elementDestination from '@/components/inspectors/taskElementDestination';
+import conditionalRedirect from '@/components/inspectors/ConditionalRedirect/conditionalRedirect';
 import loopCharacteristicsInspector from '@/components/inspectors/LoopCharacteristics';
 import { loopCharacteristicsHandler, loopCharacteristicsData } from '@/components/inspectors/LoopCharacteristics';
 import documentationAccordionConfig from '@/components/inspectors/documentationAccordionConfig';
@@ -70,6 +71,7 @@ export default {
     loopCharacteristicsHandler(value, node, setNodeProp, moddle, definitions, isMultiplayer);
     defaultInspectorHandler(omit(value, 'markerFlags', '$loopCharactetistics'), isMultiplayer);
     handleElementDestination(value.elementDestination, node, setNodeProp);
+    handleConditionalRedirect(value.conditionalRedirect, node, setNodeProp);
   },
   inspectorData(node, defaultDataTransform, inspector) {
     const inspectorData = defaultDataTransform(node);
@@ -100,6 +102,7 @@ export default {
               config: nameConfigSettings,
             },
             elementDestination,
+            conditionalRedirect,
           ],
         },
         loopCharacteristicsInspector,
@@ -129,5 +132,11 @@ function handleMarkerFlagsValue(markerFlags, node, setNodeProp) {
 function handleElementDestination(value, node, setNodeProp) {
   if (value) {
     setNodeProp(node, 'elementDestination', value);
+  }
+}
+
+function handleConditionalRedirect(value, node, setNodeProp) {
+  if (value) {
+    setNodeProp(node, 'conditionalRedirect', value);
   }
 }

--- a/tests/e2e/specs/Documentation.cy.js
+++ b/tests/e2e/specs/Documentation.cy.js
@@ -49,7 +49,7 @@ describe('Documentation accordion', { scrollBehavior: false }, () => {
         cy.contains('Advanced').click({ force: true });
         cy.tick(accordionOpenAnimationTime);
         cy.get('iframe.tox-edit-area__iframe').should('not.be.visible');
-        cy.contains('Documentation').click();
+        cy.contains('Documentation').click({ force: true });
         cy.tick(accordionOpenAnimationTime);
         getTinyMceEditor().should('be.visible');
 
@@ -67,7 +67,7 @@ describe('Documentation accordion', { scrollBehavior: false }, () => {
 
         clickAndDropElement(type, position);
         waitToRenderAllShapes();
-        cy.contains('Documentation').click();
+        cy.contains('Documentation').click({ force: true });
         cy.tick(accordionOpenAnimationTime);
         getTinyMceEditor().clear().type(docString);
         assertDownloadedXmlContainsExpected(docString);
@@ -84,14 +84,14 @@ describe('Documentation accordion', { scrollBehavior: false }, () => {
   it('can allow the documentation editor modal to edit the documentation', () => {
     clickAndDropElement(nodeTypes.task, position);
     waitToRenderAllShapes();
-    cy.contains('Documentation').click();
+    cy.contains('Documentation').click({ force: true });
     cy.wait(accordionOpenAnimationTime);
 
     const documentationFromInspector = 'some documentation';
     getTinyMceEditor().type(documentationFromInspector);
     cy.wait(modalAnimationTime);
 
-    cy.get('[data-test="documentation-modal-button"]').click();
+    cy.get('[data-test="documentation-modal-button"]').click({ force: true });
 
     const documentationFromModal = 'this is the documentation modal';
     getTinyMceEditorInModal().type(documentationFromModal);

--- a/tests/e2e/specs/conditionalRedirect/Tasks.cy.js
+++ b/tests/e2e/specs/conditionalRedirect/Tasks.cy.js
@@ -1,11 +1,8 @@
 import {
-  addNodeTypeToPaper,
   clickAndDropElement,
-  getElementAtPosition, modalAnimationTime,
-  modalCancel,
-  modalConfirm,
+  getElementAtPosition,
   toggleInspector,
-  typeIntoTextInput, waitForAnimations,
+  typeIntoTextInput,
   waitToRenderAllShapes,
 } from '../../support/utils';
 

--- a/tests/e2e/specs/conditionalRedirect/Tasks.cy.js
+++ b/tests/e2e/specs/conditionalRedirect/Tasks.cy.js
@@ -1,0 +1,277 @@
+import {
+  addNodeTypeToPaper,
+  clickAndDropElement,
+  getElementAtPosition, modalAnimationTime,
+  modalCancel,
+  modalConfirm,
+  toggleInspector,
+  typeIntoTextInput, waitForAnimations,
+  waitToRenderAllShapes,
+} from '../../support/utils';
+
+import { nodeTypes } from '../../support/constants';
+
+describe('Conditional Redirect Tasks', () => {
+  const taskPosition = { x: 350, y: 250 };
+  const testString = 'Conditional Redirect';
+
+  beforeEach(() => {
+    toggleInspector();
+  });
+
+  it('Update task name', () => {
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).click();
+
+    typeIntoTextInput('[name=name]', testString);
+    cy.get('[name=name]').should('have.value', testString);
+  });
+
+  it('Update task conditional redirect', () => {
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).click();
+
+    // Enable conditional redirect
+    cy.get('[data-test=conditional-toggle]').click({ force: true });
+    cy.get('[data-test=conditional-add-button]').should('be.visible');
+
+    // Add condition default empty
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box]').should('be.visible');
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 1);
+
+    // Conditional Redirect - Task Source (Default)
+    cy.get('[data-test=conditional-box] .task-destination').eq(0).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('score > 80');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Task Source').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Task Source');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'score > 80');
+    });
+
+    // Conditional Redirect - Task List
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 2);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(1).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('score < 80');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Task List').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Task List');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'score < 80');
+    });
+
+    // Conditional Redirect - Process Launchpad
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 3);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(2).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('score == 80');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Process Launchpad').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Process Launchpad');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'score == 80');
+    });
+
+    // Conditional Redirect - Home Page
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 4);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(3).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('amount > 1000');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Home Page').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Home Page');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'amount > 1000');
+    });
+
+    // Conditional Redirect - Custom Dashboard
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 5);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(4).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('amount == 1000');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Custom Dashboard').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Custom Dashboard');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'amount == 1000');
+    });
+
+    // Conditional Redirect - External URL
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 6);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(5).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('amount < 1000');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('External URL').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'External URL');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'amount < 1000');
+
+      cy.get('[data-test=conditional-task-external-url]').type('https://github.com');
+      cy.get('[data-test=conditional-task-external-url]').should('have.value', 'https://github.com');
+    });
+
+    // Conditional Redirect - Display Next Assigned Task
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 7);
+
+    cy.get('[data-test=conditional-box] .task-destination').eq(6).within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('amount == 1000');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Display Next Assigned Task').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Display Next Assigned Task');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'amount == 1000');
+    });
+  });
+
+  it('Max conditions reached', () => {
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).click();
+
+    // Enable conditional redirect
+    cy.get('[data-test=conditional-toggle]').click({ force: true });
+    cy.get('[data-test=conditional-add-button]').should('be.visible');
+
+    const conditionalAddButtonDataTest = '[data-test=conditional-add-button]';
+
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 1);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 2);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 3);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 4);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 5);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 6);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 7);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 8);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 9);
+
+    // Add condition default empty
+    cy.get(conditionalAddButtonDataTest).click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 10);
+
+    cy.get(conditionalAddButtonDataTest).should('be.disabled');
+  });
+
+  it('Duplicate condition', () => {
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).click();
+
+    // Enable conditional redirect
+    cy.get('[data-test=conditional-toggle]').click({ force: true });
+    cy.get('[data-test=conditional-add-button]').should('be.visible');
+
+    // Add condition default empty
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 1);
+
+    cy.get('[data-test=conditional-box] .task-destination').first().within(() => {
+      cy.get('[data-test=conditional-task-condition]').type('score == 80');
+      cy.get('[data-test=conditional-task-redirect]').click();
+
+      cy.get('.multiselect__content-wrapper').should('be.visible');
+      cy.get('.multiselect__option').contains('Process Launchpad').click();
+
+      cy.get('[class=multiselect__single]').should('exist');
+      cy.get('[class=multiselect__single]').should('contain', 'Process Launchpad');
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'score == 80');
+    });
+
+    // Duplicate condition
+    cy.get('[data-test=conditional-box] .task-destination').eq(0).within(() => {
+      cy.get('[data-test=conditional-duplicate-button]').click();
+    });
+
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 2);
+
+    cy.get('[data-test=conditional-box] .task-destination').last().within(() => {
+      cy.get('[data-test=conditional-task-condition]').should('have.value', 'score == 80');
+      cy.get('[class=multiselect__single]').should('contain', 'Process Launchpad');
+    });
+  });
+
+  it('Remove condition', () => {
+    clickAndDropElement(nodeTypes.task, taskPosition);
+    waitToRenderAllShapes();
+
+    getElementAtPosition(taskPosition).click();
+
+    // Enable conditional redirect
+    cy.get('[data-test=conditional-toggle]').click({ force: true });
+    cy.get('[data-test=conditional-add-button]').should('be.visible');
+
+    // Add condition default empty
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 1);
+
+    cy.get('[data-test=conditional-add-button]').click();
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 2);
+
+    cy.get('[data-test=conditional-box] .task-destination').last().within(() => {
+      cy.get('[data-test=conditional-remove-button]').click();
+    });
+
+    cy.get('[data-test=conditional-box] .task-destination').should('have.length', 1);
+  });
+
+});


### PR DESCRIPTION
## Implement Conditional Destination Redirect

## Solution
- Implement backend to support extra conditioned redirection rules for a Task.
- Add to the modeler Inspector the new conditioned redirection rules.

<img width="1130" height="855" alt="image" src="https://github.com/user-attachments/assets/63eb65cd-d990-456f-8259-f9d5527b817f" />

## How to Test
- Create a process like:
- Setup the conditionl redirection rules
- Note that the last task rules are overwritten by the End Event redirection 

## Related Tickets & Packages
[FOUR-26707](https://processmaker.atlassian.net/browse/FOUR-26707)


[FOUR-26707]: https://processmaker.atlassian.net/browse/FOUR-26707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds conditional redirect UI and persistence for Tasks/Manual Tasks, plus e2e tests and dependency updates (uuid, bpmn-moddle).
> 
> - **Modeler (Frontend)**:
>   - **Conditional Redirects**: New `ConditionalRedirect` and `TaskDestination` components to define up to 10 redirect rules with duplicate/remove, dashboard search, and URL validation.
>   - Integrated into `bpmn:Task` and `bpmn:ManualTask` inspectors (`src/components/nodes/task/index.js`, `manualTask/index.js`) and persisted via `handleConditionalRedirect`.
> - **Tests**:
>   - New e2e suite `tests/e2e/specs/conditionalRedirect/Tasks.cy.js` covering add/select, max rules, duplicate/remove.
>   - Documentation test tweaks to use forced clicks for stability.
> - **Dependencies**:
>   - Add `uuid@^13.0.0`; bump `@processmaker/processmaker-bpmn-moddle` to `0.16.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd0055c34f5fa4d34db7fc5af873128c18632517. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->