### PR TITLE
FOUR-26806 User cannot select a display screen when the condition is selected Display Next Assigned Task option

### DIFF
--- a/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
+++ b/src/components/inspectors/ConditionalRedirect/TaskDestination.vue
@@ -259,6 +259,7 @@ export default {
       this.$root.$emit('handle-task-interstitial', {
         nodeId,
         show: newValue === 'displayNextAssignedTask',
+        isConditionalRedirect: true,
       });
     },
   },


### PR DESCRIPTION
## Issue & Reproduction Steps

### User cannot select a display screen when the condition is selected `Display Next Assigned Task` option

Expected behavior: 
The selector of Display Screen must be shown not only when the Task Destination is “Display Next Assigned Task“, but also when any of the conditional destinations are “Display Next Assigned Task“.

Note that the Interstitial Screen is common for the Task no mather the conditions.

Actual behavior: 
The field to assign a Display Screen is not displayed.

## Related Tickets & Packages
[FOUR-26806](https://processmaker.atlassian.net/browse/FOUR-26806)


[FOUR-26806]: https://processmaker.atlassian.net/browse/FOUR-26806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ