### PR TITLE
Disable Launchpad Access When Editing Process Templates in Modeler

### DIFF
--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -21,7 +21,7 @@
     />
     <slot />
 
-    <LaunchpadButton @verifyLaunchpad="handleVerifyLaunchpad"/>
+    <LaunchpadButton @verifyLaunchpad="handleVerifyLaunchpad" :disabled="disableLaunchpad"/>
     <LaunchpadModal :show="showLaunchpadModal" @closeModal="closeModal" />
 
   </div>
@@ -84,6 +84,9 @@ export default {
     },
     isPackageAiInstalled() {
       return window.ProcessMaker?.modeler?.isPackageAiInstalled;
+    },
+    disableLaunchpad() {
+      return window.ProcessMaker.modeler.process.is_template ? true : false;
     },
   },
   watch: {

--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -86,7 +86,7 @@ export default {
       return window.ProcessMaker?.modeler?.isPackageAiInstalled;
     },
     disableLaunchpad() {
-      return window.ProcessMaker?.modeler?.process?.is_template;
+      return !!window.ProcessMaker?.modeler?.process?.is_template;
     },
   },
   watch: {

--- a/src/components/topRail/TopRail.vue
+++ b/src/components/topRail/TopRail.vue
@@ -86,7 +86,7 @@ export default {
       return window.ProcessMaker?.modeler?.isPackageAiInstalled;
     },
     disableLaunchpad() {
-      return window.ProcessMaker.modeler.process.is_template ? true : false;
+      return window.ProcessMaker?.modeler?.process?.is_template;
     },
   },
   watch: {

--- a/src/components/topRail/launchpadControl/LaunchpadButton.vue
+++ b/src/components/topRail/launchpadControl/LaunchpadButton.vue
@@ -26,8 +26,12 @@ export default {
   data() {
     return {
       iconOpen: 'fas fa-play',
-      buttonDisabledClass: 'no-hover',
     };
+  },
+  computed: {
+    buttonDisabledClass() {
+      return this.disabled ? 'no-hover' : '';
+    },
   },
   methods: {
     handleOpenLaunchpad() {

--- a/src/components/topRail/launchpadControl/LaunchpadButton.vue
+++ b/src/components/topRail/launchpadControl/LaunchpadButton.vue
@@ -2,12 +2,14 @@
   <button
     type="button"
     class="btn btn-white"
+    :class="buttonDisabledClass"
     :title="$t('Open Launchpad')"
     v-b-tooltip.hover.viewport.d50="{ customClass: 'no-pointer-events' }"
     data-cy="launchpad-button"
     @mouseleave="handleMouseLeave"
     @mouseover="handleMouseOver" 
     @click.prevent="handleOpenLaunchpad"
+    :disabled="disabled"
   >
     <i :class="iconOpen" />
   </button>
@@ -15,21 +17,40 @@
 
 <script>
 export default {
+  props: {
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data() {
     return {
       iconOpen: 'fas fa-play',
+      buttonDisabledClass: 'no-hover',
     };
   },
   methods: {
     handleOpenLaunchpad() {
-      this.$emit('verifyLaunchpad', window.ProcessMaker.modeler.launchpad === null);
+      if (!this.disabled) {
+        this.$emit('verifyLaunchpad', window.ProcessMaker.modeler.launchpad === null);
+      }
     },
     handleMouseOver() { 
-      this.iconOpen = 'fas fa-external-link-alt'; 
+      if (!this.disabled) {
+        this.iconOpen = 'fas fa-external-link-alt'; 
+      }
     }, 
     handleMouseLeave() {
-      this.iconOpen = 'fas fa-play';
+      if (!this.disabled) {
+        this.iconOpen = 'fas fa-play';
+      }
     },
   },
 };
 </script>
+
+<style scoped> 
+  .no-hover:hover {
+    background-color: transparent;
+  }
+</style>

--- a/src/components/topRail/launchpadControl/LaunchpadButton.vue
+++ b/src/components/topRail/launchpadControl/LaunchpadButton.vue
@@ -35,9 +35,7 @@ export default {
   },
   methods: {
     handleOpenLaunchpad() {
-      if (!this.disabled) {
-        this.$emit('verifyLaunchpad', window.ProcessMaker.modeler.launchpad === null);
-      }
+      this.$emit('verifyLaunchpad', window.ProcessMaker.modeler.launchpad === null);
     },
     handleMouseOver() { 
       if (!this.disabled) {


### PR DESCRIPTION
## Issue & Reproduction Steps

This PR fixes an issue where the Launchpad button remained enabled while editing a process template in the Modeler. Clicking the button incorrectly redirected users to the Launchpad, allowing templates to be executed outside the context of a process.

To prevent this unintended behavior, the Launchpad button is now disabled whenever the Modeler is opened for a process template.

## Solution
- Added a conditional check to disable the Launchpad button in the Modeler when the process has `is_template: true`.

## How to Test

1. Create a process template.
2. Navigate to Processes > Templates.
3. Select Edit Template.
4. In the Modeler, attempt to click the Launchpad button.

## Related Tickets & Packages
- [FOUR-27760](https://processmaker.atlassian.net/browse/FOUR-27760)




## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-27760]: https://processmaker.atlassian.net/browse/FOUR-27760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change that gates navigation based on an existing `is_template` flag; low risk aside from potentially blocking Launchpad access if the flag is mis-set.
> 
> **Overview**
> Prevents Launchpad access while editing process templates in the Modeler by computing `disableLaunchpad` from `process.is_template` and passing it to `LaunchpadButton`.
> 
> Updates `LaunchpadButton` to accept a `disabled` prop, apply the native disabled state, and suppress hover icon changes/hover styling when disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6645314f353ba2c95d9df13f0453f8acc5e83279. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->